### PR TITLE
Update wording, etcd is not started which is confusing

### DIFF
--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/restore-rancher-launched-kubernetes-clusters-from-backup.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/restore-rancher-launched-kubernetes-clusters-from-backup.md
@@ -50,17 +50,17 @@ If the group of etcd nodes loses quorum, the Kubernetes cluster will report a fa
 
 2. On the single remaining etcd node, run the following command:
 
-    ```
-    $ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock assaflavie/runlike etcd
+    ```bash
+    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock assaflavie/runlike etcd
     ```
 
     This command outputs the running command for etcd, save this command to use later.
 
-3. Stop the etcd container that you launched in the previous step and rename it to `etcd-old`.
+3. Stop the running `etcd` container and rename it to `etcd-old`.
 
-    ```
-    $ docker stop etcd
-    $ docker rename etcd etcd-old
+    ```bash
+    docker stop etcd
+    docker rename etcd etcd-old
     ```
 
 4. Take the saved command from Step 2 and revise it:


### PR DESCRIPTION
The `assaflavie/runlike` container prints the command to start the container specified, it won't start the container.

- Updated wording to reflect that etcd is already running
- Updated code blocks to add syntax highlighting