### PR TITLE
Update b64 example, add syntax highlighting, revise helm install steps

### DIFF
--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -136,6 +136,7 @@ Kubernetes v1.22, available as an experimental feature of v2.6.3, does not suppo
       ```bash
       kubectl get restore
       ```
+
    1. Watch the restoration logs:
       ```bash
       kubectl logs -n cattle-resources-system --tail 100 -f -l app.kubernetes.io/instance=rancher-backup

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -85,7 +85,7 @@ Kubernetes v1.22, available as an experimental feature of v2.6.3, does not suppo
 
    :::note
 
-   Add your access key and secret key as values for `accessKey` and `secretKey` in the command below.
+   Add your access key and secret key as values for `accessKey` and `secretKey` in the command above.
 
    :::
 

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -31,6 +31,7 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
      helm repo add rancher-charts https://charts.rancher.io
      helm repo update
      ```
+
   1. Select and set `CHART_VERSION` variable with a 2.x.x rancher-backup release version:
      ```bash
      helm search repo --versions rancher-charts/rancher-backup

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -141,6 +141,7 @@ Kubernetes v1.22, available as an experimental feature of v2.6.3, does not suppo
       ```bash
       kubectl logs -n cattle-resources-system --tail 100 -f -l app.kubernetes.io/instance=rancher-backup
       ```
+
    1. Once the Restore resource has the status `Completed`, you can continue the Rancher installation.
 
 ### 3. Install cert-manager

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -73,7 +73,7 @@ Kubernetes v1.22, available as an experimental feature of v2.6.3, does not suppo
 
 :::
 
-1. When using S3 object storage that as the backup source for restore that requires credentials, create a `Secret` object in this cluster to add the S3 credentials. The secret data must have two keys - `accessKey`, and `secretKey`, that contain the S3 credentials.
+1. When using S3 object storage as the backup source for a restore that requires credentials, create a `Secret` object in this cluster to add the S3 credentials. The secret data must have two keys - `accessKey`, and `secretKey`, that contain the S3 credentials.
 
    The secret can be created in any namespace, this example uses the default namespace.
 

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -101,6 +101,7 @@ Kubernetes v1.22, available as an experimental feature of v2.6.3, does not suppo
      name: restore-migration
    spec:
      backupFilename: backup-b0450532-cee1-4aa1-a881-f5f48a007b1c-2020-09-15T07-27-09Z.tar.gz
+     // highlight-next-line
      prune: false
      encryptionConfigSecretName: encryptionconfig
      storageLocation:

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -91,7 +91,7 @@ Kubernetes v1.22, available as an experimental feature of v2.6.3, does not suppo
 
 1. Create a `Restore` object:
 
-   During a migration, `prune` must be set to `false`, the example below:
+   During a migration, `prune` must be set to `false`. See the example below:
 
    ```yaml
    # restore-migration.yaml

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -124,6 +124,7 @@ Kubernetes v1.22, available as an experimental feature of v2.6.3, does not suppo
         --from-file=./encryption-provider-config.yaml \
         -n cattle-resources-system
       ```
+
 1. Apply the manifest, and monitor the Restore status:
    1. Apply the `Restore` object resource:
       ```bash

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -131,6 +131,7 @@ Kubernetes v1.22, available as an experimental feature of v2.6.3, does not suppo
       ```bash
       kubectl apply -f restore-migration.yaml
       ```
+
    1. Watch the Restore status:
       ```bash
       kubectl get restore

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -48,7 +48,8 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
 
      The above assumes an environment with outbound connectivity to Docker Hub
 
-     For an **air-gapped environment**, use the helm value below to pull the `backup-restore-operator` image from your private registry when installing the rancher-backup helm chart.
+     For an **air-gapped environment**, use the Helm value below to pull the `backup-restore-operator` image from your private registry when installing the rancher-backup Helm chart.
+     
      ```bash
      --set image.repository $REGISTRY/rancher/backup-restore-operator
      ```

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -114,7 +114,7 @@ Kubernetes v1.22, available as an experimental feature of v2.6.3, does not suppo
          endpoint: s3.us-west-2.amazonaws.com
    ```
 
-   :::note Important:
+   :::note Important
 
    The field `encryptionConfigSecretName` must be set only if your backup was created with encryption enabled. Provide the name of the `Secret` object containing the encryption config file. If you only have the encryption config file, but don't have a secret created with it in this cluster, use the following steps to create the secret:
 

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -127,6 +127,7 @@ Kubernetes v1.22, available as an experimental feature of v2.6.3, does not suppo
 
 1. Apply the manifest, and monitor the Restore status:
    1. Apply the `Restore` object resource:
