### PR TITLE
Fix the outdated Rancher CLI link

### DIFF
--- a/docs/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/docs/reference-guides/cli-with-rancher/rancher-cli.md
@@ -8,11 +8,11 @@ The Rancher CLI (Command Line Interface) is a unified tool that you can use to i
 
 ### Download Rancher CLI
 
-The binary can be downloaded directly from the UI. The link can be found in the right hand side of the footer in the UI. We have binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli) for direct downloads of the binary.
+The binary can be downloaded directly from the UI. The link can be found in the right hand side of the footer in the UI. We have binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
 
 1. In the upper left corner, click **☰**.
 1. At the bottom, click **v2.6.x**, where **v2.6.x** is a hyperlinked text indicating the installed Rancher version.
-1. Under the **CLI Downloads section**, there are links to download the binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli) for direct downloads of the binary.
+1. Under the **CLI Downloads section**, there are links to download the binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
 
 ### Requirements
 

--- a/docs/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/docs/reference-guides/cli-with-rancher/rancher-cli.md
@@ -8,11 +8,11 @@ The Rancher CLI (Command Line Interface) is a unified tool that you can use to i
 
 ### Download Rancher CLI
 
-The binary can be downloaded directly from the UI. The link can be found in the right hand side of the footer in the UI. We have binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/ranchcli/releases) for direct downloads of the binary.
+The binary can be downloaded directly from the UI. The link can be found in the right hand side of the footer in the UI. We have binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli) for direct downloads of the binary.
 
 1. In the upper left corner, click **☰**.
 1. At the bottom, click **v2.6.x**, where **v2.6.x** is a hyperlinked text indicating the installed Rancher version.
-1. Under the **CLI Downloads section**, there are links to download the binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/ranchcli/releases) for direct downloads of the binary.
+1. Under the **CLI Downloads section**, there are links to download the binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli) for direct downloads of the binary.
 
 ### Requirements
 

--- a/versioned_docs/version-2.0-2.4/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/cli-with-rancher/rancher-cli.md
@@ -8,11 +8,11 @@ The Rancher CLI (Command Line Interface) is a unified tool that you can use to i
 
 ### Download Rancher CLI
 
-The binary can be downloaded directly from the UI. The link can be found in the right hand side of the footer in the UI. We have binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/ranchcli/releases) for direct downloads of the binary.
+The binary can be downloaded directly from the UI. The link can be found in the right hand side of the footer in the UI. We have binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
 
 1. In the upper left corner, click **☰**.
 1. At the bottom, click **v2.6.x**, where **v2.6.x** is a hyperlinked text indicating the installed Rancher version.
-1. Under the **CLI Downloads section**, there are links to download the binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/ranchcli/releases) for direct downloads of the binary.
+1. Under the **CLI Downloads section**, there are links to download the binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
 
 ### Requirements
 

--- a/versioned_docs/version-2.5/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/versioned_docs/version-2.5/reference-guides/cli-with-rancher/rancher-cli.md
@@ -7,11 +7,11 @@ The Rancher CLI (Command Line Interface) is a unified tool that you can use to i
 
 ### Download Rancher CLI
 
-The binary can be downloaded directly from the UI. The link can be found in the right hand side of the footer in the UI. We have binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/ranchcli/releases) for direct downloads of the binary.
+The binary can be downloaded directly from the UI. The link can be found in the right hand side of the footer in the UI. We have binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
 
 1. In the upper left corner, click **☰**.
 1. At the bottom, click **v2.6.x**, where **v2.6.x** is a hyperlinked text indicating the installed Rancher version.
-1. Under the **CLI Downloads section**, there are links to download the binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/ranchcli/releases) for direct downloads of the binary.
+1. Under the **CLI Downloads section**, there are links to download the binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
 
 ### Requirements
 


### PR DESCRIPTION
The repository URL of the Rancher CLI on the docs is outdated. This PR fixes the URL to guide users to the right place.