### PR TITLE
Updating Proxy/Airgap Install Instructions and AWS Marketplace Listing Link

### DIFF
--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace.md
@@ -4,4 +4,4 @@ description: Use Amazon EKS to deploy Rancher server.
 weight: 110
 ---
 
-There is now an additional way for you to deploy the Rancher server in AWS by using Amazon EKS. To learn more, see our [Amazon Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-2yzbnvagmi4as).
+There is now an additional way for you to deploy the Rancher server in AWS by using Amazon EKS. To learn more, see our [Amazon Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-go7ent7goo5ae).


### PR DESCRIPTION
This PR has two commits:

## Commit 1 - Updating Rancher Proxy/Airgap Install Instructions

This is related to rancher/rancher#37993. Our current instructions tell users to render the templates offline using `helm template` and install them using `kubectl apply`. This has the downside of preventing our pre-install hooks from running, which breaks (among other potential items) our creation of a bootstrap password. See [here](https://github.com/rancher/rancher/issues/37993#issuecomment-1251475897) for more information on this issue and the proposed solution

## Commit 2 - Changing the "Deploy Rancher using the AWS marketplace" link

The current link for "How to deploy Rancher using the AWS marketplace" points to an old product which is no longer supported. We have a new product, called "Rancher Setup" which will allow users to create an EKS cluster with rancher installed. This link has been updated to point to this new product, rather than to the old, deprecated product.


## Notes

I also, as part of my work here, made a quick dockerfile and dockercompose that allows you to run these docs on local without installing yarn. If you would like me to include these items/usage instructions as part of this PR/a separate commit, please let me know and I can include that.

I do think that we will want QA to test these out before we merge this, but I need to check with them to see if that's something that they can/do want to do.