+
       ```bash
       kubectl apply -f restore-migration.yaml
       ```

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -26,6 +26,7 @@ Rancher can be installed on any Kubernetes cluster, including hosted Kubernetes 
 Install the [rancher-backup chart](https://github.com/rancher/backup-restore-operator/tags), using a version in the 2.x.x major version range:
 
   1. Add the helm repository:
+
      ```bash
      helm repo add rancher-charts https://charts.rancher.io
      helm repo update

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -37,7 +37,8 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
      helm search repo --versions rancher-charts/rancher-backup
      CHART_VERSION=<2.x.x>
      ```
-  2. Install the charts:
+
+  1. Install the charts:
      ```bash
      helm install rancher-backup-crd rancher-charts/rancher-backup-crd -n cattle-resources-system --create-namespace --version $CHART_VERSION
      helm install rancher-backup rancher-charts/rancher-backup -n cattle-resources-system --version $CHART_VERSION

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -103,6 +103,7 @@ Kubernetes v1.22, available as an experimental feature of v2.6.3, does not suppo
      backupFilename: backup-b0450532-cee1-4aa1-a881-f5f48a007b1c-2020-09-15T07-27-09Z.tar.gz
      // highlight-next-line
      prune: false
+     // highlight-next-line
      encryptionConfigSecretName: encryptionconfig
      storageLocation:
        s3:
@@ -116,16 +117,20 @@ Kubernetes v1.22, available as an experimental feature of v2.6.3, does not suppo
 
    :::note Important
 
-   The field `encryptionConfigSecretName` must be set only if your backup was created with encryption enabled. Provide the name of the `Secret` object containing the encryption config file. If you only have the encryption config file, but don't have a secret created with it in this cluster, use the following steps to create the secret:
+   The field `encryptionConfigSecretName` should be used only if your backup was created with encryption enabled.
 
-   :::
+   If this applies, provide the name of the `Secret` object containing the encryption config file. If you only have the encryption config file, but don't have the secret created in this cluster, use the following steps to create the secret:
 
-   1. The [encryption configuration file](reference-guides/backup-restore-configuration/backup-configuration.md#encryption) must be named `encryption-provider-config.yaml`, and the `--from-file` flag must be used to create this secret. So save your `EncryptionConfiguration` in a file called `encryption-provider-config.yaml` and run this command:
+   1. Create an [encryption configuration file](reference-guides/backup-restore-configuration/backup-configuration.md#encryption)
+   1. The command below uses a file named `encryption-provider-config.yaml`, with the `--from-file` flag. Run the below once the `EncryptionConfiguration` is saved in a file called `encryption-provider-config.yaml`:
+
       ```bash
       kubectl create secret generic encryptionconfig \
         --from-file=./encryption-provider-config.yaml \
         -n cattle-resources-system
       ```
+
+   :::
 
 1. Apply the manifest, and monitor the Restore status:
    1. Apply the `Restore` object resource:
@@ -144,7 +149,7 @@ Kubernetes v1.22, available as an experimental feature of v2.6.3, does not suppo
       kubectl logs -n cattle-resources-system --tail 100 -f -l app.kubernetes.io/instance=rancher-backup
       ```
 
-   1. Once the Restore resource has the status `Completed`, you can continue the Rancher installation.
+   1. Once the Restore resource has the status `Completed`, you can continue the cert-manager and Rancher installation.
 
 ### 3. Install cert-manager
 
@@ -169,7 +174,7 @@ If the original Rancher environment is running, you can collect the current valu
 helm get values rancher -n cattle-system -o yaml > rancher-values.yaml
 ```
 
-These values can be reused using the `rancher-values.yaml` file:
+These values can be reused using the `rancher-values.yaml` file. Be sure to switch the kubeconfig to the new Rancher environment.
 
 ```bash
 helm install rancher rancher-latest/rancher -n cattle-system -f rancher-values.yaml --version x.y.z

--- a/docs/reference-guides/backup-restore-configuration/backup-configuration.md
+++ b/docs/reference-guides/backup-restore-configuration/backup-configuration.md
@@ -127,7 +127,8 @@ data:
 
 :::note
 
-To avoid encoding issues, the credentialSecret can be created with the below command, updating the values for `accessKey` and `secretKey`.
+To avoid encoding issues, the `credentialSecret` can be created with the below command, updating the values for `accessKey` and `secretKey`.
+
 ```bash
 kubectl create secret generic s3-creds \
   --from-literal=accessKey=<access key> \

--- a/docs/reference-guides/backup-restore-configuration/backup-configuration.md
+++ b/docs/reference-guides/backup-restore-configuration/backup-configuration.md
@@ -23,22 +23,23 @@ Select the first option to perform a one-time backup, or select the second optio
 
 ## Encryption
 
-The rancher-backup gathers resources by making calls to the kube-apiserver. Objects returned by apiserver are decrypted, so even if [encryption At rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) is enabled, even the encrypted objects gathered by the backup will be in plaintext.
+The rancher-backup gathers resources by making calls to the kube-apiserver. Objects returned by apiserver are decrypted, so even if [encryption at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) is enabled, even the encrypted objects gathered by the backup will be in plaintext.
 
-To avoid storing them in plaintext, you can use the same encryptionConfig file that was used for at-rest encryption, to encrypt certain resources in your backup.
+To avoid storing them in plaintext, you can use the same `EncryptionConfiguration` file that was used for at rest encryption, to encrypt certain resources in your backup.
 
 :::note Important:
 
-You must save the encryptionConfig file, because it won’t be saved by the rancher-backup operator.
-The same encryptionFile needs to be used when performing a restore.
+When encrypting objects in the backup you must save the `EncryptionConfiguration` file for future use, because it won’t be saved by the rancher-backup operator.
+
+For example, when [migrating Rancher to a new cluster](new-user-guides/backup-restore-and-disaster-recovery) the file is used to re-create the secret in the new cluster.
 
 :::
 
-The operator consumes this encryptionConfig as a Kubernetes Secret, and the Secret must be in the operator’s namespace. Rancher installs the `rancher-backup` operator in the `cattle-resources-system` namespace, so create this encryptionConfig secret in that namespace.
+The operator consumes the `EncryptionConfiguration` as a Kubernetes Secret in the `cattle-resources-system` namespace under the key named  `encryption-provider-config.yaml` in the secret data.
 
 For the `EncryptionConfiguration`, you can use the [sample file provided in the Kubernetes documentation.](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#understanding-the-encryption-at-rest-configuration)
 
-To create the Secret, the encryption configuration file must be named `encryption-provider-config.yaml`, and the `--from-file` flag must be used to create this secret.
+To ensure the correct key is used in the secret, the encryption configuration file must be named `encryption-provider-config.yaml`. The below command uses the `--from-file` flag to create the secret with the correct key name.
 
 Save the `EncryptionConfiguration` in a file called `encryption-provider-config.yaml` and run this command:
 
@@ -50,7 +51,7 @@ kubectl create secret generic encryptionconfig \
 
 This will ensure that the secret contains a key named `encryption-provider-config.yaml`, and the operator will use this key to get the encryption configuration.
 
-The `Encryption Config Secret` dropdown will filter out and list only those Secrets that have this exact key
+The `Encryption Config Secret` dropdown will filter out and list only those Secrets that have this exact key.
 
 ![](/img/backup_restore/backup/encryption.png)
 

--- a/docs/reference-guides/backup-restore-configuration/backup-configuration.md
+++ b/docs/reference-guides/backup-restore-configuration/backup-configuration.md
@@ -42,7 +42,7 @@ To create the Secret, the encryption configuration file must be named `encryptio
 
 Save the `EncryptionConfiguration` in a file called `encryption-provider-config.yaml` and run this command:
 
-```
+```bash
 kubectl create secret generic encryptionconfig \
   --from-file=./encryption-provider-config.yaml \
   -n cattle-resources-system
@@ -121,9 +121,20 @@ metadata:
   name: creds
 type: Opaque
 data:
-  accessKey: <Enter your base64-encoded access key>
-  secretKey: <Enter your base64-encoded secret key>
+  accessKey: <base64-encoded access key>
+  secretKey: <base64-encoded secret key>
 ```
+
+:::note
+
+To avoid encoding issues, the credentialSecret can be created with the below command, updating the values for `accessKey` and `secretKey`.
+```bash
+kubectl create secret generic s3-creds \
+  --from-literal=accessKey=<access key> \
+  --from-literal=secretKey=<secret key>
+```
+
+:::
 
 ### IAM Permissions for EC2 Nodes to Access S3
 


### PR DESCRIPTION
- Revise the restore-migration steps
- Revise helm chart install steps
- Add syntax highlighting

This was inspired by a number of issues with the b64 encoding example creating a pre-encoded secret object. Issues can occur with b64 encoding not being equal between different languages/libraries (golang, python, etc.). The aim is to avoid confusion with errors around encoded credentials.