### PR TITLE
Add note about resource group and vnet

### DIFF
--- a/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/azure.md
+++ b/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/azure.md
@@ -10,6 +10,12 @@ Account access information is stored as a cloud credential. Cloud credentials ar
 - **Network** configures the networking used in your cluster.
 - **Instance** customizes your VM configuration.
 
+:::note
+
+If using a VNet in a different Resource Group than the VMs, the VNet name should be prefixed with with the Resource Group name, example: `<resource group>:<vnet>` 
+
+:::
+
 The [Docker daemon](https://docs.docker.com/engine/docker-overview/#the-docker-daemon) configuration options include:
 
 - **Labels:** For information on labels, refer to the [Docker object label documentation.](https://docs.docker.com/config/labels-custom-metadata/)


### PR DESCRIPTION
Adding note about prefix required for the VNet when in a different RG from the VMs (node template).

Reference https://github.com/rancher/rancher/issues/12582#issuecomment-424989612