### PR TITLE
Add workflow for stale issues/PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - uses: actions/stale@v5
+      with:
+          stale-issue-message: 'This repository uses an automated workflow to automatically label issues which have not had any activity (commit/comment/label) for 90 days. This helps us manage the community issues better. If the issue is still relevant, please add a comment to the issue so the workflow can remove the label and we know it is still valid. If it is no longer relevant (or possibly fixed in the latest release), the workflow will automatically close the issue in 30 days. Thank you for your contributions.'
+          stale-pr-message: 'This repository uses an automated workflow to automatically label pull requests which have not had any activity (commit/comment/label) for 90 days. This helps us manage the community pull requests better. If the pull request is still relevant, please add a comment to the pull request so the workflow can remove the label and we know it is still valid. If it is no longer relevant (or possibly fixed in the latest release), the workflow will automatically close the pull request in 30 days. Thank you for your contributions.'
+          stale-issue-label: 'status/stale'
+          stale-pr-label: 'status/stale'
+          days-before-stale: 90
+          days-before-close: 30
+          exempt-issue-labels: 'internal'
+          exempt-pr-labels: 'internal'
+          exempt-all-milestones: true
+          exempt-all-assignees: true
+          operations-per-run: 200


### PR DESCRIPTION
Uses the config from [rancher/rancher](https://github.com/rancher/rancher/blob/release/v2.7/.github/workflows/stale.yml) as a reference.

Slight modifications include:
- 90 days before marking an item as stale
- 30 days before items marked stale are closed
- Only items labeled `internal` are exempt. Most of the other labels do not exist in our docs repo. We can revisit this later 