### PR TITLE
Add Docker alternative to preview docs locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ $ yarn start
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
 
+You can also use Docker to launch the website without needing to install and configure yarn:
+
+```
+docker run --rm -it -v $PWD:$PWD -w $PWD -p 3000:3000 node yarn start -h 0.0.0.0
+```
+
 ### Build
 
 ```


### PR DESCRIPTION
This is an alternative to https://github.com/rancher/rancher-docs/pull/215 that was suggested via Slack.  This method `also has the benefit of mounting the directories into the container so they live-reload as you make changes`.

