### PR TITLE
Replace Hugo shortcodes

### DIFF
--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.md
@@ -74,7 +74,19 @@ You'll use the backup as a restore point if something goes wrong during upgrade.
 
     For information about the repos and their differences, see [Helm Chart Repositories](../../../reference-guides/installation-references/helm-chart-options.md#helm-chart-repositories).
 
-    {{< release-channel >}}
+    - Latest: Recommended for trying out the newest features
+        ```
+        helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+        ```
+    - Stable: Recommended for production environments
+        ```
+        helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+        ```
+    - Alpha: Experimental preview of upcoming releases.
+        ```
+        helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+        ```
+        Note: Upgrades are not supported to, from, or between Alphas.
 
     ```
     helm repo list

--- a/docs/getting-started/installation-and-upgrade/installation-requirements/port-requirements.md
+++ b/docs/getting-started/installation-and-upgrade/installation-requirements/port-requirements.md
@@ -6,24 +6,11 @@ weight: 300
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import PortsIaasNodes from '@site/src/components/PortsIaasNodes'
+import PortsCustomNodes from '@site/src/components/PortsCustomNodes'
+import PortsImportedHosted from '@site/src/components/PortsImportedHosted'
 
 To operate properly, Rancher requires a number of ports to be open on Rancher nodes and on downstream Kubernetes cluster nodes.
-
-- [Rancher Nodes](#rancher-nodes)
-  - [Ports for Rancher Server Nodes on K3s](#ports-for-rancher-server-nodes-on-k3s)
-  - [Ports for Rancher Server Nodes on RKE](#ports-for-rancher-server-nodes-on-rke)
-  - [Ports for Rancher Server Nodes on RKE2](#ports-for-rancher-server-nodes-on-rke2)
-  - [Ports for Rancher Server in Docker](#ports-for-rancher-server-in-docker)
-- [Downstream Kubernetes Cluster Nodes](#downstream-kubernetes-cluster-nodes)
-  - [Ports for Rancher Launched Kubernetes Clusters using Node Pools](#ports-for-rancher-launched-kubernetes-clusters-using-node-pools)
-  - [Ports for Rancher Launched Kubernetes Clusters using Custom Nodes](#ports-for-rancher-launched-kubernetes-clusters-using-custom-nodes)
-  - [Ports for Hosted Kubernetes Clusters](#ports-for-hosted-kubernetes-clusters)
-  - [Ports for Registered Clusters](#ports-for-registered-clusters)
-- [Other Port Considerations](#other-port-considerations)
-  - [Commonly Used Ports](#commonly-used-ports)
-  - [Local Node Traffic](#local-node-traffic)
-  - [Rancher AWS EC2 Security Group](#rancher-aws-ec2-security-group)
-  - [Opening SUSE Linux Ports](#opening-suse-linux-ports)
 
 # Rancher Nodes
 
@@ -219,7 +206,7 @@ The required ports are automatically opened by Rancher during creation of cluste
 
 :::
 
-{{< ports-iaas-nodes >}}
+ <PortsIaasNodes/>
 
 </details>
 
@@ -230,7 +217,7 @@ The required ports are automatically opened by Rancher during creation of cluste
 
 The following table depicts the port requirements for [Rancher Launched Kubernetes](../../../pages-for-subheaders/launch-kubernetes-with-rancher.md) with [Custom Nodes](../../../pages-for-subheaders/use-existing-nodes.md).
 
-{{< ports-custom-nodes >}}
+<PortsCustomNodes/>
 
 </details>
 
@@ -241,7 +228,7 @@ The following table depicts the port requirements for [Rancher Launched Kubernet
 
 The following table depicts the port requirements for [hosted clusters](../../../pages-for-subheaders/set-up-clusters-from-hosted-kubernetes-providers.md).
 
-{{< ports-imported-hosted >}}
+<PortsImportedHosted/>
 
 </details>
 
@@ -258,7 +245,7 @@ Registered clusters were called imported clusters before Rancher v2.5.
 
 The following table depicts the port requirements for [registered clusters](../../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md).
 
-{{< ports-imported-hosted >}}
+<PortsImportedHosted/>
 
 </details>
 

--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
@@ -31,10 +31,19 @@ From a system that has access to the internet, fetch the latest Helm chart and c
 1. If you haven't already, install `helm` locally on a workstation that has internet access. Note: Refer to the [Helm version requirements](../../resources/helm-version-requirements.md) to choose a version of Helm to install Rancher.
 
 2. Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see [Choosing a Version of Rancher](../../../../reference-guides/installation-references/helm-chart-options.md#helm-chart-repositories).
-  {{< release-channel >}}
-    ```
-    helm repo add rancher-<CHART_REPO> https://releases.rancher.com/server-charts/<CHART_REPO>
-    ```
+    - Latest: Recommended for trying out the newest features
+        ```
+        helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+        ```
+    - Stable: Recommended for production environments
+        ```
+        helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+        ```
+    - Alpha: Experimental preview of upcoming releases.
+        ```
+        helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+        ```
+        Note: Upgrades are not supported to, from, or between Alphas.
 
 3. Fetch the latest Rancher chart. This will pull down the chart and save it in the current directory as a `.tgz` file.
     ```plain

--- a/docs/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
+++ b/docs/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
@@ -59,7 +59,19 @@ Because the rancher-alpha repository contains only alpha charts, switching betwe
 
 :::
 
-{{< release-channel >}}
+- Latest: Recommended for trying out the newest features
+    ```
+    helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+    ```
+- Stable: Recommended for production environments
+    ```
+    helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+    ```
+- Alpha: Experimental preview of upcoming releases.
+    ```
+    helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+    ```
+    Note: Upgrades are not supported to, from, or between Alphas.
 
 1. List the current Helm chart repositories.
 

--- a/docs/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-keycloak-saml.md
+++ b/docs/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-keycloak-saml.md
@@ -129,7 +129,14 @@ The following is an example process for Firefox, but will vary slightly for othe
 
 **Result:** Rancher is configured to work with Keycloak. Your users can now sign into Rancher using their Keycloak logins.
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::
 
 ## Configuration Reference
 

--- a/docs/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-okta-saml.md
+++ b/docs/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-okta-saml.md
@@ -59,4 +59,11 @@ Setting | Value
     
 **Result:** Rancher is configured to work with Okta. Your users can now sign into Rancher using their Okta logins.
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::

--- a/docs/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-pingidentity.md
+++ b/docs/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-pingidentity.md
@@ -53,4 +53,11 @@ Note that these URLs will not return valid data until the authentication configu
     
 **Result:** Rancher is configured to work with PingIdentity. Your users can now sign into Rancher using their PingIdentity logins.
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::

--- a/docs/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/manage-users-and-groups.md
+++ b/docs/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/manage-users-and-groups.md
@@ -13,7 +13,14 @@ When adding a user or group to a resource, you can search for users or groups by
 
 All users, whether they are local users or from an authentication provider, can be viewed and managed. In the upper left corner, click **☰ > Users & Authentication**. In the left navigation bar, click **Users**.
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::
 
 ## User Information
 

--- a/docs/pages-for-subheaders/about-authentication.md
+++ b/docs/pages-for-subheaders/about-authentication.md
@@ -63,7 +63,14 @@ To set the Rancher access level for users in the authorization service, follow t
 
 **Result:** The Rancher access configuration settings are applied.
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::
 
 ## External Authentication Configuration and Principal Users
 

--- a/docs/pages-for-subheaders/configure-microsoft-ad-federation-service-saml.md
+++ b/docs/pages-for-subheaders/configure-microsoft-ad-federation-service-saml.md
@@ -24,7 +24,14 @@ Setting up Microsoft AD FS with Rancher Server requires configuring AD FS on you
 - [1. Configuring Microsoft AD FS for Rancher](../how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/configure-microsoft-ad-federation-service-saml/configure-ms-adfs-for-rancher.md)
 - [2. Configuring Rancher for Microsoft AD FS](../how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/configure-microsoft-ad-federation-service-saml/configure-rancher-for-ms-adfs.md)
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::
 
 
 ### [Next: Configuring Microsoft AD FS for Rancher](../how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/configure-microsoft-ad-federation-service-saml/configure-ms-adfs-for-rancher.md)

--- a/docs/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster.md
+++ b/docs/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster.md
@@ -80,11 +80,19 @@ To set up Rancher,
 
 Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see [Choosing a Version of Rancher](../reference-guides/installation-references/helm-chart-options.md#helm-chart-repositories).
 
-{{< release-channel >}}
-
-```
-helm repo add rancher-<CHART_REPO> https://releases.rancher.com/server-charts/<CHART_REPO>
-```
+- Latest: Recommended for trying out the newest features
+    ```
+    helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+    ```
+- Stable: Recommended for production environments
+    ```
+    helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+    ```
+- Alpha: Experimental preview of upcoming releases.
+    ```
+    helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+    ```
+    Note: Upgrades are not supported to, from, or between Alphas.
 
 ### 2. Create a Namespace for Rancher
 

--- a/docs/pages-for-subheaders/vsphere.md
+++ b/docs/pages-for-subheaders/vsphere.md
@@ -5,6 +5,7 @@ description: Use Rancher to create a vSphere cluster. It may consist of groups o
 metaDescription: Use Rancher to create a vSphere cluster. It may consist of groups of VMs with distinct properties which allow for fine-grained control over the sizing of nodes.
 weight: 2225
 ---
+import YouTube from '@site/src/components/YouTube'
 
 By using Rancher with vSphere, you can bring cloud operations on-premises.
 
@@ -45,7 +46,7 @@ You can provision VMs with any operating system that supports `cloud-init`. Only
 
 In this YouTube video, we demonstrate how to set up a node template with the new features designed to help you bring cloud operations to on-premises clusters.
 
-{{< youtube id="dPIwg6x1AlU">}}
+<YouTube id="dPIwg6x1AlU"/>
 
 # Creating a vSphere Cluster
 

--- a/src/components/PortsCustomNodes.js
+++ b/src/components/PortsCustomNodes.js
@@ -1,0 +1,263 @@
+import React from 'react';
+const PortsCustomNodes = () => (
+<table>
+    <thead>
+        <tr>
+          <th>From / To</th>
+          <th>Rancher Nodes</th>
+          <th>etcd Plane Nodes</th>
+          <th>Control Plane Nodes</th>
+          <th>Worker Plane Nodes</th>
+          <th>External Rancher Load Balancer</th>
+          <th>Internet</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+          <td >Rancher Nodes <sup>(1)</sup></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>git.rancher.io</td>
+        </tr>
+        <tr>
+          <td rowspan="6">etcd Plane Nodes</td>
+          <td rowspan="6" style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>443 TCP <sup>(3)</sup></td>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>2379 TCP</td>
+          <td></td>
+          <td></td>
+          <td rowspan="5" style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>443 TCP</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>2380 TCP</td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td></td>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>6443 TCP</td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td colspan="3" style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>8472 UDP</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td colspan="3" style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>4789 UDP <sup>(6)</sup></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>9099 TCP <sup>(4)</sup></td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td rowspan="8">Control Plane Nodes</td>
+          <td rowspan="8" style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>443 TCP <sup>(3)</sup></td>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>2379 TCP</td>
+          <td></td>
+          <td></td>
+          <td rowspan="7" style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>443 TCP</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>2380 TCP</td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td></td>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>6443 TCP</td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td colspan="3" style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>8472 UDP</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td colspan="3" style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>4789 UDP <sup>(6)</sup></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td colspan="3" style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>10250 TCP</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td></td>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>9099 TCP <sup>(4)</sup></td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td></td>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>10254 TCP <sup>(4)</sup></td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td rowspan="5">Worker Plane Nodes</td>
+          <td rowspan="5" style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>443 TCP <sup>(3)</sup></td>
+          <td></td>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>6443 TCP</td>
+          <td></td>
+          <td rowspan="4" style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>443 TCP</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td colspan="3" style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>8472 UDP</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td colspan="3" style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>4789 UDP <sup>(6)</sup></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td></td>
+          <td></td>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>9099 TCP <sup>(4)</sup></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td></td>
+          <td></td>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>10254 TCP <sup>(4)</sup></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>Kubernetes API Clients</td>
+          <td></td>
+          <td></td>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>6443 TCP <sup>(5)</sup></td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td rowspan="3">Workload Clients or Load Balancer</td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>30000-32767 TCP / UDP<br/>(nodeport)</td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>80 TCP (Ingress)</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>443 TCP (Ingress)</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td colspan="7">Notes:<br/><br/>1. Nodes running standalone server or Rancher HA deployment.<br/>2. Required to fetch Rancher chart library.<br/>3. Only without external load balancer in front of Rancher.<br/>4. Local traffic to the node itself (not across nodes).<br/>5. Only if Authorized Cluster Endpoints are activated.<br/>6. Only if using Overlay mode on Windows cluster.
+          </td>
+        </tr>
+    </tbody>
+</table>
+)
+export default PortsCustomNodes;

--- a/src/components/PortsIaasNodes.js
+++ b/src/components/PortsIaasNodes.js
@@ -1,0 +1,257 @@
+import React from 'react';
+const PortsIaasNodes = () => (
+   <table style={{
+      "border-style": 'solid'
+  }}>
+      <thead>
+          <tr>
+          <th>From / To</th>
+          <th>Rancher Nodes</th>
+          <th>etcd Plane Nodes</th>
+          <th>Control Plane Nodes</th>
+          <th>Worker Plane Nodes</th>
+          <th>External Rancher Load Balancer</th>
+          <th>Internet</th>
+          </tr>
+      </thead>
+      <tbody>
+          <tr>
+          <td rowspan="2">Rancher Nodes <sup>(1)</sup></td>
+          <td></td>
+          <td colspan="3" style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>22 TCP</td>
+          <td></td>
+          <td rowspan="2" style={{
+             "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>git.rancher.io</td>
+          </tr>
+          <tr>
+          <td></td>
+          <td colspan="3" style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>2376 TCP</td>
+          <td></td>
+          </tr>
+          <tr>
+          <td rowspan="5">etcd Plane Nodes</td>
+          <td rowspan="5" style={{
+             "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>443 TCP <sup>(3)</sup></td>
+          <td style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>2379 TCP</td>
+          <td></td>
+          <td></td>
+          <td rowspan="5" style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>443 TCP</td>
+          <td></td>
+          </tr>
+          <tr>
+          <td style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>2380 TCP</td>
+          <td></td>
+          <td></td>
+          <td></td>
+          </tr>
+          <tr>
+          <td></td>
+          <td style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>6443 TCP</td>
+          <td></td>
+          <td></td>
+          </tr>
+          <tr>
+          <td colspan="3" style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>8472 UDP</td>
+          <td></td>
+          </tr>
+          <tr>
+          <td style={{
+             "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>9099 TCP <sup>(4)</sup></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          </tr>
+          <tr>
+          <td rowspan="7">Control Plane Nodes</td>
+          <td rowspan="7" style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>443 TCP <sup>(3)</sup></td>
+          <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>2379 TCP</td>
+          <td></td>
+          <td></td>
+          <td rowspan="7" style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>443 TCP</td>
+          <td></td>
+          </tr>
+          <tr>
+          <td style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>2380 TCP</td>
+          <td></td>
+          <td></td>
+          <td></td>
+          </tr>
+          <tr>
+          <td></td>
+          <td style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>6443 TCP</td>
+          <td></td>
+          <td></td>
+          </tr>
+          <tr>
+          <td colspan="3" style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>8472 UDP</td>
+          <td></td>
+          </tr>
+          <tr>
+          <td colspan="3" style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>10250 TCP</td>
+          <td></td>
+          </tr>
+          <tr>
+          <td></td>
+          <td style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>9099 TCP <sup>(4)</sup></td>
+          <td></td>
+          <td></td>
+          </tr>
+          <tr>
+          <td></td>
+          <td style={{
+             "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>10254 TCP <sup>(4)</sup></td>
+          <td></td>
+          <td></td>
+          </tr>
+          <tr>
+          <td rowspan="4">Worker Plane Nodes</td>
+          <td rowspan="4" style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>443 TCP <sup>(3)</sup></td>
+          <td></td>
+          <td style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>6443 TCP</td>
+          <td></td>
+          <td rowspan="4" style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>443 TCP</td>
+          <td></td>
+          </tr>
+          <tr>
+          <td colspan="3" style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>8472 UDP</td>
+          <td></td>
+          </tr>
+          <tr>
+          <td></td>
+          <td></td>
+          <td style={{
+             "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>9099 TCP <sup>(4)</sup></td>
+          <td></td>
+          </tr>
+          <tr>
+          <td></td>
+          <td></td>
+          <td style={{
+             "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>10254 TCP <sup>(4)</sup></td>
+          <td></td>
+          </tr>
+          <tr>
+          <td>Kubernetes API Clients</td>
+          <td></td>
+          <td></td>
+          <td style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>6443 TCP <sup>(5)</sup></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          </tr>
+          <tr>
+          <td rowspan="3">Workload Clients or Load Balancer</td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td style={{
+             "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>30000-32767 TCP / UDP<br/>(nodeport)</td>
+          <td></td>
+          <td></td>
+          </tr>
+          <tr>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>80 TCP (Ingress)</td>
+          <td></td>
+          </tr>
+          <tr>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td style={{
+              "background-color": "#3497DA", 
+              color: "#ffffff"
+          }}>443 TCP (Ingress)</td>
+          <td></td>
+          </tr>
+          <tr>
+          <td 
+              colspan="7">Notes:
+              <br/>
+              <br/>1. Nodes running standalone server or Rancher HA deployment.<br/>2. Required to fetch Rancher chart library.<br/>3. Only without external load balancer in front of Rancher.
+              <br/>4. Local traffic to the node itself (not across nodes).<br/>5. Only if Authorized Cluster Endpoints are activated.
+          </td>
+          </tr>
+      </tbody>
+   </table>
+)
+export default PortsIaasNodes

--- a/src/components/PortsImportedHosted.js
+++ b/src/components/PortsImportedHosted.js
@@ -1,0 +1,82 @@
+import React from 'react';
+const PortsImportedHosted = () => (
+<table>
+    <thead>
+        <tr>
+        <th>From / To</th>
+        <th>Rancher Nodes</th>
+        <th>Hosted / Imported Cluster</th>
+        <th>External Rancher Load Balancer</th>
+        <th>Internet</th>
+    </tr>
+    </thead>
+    <tbody>
+        <tr>
+        <td rowspan="3">Rancher Nodes <sup>(1)</sup></td>
+        <td></td>
+        <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>Kubernetes API <br/>Endpoint Port <sup>(2)</sup></td>
+        <td></td>
+        <td rowspan="3" style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>git.rancher.io</td>
+        </tr>
+        <tr>
+        <td></td>
+        <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>8443 TCP</td>
+        <td></td>
+        </tr>
+        <tr>
+        <td></td>
+        <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>9443 TCP</td>
+        <td></td>
+        </tr>
+        <tr>
+        <td>Hosted / Imported Cluster</td>
+        <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>443 TCP <sup>(4)(5)</sup></td>
+        <td></td>
+        <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>443 TCP <sup>(5)</sup></td>
+        <td></td>
+        </tr>
+        <tr>
+        <td>Kubernetes API Clients</td>
+        <td></td>
+        <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>Cluster / Provider Specific <sup>(6)</sup></td>
+        <td></td>
+        <td></td>
+        </tr>
+        <tr>
+        <td>Workload Client</td>
+        <td></td>
+        <td style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>Cluster / Provider Specific <sup>(7)</sup></td>
+        <td></td>
+        <td></td>
+        </tr>
+        <tr>
+        <td colspan="5">Notes:<br/><br/>1. Nodes running standalone server or Rancher HA deployment.<br/>2. Only for hosted clusters.<br/>3. Required to fetch Rancher chart library.<br/>4. Only without external load balancer.<br/>5. From worker nodes.<br/>6. For direct access to the Kubernetes API without Rancher.<br/>7. Usually Ingress backed by infrastructure load balancer and/or nodeport.</td>
+        </tr>
+    </tbody>
+  </table>
+)
+export default PortsImportedHosted;

--- a/src/components/SslFaqHa.js
+++ b/src/components/SslFaqHa.js
@@ -1,0 +1,120 @@
+import React from 'react';
+const SslFaqHa = () => (
+<div>
+
+    <h3 id="pem">How Do I Know if My Certificates are in PEM Format?</h3>
+
+    <p>You can recognize the PEM format by the following traits:</p>
+    <ul>
+    <li>The file begins with the following header:<br /> <code>-----BEGIN CERTIFICATE-----</code></li>
+    <li>The header is followed by a long string of characters. Like, really long.</li>
+    <li>The file ends with a footer:<br /> <code>-----END CERTIFICATE-----</code></li>
+    </ul>
+
+    <p><strong>PEM Certificate Example:</strong></p>
+
+    <pre style={{
+            color: "#f8f8f2",
+            "background-color": "#272822",
+            "-moz-tab-size" :4,
+            "-o-tab-size" :4,
+            "tab-size":4
+        }}>
+    ----BEGIN CERTIFICATE-----
+    MIIGVDCCBDygAwIBAgIJAMiIrEm29kRLMA0GCSqGSIb3DQEBCwUAMHkxCzAJBgNV
+    ... more lines
+    VWQqljhfacYPgp8KJUJENQ9h5hZ2nSCrI+W00Jcw4QcEdCI8HL5wmg==
+    -----END CERTIFICATE-----
+    </pre>
+
+    <h3 id="base64">How Can I Encode My PEM Files in base64?</h3>
+
+    <p>To encode your certificates in base64:</p>
+
+    <ol>
+    <li>Change directory to where the PEM file resides.</li>
+    <li>Run one of the following commands. Replace <code>FILENAME</code> with the name of your certificate.
+        <pre style={{
+            color: "#f8f8f2",
+            "background-color": "#272822",
+            "-moz-tab-size" :4,
+            "-o-tab-size" :4,
+            "tab-size":4
+        }}>
+    # MacOS
+    cat FILENAME | base64
+    # Linux
+    cat FILENAME | base64 -w0
+    # Windows
+    certutil -encode FILENAME FILENAME.base64
+    </pre>
+    </li>
+    </ol>
+
+    <h3 id="base64">How Can I Verify My Generated base64 String For The Certificates?</h3>
+
+    <p>To decode your certificates in base64:</p>
+
+    <ol>
+    <li>Copy the generated base64 string.</li>
+    <li>Run one of the following commands. Replace <code>YOUR_BASE64_STRING</code> with the previously copied base64
+        string.
+        <pre style={{
+            color: "#f8f8f2",
+            "background-color": "#272822",
+            "-moz-tab-size" :4,
+            "-o-tab-size" :4,
+            "tab-size":4
+        }}>
+    # MacOS
+    echo YOUR_BASE64_STRING | base64 -D
+    # Linux
+    echo YOUR_BASE64_STRING | base64 -d
+    # Windows
+    certutil -decode FILENAME.base64 FILENAME.verify
+    </pre>
+    </li>
+    </ol>
+
+
+    <h3 id="cert-order">What is the Order of Certificates if I Want to Add My Intermediate(s)?</h3>
+
+    <p>The order of adding certificates is as follows:</p>
+
+    <pre style={{
+            color: "#f8f8f2",
+            "background-color": "#272822",
+            "-moz-tab-size" :4,
+            "-o-tab-size" :4,
+            "tab-size":4
+        }}>
+    -----BEGIN CERTIFICATE-----
+    %YOUR_CERTIFICATE%
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    %YOUR_INTERMEDIATE_CERTIFICATE%
+    -----END CERTIFICATE-----
+    </pre>
+
+    <h3 id="validate-cert-chain">How Do I Validate My Certificate Chain?</h3>
+
+    <p>You can validate the certificate chain by using the <code>openssl</code> binary. If the output of the command (see
+    the command example below) ends with <code>Verify return code: 0 (ok)</code>, your certificate chain is valid. The
+    <code>ca.pem</code> file must be the same as you added to the <code>rancher/rancher</code> container. When using a
+    certificate signed by a recognized Certificate Authority, you can omit the <code>-CAfile</code> parameter.</p>
+
+    <p>Command:</p>
+    <pre style={{
+            color: "#f8f8f2",
+            "background-color": "#272822",
+            "-moz-tab-size" :4,
+            "-o-tab-size" :4,
+            "tab-size":4
+        }}>
+    openssl s_client -CAfile ca.pem -connect rancher.yourdomain.com:443 -servername rancher.yourdomain.com
+    ...
+        Verify return code: 0 (ok)
+    </pre>
+</div>
+)
+export default SslFaqHa

--- a/src/components/YouTube.js
+++ b/src/components/YouTube.js
@@ -1,0 +1,24 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+// This code was authored by bravemaster619 https://dev.to/bravemaster619/simplest-way-to-embed-a-youtube-video-in-your-react-app-3bk2
+
+const YoutubeEmbed = ({ id }) => (
+  <div className="video-responsive">
+    <iframe
+      width="853"
+      height="480"
+      src={`https://www.youtube.com/embed/${id}`}
+      frameBorder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+      title="Embedded youtube"
+    />
+  </div>
+);
+
+YoutubeEmbed.propTypes = {
+  embedId: PropTypes.string.isRequired
+};
+
+export default YoutubeEmbed;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -145,3 +145,19 @@ a.btn.navbar__github::before {
   padding: 0 var(--ifm-pre-padding);
 }
 
+
+/* These styles are authored by bravemaster619 https://dev.to/bravemaster619/simplest-way-to-embed-a-youtube-video-in-your-react-app-3bk2 */
+.video-responsive {
+  overflow: hidden;
+  padding-bottom: 56.25%;
+  position: relative;
+  height: 0;
+}
+
+.video-responsive iframe {
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: 100%;
+  position: absolute;
+}

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/advanced-options/advanced-use-cases/air-gap-helm2/install-rancher.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/advanced-options/advanced-use-cases/air-gap-helm2/install-rancher.md
@@ -39,10 +39,19 @@ From a system that has access to the internet, fetch the latest Helm chart and c
     ```
 
 2. Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see [Choosing a Version of Rancher](../../../resources/choose-a-rancher-version.md).
-  {{< release-channel >}}
-    ```
-    helm repo add rancher-<CHART_REPO> https://releases.rancher.com/server-charts/<CHART_REPO>
-    ```
+    - Latest: Recommended for trying out the newest features
+        ```
+        helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+        ```
+    - Stable: Recommended for production environments
+        ```
+        helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+        ```
+    - Alpha: Experimental preview of upcoming releases.
+        ```
+        helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+        ```
+        Note: Upgrades are not supported to, from, or between Alphas.
 
 3. Fetch the latest Rancher chart. This will pull down the chart and save it in the current directory as a `.tgz` file.
 ```plain

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/advanced-options/advanced-use-cases/rke-add-on/layer-4-lb.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/advanced-options/advanced-use-cases/rke-add-on/layer-4-lb.md
@@ -7,6 +7,7 @@ aliases:
   - /rancher/v2.0-v2.4/en/installation/options/rke-add-on/layer-4-lb
   - /rancher/v2.x/en/installation/resources/advanced/rke-add-on/layer-4-lb/
 ---
+import SSlFaqHa from '@site/src/components/SslFaqHa'
 
 > #### **Important: RKE add-on install is only supported up to Rancher v2.0.8**
 >
@@ -398,4 +399,4 @@ You have a couple of options:
 
 ## FAQ and Troubleshooting
 
-{{< ssl_faq_ha >}}
+<SslFaqHa/>

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/advanced-options/advanced-use-cases/rke-add-on/layer-7-lb.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/advanced-options/advanced-use-cases/rke-add-on/layer-7-lb.md
@@ -7,6 +7,7 @@ aliases:
   - /rancher/v2.0-v2.4/en/installation/options/rke-add-on/layer-7-lb
   - /rancher/v2.x/en/installation/resources/advanced/rke-add-on/layer-7-lb/
 ---
+import SslFaqHa from '@site/src/components/SslFaqHa'
 
 > #### **Important: RKE add-on install is only supported up to Rancher v2.0.8**
 >
@@ -289,4 +290,4 @@ During installation, RKE automatically generates a config file named `kube_confi
 
 ## FAQ and Troubleshooting
 
-{{< ssl_faq_ha >}}
+<SslFaqHa/>

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades/helm2.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades/helm2.md
@@ -62,7 +62,19 @@ of your Kubernetes cluster running Rancher server. You'll use the snapshot as a 
 
     For information about the repos and their differences, see [Helm Chart Repositories](../../../../reference-guides/installation-references/helm-chart-options.md#helm-chart-repositories).
 
-    {{< release-channel >}}
+    - Latest: Recommended for trying out the newest features
+        ```
+        helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+        ```
+    - Stable: Recommended for production environments
+        ```
+        helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+        ```
+    - Alpha: Experimental preview of upcoming releases.
+        ```
+        helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+        ```
+        Note: Upgrades are not supported to, from, or between Alphas.
 
     ```
     helm repo list

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/installation-requirements/port-requirements.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/installation-requirements/port-requirements.md
@@ -4,22 +4,11 @@ description: Read about port requirements needed in order for Rancher to operate
 weight: 300
 ---
 
-To operate properly, Rancher requires a number of ports to be open on Rancher nodes and on downstream Kubernetes cluster nodes.
+import PortsIaasNodes from '@site/src/components/PortsIaasNodes'
+import PortsCustomNodes from '@site/src/components/PortsCustomNodes'
+import PortsImportedHosted from '@site/src/components/PortsImportedHosted'
 
-- [Rancher Nodes](#rancher-nodes)
-  - [Ports for Rancher Server Nodes on K3s](#ports-for-rancher-server-nodes-on-k3s)
-  - [Ports for Rancher Server Nodes on RKE](#ports-for-rancher-server-nodes-on-rke)
-  - [Ports for Rancher Server in Docker](#ports-for-rancher-server-in-docker)
-- [Downstream Kubernetes Cluster Nodes](#downstream-kubernetes-cluster-nodes)
-  - [Ports for Rancher Launched Kubernetes Clusters using Node Pools](#ports-for-rancher-launched-kubernetes-clusters-using-node-pools)
-  - [Ports for Rancher Launched Kubernetes Clusters using Custom Nodes](#ports-for-rancher-launched-kubernetes-clusters-using-custom-nodes)
-  - [Ports for Hosted Kubernetes Clusters](#ports-for-hosted-kubernetes-clusters)
-  - [Ports for Imported Clusters](#ports-for-imported-clusters)
-- [Other Port Considerations](#other-port-considerations)
-  - [Commonly Used Ports](#commonly-used-ports)
-  - [Local Node Traffic](#local-node-traffic)
-  - [Rancher AWS EC2 Security Group](#rancher-aws-ec2-security-group)
-  - [Opening SUSE Linux Ports](#opening-suse-linux-ports)
+To operate properly, Rancher requires a number of ports to be open on Rancher nodes and on downstream Kubernetes cluster nodes.
 
 # Rancher Nodes
 
@@ -165,7 +154,7 @@ The following table depicts the port requirements for [Rancher Launched Kubernet
 >**Note:**
 >The required ports are automatically opened by Rancher during creation of clusters in cloud providers like Amazon EC2 or DigitalOcean.
 
-{{< ports-iaas-nodes >}}
+<PortsIaasNodes/>
 
 </details>
 
@@ -176,7 +165,7 @@ The following table depicts the port requirements for [Rancher Launched Kubernet
 
 The following table depicts the port requirements for [Rancher Launched Kubernetes](../../../pages-for-subheaders/launch-kubernetes-with-rancher.md) with [Custom Nodes](../../../pages-for-subheaders/use-existing-nodes.md).
 
-{{< ports-custom-nodes >}}
+<PortsCustomNodes/>
 
 </details>
 
@@ -187,7 +176,7 @@ The following table depicts the port requirements for [Rancher Launched Kubernet
 
 The following table depicts the port requirements for [hosted clusters](../../../pages-for-subheaders/set-up-clusters-from-hosted-kubernetes-providers.md).
 
-{{< ports-imported-hosted >}}
+<PortsImportedHosted/>
 
 </details>
 
@@ -199,7 +188,7 @@ The following table depicts the port requirements for [hosted clusters](../../..
 
 The following table depicts the port requirements for [imported clusters](../../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/import-existing-clusters.md).
 
-{{< ports-imported-hosted >}}
+<PortsImportedHosted/>
 
 </details>
 

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
@@ -34,10 +34,19 @@ From a system that has access to the internet, fetch the latest Helm chart and c
 1. If you haven't already, install `helm` locally on a workstation that has internet access. Note: Refer to the [Helm version requirements](../../resources/helm-version-requirements.md) to choose a version of Helm to install Rancher.
 
 2. Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see [Choosing a Version of Rancher](../../../../reference-guides/installation-references/helm-chart-options.md#helm-chart-repositories).
-  {{< release-channel >}}
-    ```
-    helm repo add rancher-<CHART_REPO> https://releases.rancher.com/server-charts/<CHART_REPO>
-    ```
+    - Latest: Recommended for trying out the newest features
+        ```
+        helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+        ```
+    - Stable: Recommended for production environments
+        ```
+        helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+        ```
+    - Alpha: Experimental preview of upcoming releases.
+        ```
+        helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+        ```
+        Note: Upgrades are not supported to, from, or between Alphas.
 
 3. Fetch the latest Rancher chart. This will pull down the chart and save it in the current directory as a `.tgz` file.
     ```plain

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
@@ -55,7 +55,19 @@ After installing Rancher, if you want to change which Helm chart repository to i
 
 > **Note:** Because the rancher-alpha repository contains only alpha charts, switching between the rancher-alpha repository and the rancher-stable or rancher-latest repository for upgrades is not supported.
 
-{{< release-channel >}}
+- Latest: Recommended for trying out the newest features
+    ```
+    helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+    ```
+- Stable: Recommended for production environments
+    ```
+    helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+    ```
+- Alpha: Experimental preview of upcoming releases.
+    ```
+    helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+    ```
+    Note: Upgrades are not supported to, from, or between Alphas.
 
 1. List the current Helm chart repositories.
 

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-keycloak.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-keycloak.md
@@ -89,7 +89,14 @@ If your organization uses Keycloak Identity Provider (IdP) for user authenticati
 
 **Result:** Rancher is configured to work with Keycloak. Your users can now sign into Rancher using their Keycloak logins.
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::
 
 ## Annex: Troubleshooting
 

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-okta-saml.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-okta-saml.md
@@ -50,4 +50,11 @@ Setting | Value
 
 **Result:** Rancher is configured to work with Okta. Your users can now sign into Rancher using their Okta logins.
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-pingidentity.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-pingidentity.md
@@ -51,4 +51,11 @@ Note that these URLs will not return valid data until the authentication configu
 
 **Result:** Rancher is configured to work with PingIdentity. Your users can now sign into Rancher using their PingIdentity logins.
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/manage-users-and-groups.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/manage-users-and-groups.md
@@ -13,7 +13,14 @@ When adding a user or group to a resource, you can search for users or groups by
 
 All users, whether they are local users or from an authentication provider, can be viewed and managed. From the **Global** view, click on **Users**.
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::
 
 ## User Information
 

--- a/versioned_docs/version-2.0-2.4/pages-for-subheaders/about-authentication.md
+++ b/versioned_docs/version-2.0-2.4/pages-for-subheaders/about-authentication.md
@@ -63,7 +63,14 @@ To set the Rancher access level for users in the authorization service, follow t
 
 **Result:** The Rancher access configuration settings are applied.
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::
 
 ## External Authentication Configuration and Principal Users
 

--- a/versioned_docs/version-2.0-2.4/pages-for-subheaders/configure-microsoft-ad-federation-service-saml.md
+++ b/versioned_docs/version-2.0-2.4/pages-for-subheaders/configure-microsoft-ad-federation-service-saml.md
@@ -25,7 +25,14 @@ Setting up Microsoft AD FS with Rancher Server requires configuring AD FS on you
 - [1. Configuring Microsoft AD FS for Rancher](../how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/configure-microsoft-ad-federation-service-saml/configure-ms-adfs-for-rancher.md)
 - [2. Configuring Rancher for Microsoft AD FS](../how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/configure-microsoft-ad-federation-service-saml/configure-rancher-for-ms-adfs.md)
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::
 
 
 ### [Next: Configuring Microsoft AD FS for Rancher](../how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/configure-microsoft-ad-federation-service-saml/configure-ms-adfs-for-rancher.md)

--- a/versioned_docs/version-2.0-2.4/pages-for-subheaders/helm-rancher.md
+++ b/versioned_docs/version-2.0-2.4/pages-for-subheaders/helm-rancher.md
@@ -18,11 +18,19 @@ Refer to the [Helm version requirements](../getting-started/installation-and-upg
 
 Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see [Choosing a Version of Rancher](../getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md).
 
-{{< release-channel >}}
-
-```
-helm repo add rancher-<CHART_REPO> https://releases.rancher.com/server-charts/<CHART_REPO>
-```
+- Latest: Recommended for trying out the newest features
+    ```
+    helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+    ```
+- Stable: Recommended for production environments
+    ```
+    helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+    ```
+- Alpha: Experimental preview of upcoming releases.
+    ```
+    helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+    ```
+    Note: Upgrades are not supported to, from, or between Alphas.
 
 ### Choose your SSL Configuration
 

--- a/versioned_docs/version-2.0-2.4/pages-for-subheaders/helm2-rke-add-on-layer-4-lb.md
+++ b/versioned_docs/version-2.0-2.4/pages-for-subheaders/helm2-rke-add-on-layer-4-lb.md
@@ -5,6 +5,7 @@ aliases:
   - /rancher/v2.0-v2.4/en/installation/options/helm2/rke-add-on/layer-4-lb
   - /rancher/v2.x/en/installation/resources/advanced/helm2/rke-add-on/layer-4-lb/
 ---
+import SslFaqHa from '@site/src/components/SslFaqHa'
 
 > #### **Important: RKE add-on install is only supported up to Rancher v2.0.8**
 >
@@ -400,4 +401,4 @@ You have a couple of options:
 
 ## FAQ and Troubleshooting
 
-{{< ssl_faq_ha >}}
+<SslFaqHa/>

--- a/versioned_docs/version-2.0-2.4/pages-for-subheaders/helm2-rke-add-on-layer-7-lb.md
+++ b/versioned_docs/version-2.0-2.4/pages-for-subheaders/helm2-rke-add-on-layer-7-lb.md
@@ -6,6 +6,7 @@ aliases:
   - /rancher/v2.0-v2.4/en/installation/options/helm2/rke-add-on/layer-7-lb
   - /rancher/v2.x/en/installation/resources/advanced/helm2/rke-add-on/layer-7-lb/
 ---
+import SslFaqHa from '@site/src/components/SslFaqHa'
 
 > #### **Important: RKE add-on install is only supported up to Rancher v2.0.8**
 >
@@ -291,4 +292,4 @@ During installation, RKE automatically generates a config file named `kube_confi
 
 ## FAQ and Troubleshooting
 
-{{< ssl_faq_ha >}}
+<SslFaqHa/>

--- a/versioned_docs/version-2.0-2.4/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster.md
+++ b/versioned_docs/version-2.0-2.4/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster.md
@@ -64,11 +64,19 @@ Refer to the [instructions provided by the Helm project](https://helm.sh/docs/in
 
 Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see [Choosing a Version of Rancher](../reference-guides/installation-references/helm-chart-options.md#helm-chart-repositories).
 
-{{< release-channel >}}
-
-```
-helm repo add rancher-<CHART_REPO> https://releases.rancher.com/server-charts/<CHART_REPO>
-```
+- Latest: Recommended for trying out the newest features
+    ```
+    helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+    ```
+- Stable: Recommended for production environments
+    ```
+    helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+    ```
+- Alpha: Experimental preview of upcoming releases.
+    ```
+    helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+    ```
+    Note: Upgrades are not supported to, from, or between Alphas.
 
 ### 3. Create a Namespace for Rancher
 

--- a/versioned_docs/version-2.0-2.4/pages-for-subheaders/migrate-from-v1.6-v2.x.md
+++ b/versioned_docs/version-2.0-2.4/pages-for-subheaders/migrate-from-v1.6-v2.x.md
@@ -4,6 +4,7 @@ weight: 28
 aliases:
   - /rancher/v2.x/en/v1.6-migration/
 ---
+import YouTube from '@site/src/components/YouTube'
 
 Rancher v2.x has been rearchitected and rewritten with the goal of providing a complete management solution for Kubernetes and Docker.  Due to these extensive changes, there is no direct upgrade path from v1.6 to v2.x, but rather a migration of your v1.6 services into v2.x as Kubernetes workloads.  In v1.6, the most common orchestration used was Rancher's own engine called Cattle. The following guide explains and educates our Cattle users on running workloads in a Kubernetes environment.
 
@@ -11,7 +12,7 @@ Rancher v2.x has been rearchitected and rewritten with the goal of providing a c
 
 This video demonstrates a complete walk through of migration from Rancher v1.6 to v2.x.
 
-{{< youtube OIifcqj5Srw >}}
+<YouTube id="OIifcqj5Srw"/>
 
 ## Migration Plan
 

--- a/versioned_docs/version-2.0-2.4/pages-for-subheaders/upgrades.md
+++ b/versioned_docs/version-2.0-2.4/pages-for-subheaders/upgrades.md
@@ -98,7 +98,19 @@ You'll use the backup as a restoration point if something goes wrong during upgr
 
     For information about the repos and their differences, see [Helm Chart Repositories](../reference-guides/installation-references/helm-chart-options.md#helm-chart-repositories).
 
-    {{< release-channel >}}
+    - Latest: Recommended for trying out the newest features
+        ```
+        helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+        ```
+    - Stable: Recommended for production environments
+        ```
+        helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+        ```
+    - Alpha: Experimental preview of upcoming releases.
+        ```
+        helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+        ```
+        Note: Upgrades are not supported to, from, or between Alphas.
 
     ```
     helm repo list

--- a/versioned_docs/version-2.0-2.4/pages-for-subheaders/vsphere.md
+++ b/versioned_docs/version-2.0-2.4/pages-for-subheaders/vsphere.md
@@ -7,6 +7,7 @@ weight: 2225
 aliases:
   - /rancher/v2.0-v2.4/en/tasks/clusters/creating-a-cluster/create-cluster-vsphere/
 ---
+import YouTube from '@site/src/components/YouTube'
 
 By using Rancher with vSphere, you can bring cloud operations on-premises.
 
@@ -49,7 +50,7 @@ In Rancher before v2.3.3, the vSphere node driver included in Rancher only suppo
 
 In this YouTube video, we demonstrate how to set up a node template with the new features designed to help you bring cloud operations to on-premises clusters.
 
-{{< youtube id="dPIwg6x1AlU">}}
+<YouTube id="dPIwg6x1AlU"/>
 
 # Creating a vSphere Cluster
 

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.md
@@ -91,7 +91,19 @@ You'll use the backup as a restoration point if something goes wrong during upgr
 
     For information about the repos and their differences, see [Helm Chart Repositories](../../../reference-guides/installation-references/helm-chart-options.md#helm-chart-repositories).
 
-    {{< release-channel >}}
+    - Latest: Recommended for trying out the newest features
+        ```
+        helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+        ```
+    - Stable: Recommended for production environments
+        ```
+        helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+        ```
+    - Alpha: Experimental preview of upcoming releases.
+        ```
+        helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+        ```
+        Note: Upgrades are not supported to, from, or between Alphas.
 
     ```
     helm repo list

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/installation-requirements/port-requirements.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/installation-requirements/port-requirements.md
@@ -8,24 +8,11 @@ aliases:
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import PortsIaasNodes from '@site/src/components/PortsIaasNodes'
+import PortsCustomNodes from '@site/src/components/PortsCustomNodes'
+import PortsImportedHosted from '@site/src/components/PortsImportedHosted'
 
 To operate properly, Rancher requires a number of ports to be open on Rancher nodes and on downstream Kubernetes cluster nodes.
-
-- [Rancher Nodes](#rancher-nodes)
-  - [Ports for Rancher Server Nodes on K3s](#ports-for-rancher-server-nodes-on-k3s)
-  - [Ports for Rancher Server Nodes on RKE](#ports-for-rancher-server-nodes-on-rke)
-  - [Ports for Rancher Server Nodes on RancherD or RKE2](#ports-for-rancher-server-nodes-on-rancherd-or-rke2)
-  - [Ports for Rancher Server in Docker](#ports-for-rancher-server-in-docker)
-- [Downstream Kubernetes Cluster Nodes](#downstream-kubernetes-cluster-nodes)
-  - [Ports for Rancher Launched Kubernetes Clusters using Node Pools](#ports-for-rancher-launched-kubernetes-clusters-using-node-pools)
-  - [Ports for Rancher Launched Kubernetes Clusters using Custom Nodes](#ports-for-rancher-launched-kubernetes-clusters-using-custom-nodes)
-  - [Ports for Hosted Kubernetes Clusters](#ports-for-hosted-kubernetes-clusters)
-  - [Ports for Registered Clusters](#ports-for-registered-clusters)
-- [Other Port Considerations](#other-port-considerations)
-  - [Commonly Used Ports](#commonly-used-ports)
-  - [Local Node Traffic](#local-node-traffic)
-  - [Rancher AWS EC2 Security Group](#rancher-aws-ec2-security-group)
-  - [Opening SUSE Linux Ports](#opening-suse-linux-ports)
 
 # Rancher Nodes
 
@@ -205,7 +192,7 @@ The following table depicts the port requirements for [Rancher Launched Kubernet
 >**Note:**
 >The required ports are automatically opened by Rancher during creation of clusters in cloud providers like Amazon EC2 or DigitalOcean.
 
-{{< ports-iaas-nodes >}}
+<PortsIaasNodes/>
 
 </details>
 
@@ -216,7 +203,7 @@ The following table depicts the port requirements for [Rancher Launched Kubernet
 
 The following table depicts the port requirements for [Rancher Launched Kubernetes](../../../pages-for-subheaders/launch-kubernetes-with-rancher.md) with [Custom Nodes](../../../pages-for-subheaders/use-existing-nodes.md).
 
-{{< ports-custom-nodes >}}
+<PortsCustomNodes/>
 
 </details>
 
@@ -227,7 +214,7 @@ The following table depicts the port requirements for [Rancher Launched Kubernet
 
 The following table depicts the port requirements for [hosted clusters](../../../pages-for-subheaders/set-up-clusters-from-hosted-kubernetes-providers.md).
 
-{{< ports-imported-hosted >}}
+<PortsImportedHosted/>
 
 </details>
 
@@ -240,7 +227,7 @@ Note: Registered clusters were called imported clusters before Rancher v2.5.
 
 The following table depicts the port requirements for [registered clusters](../../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md).
 
-{{< ports-imported-hosted >}}
+<PortsImportedHosted/>
 
 </details>
 

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
@@ -42,10 +42,19 @@ From a system that has access to the internet, fetch the latest Helm chart and c
 1. If you haven't already, install `helm` locally on a workstation that has internet access. Note: Refer to the [Helm version requirements](../../resources/helm-version-requirements.md) to choose a version of Helm to install Rancher.
 
 2. Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see [Choosing a Version of Rancher](../../../../reference-guides/installation-references/helm-chart-options.md#helm-chart-repositories).
-  {{< release-channel >}}
-    ```
-    helm repo add rancher-<CHART_REPO> https://releases.rancher.com/server-charts/<CHART_REPO>
-    ```
+    - Latest: Recommended for trying out the newest features
+        ```
+        helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+        ```
+    - Stable: Recommended for production environments
+        ```
+        helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+        ```
+    - Alpha: Experimental preview of upcoming releases.
+        ```
+        helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+        ```
+    Note: Upgrades are not supported to, from, or between Alphas.
 
 3. Fetch the latest Rancher chart. This will pull down the chart and save it in the current directory as a `.tgz` file.
     ```plain

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
@@ -58,7 +58,19 @@ After installing Rancher, if you want to change which Helm chart repository to i
 
 > **Note:** Because the rancher-alpha repository contains only alpha charts, switching between the rancher-alpha repository and the rancher-stable or rancher-latest repository for upgrades is not supported.
 
-{{< release-channel >}}
+- Latest: Recommended for trying out the newest features
+    ```
+    helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+    ```
+- Stable: Recommended for production environments
+    ```
+    helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+    ```
+- Alpha: Experimental preview of upcoming releases.
+    ```
+    helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+    ```
+    Note: Upgrades are not supported to, from, or between Alphas.
 
 1. List the current Helm chart repositories.
 

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-keycloak.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-keycloak.md
@@ -129,7 +129,14 @@ The following is an example process for Firefox, but will vary slightly for othe
 
 **Result:** Rancher is configured to work with Keycloak. Your users can now sign into Rancher using their Keycloak logins.
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::
 
 ## Configuration Reference
 

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-okta-saml.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-okta-saml.md
@@ -50,4 +50,11 @@ Setting | Value
 
 **Result:** Rancher is configured to work with Okta. Your users can now sign into Rancher using their Okta logins.
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-pingidentity.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-pingidentity.md
@@ -52,4 +52,11 @@ Note that these URLs will not return valid data until the authentication configu
 
 **Result:** Rancher is configured to work with PingIdentity. Your users can now sign into Rancher using their PingIdentity logins.
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/manage-users-and-groups.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/manage-users-and-groups.md
@@ -15,7 +15,14 @@ When adding a user or group to a resource, you can search for users or groups by
 
 All users, whether they are local users or from an authentication provider, can be viewed and managed. From the **Global** view, click on **Users**.
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::
 
 ## User Information
 

--- a/versioned_docs/version-2.5/pages-for-subheaders/about-authentication.md
+++ b/versioned_docs/version-2.5/pages-for-subheaders/about-authentication.md
@@ -64,7 +64,14 @@ To set the Rancher access level for users in the authorization service, follow t
 
 **Result:** The Rancher access configuration settings are applied.
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::
 
 ## External Authentication Configuration and Principal Users
 

--- a/versioned_docs/version-2.5/pages-for-subheaders/configure-microsoft-ad-federation-service-saml.md
+++ b/versioned_docs/version-2.5/pages-for-subheaders/configure-microsoft-ad-federation-service-saml.md
@@ -26,7 +26,14 @@ Setting up Microsoft AD FS with Rancher Server requires configuring AD FS on you
 - [1. Configuring Microsoft AD FS for Rancher](../how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/configure-microsoft-ad-federation-service-saml/configure-ms-adfs-for-rancher.md)
 - [2. Configuring Rancher for Microsoft AD FS](../how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/configure-microsoft-ad-federation-service-saml/configure-rancher-for-ms-adfs.md)
 
-{{< saml_caveats >}}
+:::note SAML Provider Caveats:
+
+- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+- When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
+- When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
+- The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
+
+:::
 
 
 ### [Next: Configuring Microsoft AD FS for Rancher](../how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/configure-microsoft-ad-federation-service-saml/configure-ms-adfs-for-rancher.md)

--- a/versioned_docs/version-2.5/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster.md
+++ b/versioned_docs/version-2.5/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster.md
@@ -81,11 +81,19 @@ To set up Rancher,
 
 Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see [Choosing a Version of Rancher](../reference-guides/installation-references/helm-chart-options.md#helm-chart-repositories).
 
-{{< release-channel >}}
-
-```
-helm repo add rancher-<CHART_REPO> https://releases.rancher.com/server-charts/<CHART_REPO>
-```
+- Latest: Recommended for trying out the newest features
+    ```
+    helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+    ```
+- Stable: Recommended for production environments
+    ```
+    helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+    ```
+- Alpha: Experimental preview of upcoming releases.
+    ```
+    helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+    ```
+    Note: Upgrades are not supported to, from, or between Alphas.
 
 ### 2. Create a Namespace for Rancher
 

--- a/versioned_docs/version-2.5/pages-for-subheaders/vsphere.md
+++ b/versioned_docs/version-2.5/pages-for-subheaders/vsphere.md
@@ -8,6 +8,7 @@ aliases:
   - /rancher/v2.5/en/tasks/clusters/creating-a-cluster/create-cluster-vsphere/
   - /rancher/v2.x/en/cluster-provisioning/rke-clusters/node-pools/vsphere/
 ---
+import YouTube from '@site/src/components/YouTube'
 
 By using Rancher with vSphere, you can bring cloud operations on-premises.
 
@@ -44,7 +45,7 @@ You can provision VMs with any operating system that supports `cloud-init`. Only
 
 In this YouTube video, we demonstrate how to set up a node template with the new features designed to help you bring cloud operations to on-premises clusters.
 
-{{< youtube id="dPIwg6x1AlU">}}
+<YouTube id="dPIwg6x1AlU"/>
 
 # Creating a vSphere Cluster
 


### PR DESCRIPTION
- Fixes artifacts in docusaurus where there is a `{{< something >}}` left over from the Hugo docs
- Re-adds the `helm repo add` commands
- Re-adds some port requirements tables - creates a reusable React component for each table
- Creates a component for embedded YouTube videos that should retain the same functionality as Hugo