### PR TITLE
Fix last updated timestamp

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: 18


### PR DESCRIPTION
When deploying with GitHub Actions the current config will only fetch the last commit and this is used by the "Last updated on" value which results in all pages having the same date. This changes the checkout action to fetch all history which should give better results.

Reference: https://github.com/facebook/docusaurus/issues/2798