### PR TITLE
Update Rancher installation requirements page

### DIFF
--- a/docs/getting-started/installation-and-upgrade/installation-requirements/dockershim.md
+++ b/docs/getting-started/installation-and-upgrade/installation-requirements/dockershim.md
@@ -6,6 +6,8 @@ The Dockershim is the CRI compliant layer between the Kubelet and the Docker dae
 
 RKE clusters now support the external Dockershim to continue leveraging Docker as the CRI runtime. We now implement the upstream open source community external Dockershim announced by [Mirantis and Docker](https://www.mirantis.com/blog/mirantis-to-take-over-support-of-kubernetes-dockershim-2/) to ensure RKE clusters can continue to leverage Docker.
 
+RKE2 and K3s clusters use an embedded containerd as a container runtime and are not affected.
+
 To enable the external Dockershim in versions of RKE before 1.24, configure the following option.
 
 ```

--- a/docs/getting-started/installation-and-upgrade/installation-requirements/install-docker.md
+++ b/docs/getting-started/installation-and-upgrade/installation-requirements/install-docker.md
@@ -2,7 +2,7 @@
 title: Installing Docker
 ---
 
-Docker is required to be installed on nodes where the Rancher server will be installed with Helm or Docker.
+Docker is required to be installed on nodes where the Rancher server will be installed with Helm on an RKE cluster or with Docker. Docker is not required for RKE2 or K3s clusters.
 
 There are a couple of options for installing Docker. One option is to refer to the [official Docker documentation](https://docs.docker.com/install/) about how to install Docker on Linux. The steps will vary based on the Linux distribution.
 
@@ -15,3 +15,9 @@ curl https://releases.rancher.com/install-docker/20.10.sh | sh
 ```
 
 Rancher has installation scripts for every version of upstream Docker that Kubernetes supports. To find out whether a script is available for installing a certain Docker version, refer to this [GitHub repository,](https://github.com/rancher/install-docker) which contains all of Rancher's Docker installation scripts.
+
+Note that the following sysctl setting must be applied:
+
+```
+net.bridge.bridge-nf-call-iptables=1
+```

--- a/docs/pages-for-subheaders/installation-requirements.md
+++ b/docs/pages-for-subheaders/installation-requirements.md
@@ -33,13 +33,13 @@ Make sure the node(s) for the Rancher server fulfill the following requirements:
 
 For a list of best practices that we recommend for running the Rancher server in production, refer to the [best practices section.](../reference-guides/best-practices/rancher-server/tips-for-running-rancher.md)
 
-The Rancher UI works best in Firefox or Chrome.
+The Rancher UI works best in Firefox or Chromium based browsers (Chrome, Edge, Opera, Brave, ...).
 
 # Operating Systems and Container Runtime Requirements
 
 Rancher should work with any modern Linux distribution.
 
-Docker is required for nodes that will run RKE Kubernetes clusters. It is not required for Kubernetes installs.
+Docker is required for nodes that will run RKE Kubernetes clusters. It is not required for RKE2 or K3s clusters.
 
 Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
@@ -49,9 +49,9 @@ All supported operating systems are 64-bit x86.
 
 The `ntp` (Network Time Protocol) package should be installed. This prevents errors with certificate validation that can occur when the time is not synchronized between the client and server.
 
-Some distributions of Linux may have default firewall rules that block communication with Helm. We recommend disabling firewalld. For Kubernetes v1.19, v1.20 and v1.21, firewalld must be turned off.
+Some distributions of Linux may have default firewall rules that block communication within the Kubernetes cluster. Since Kubernetes v1.19, firewalld must be turned off, because it conflicts with the Kubernetes networking plugins.
 
-If you don't feel comfortable doing so you might check suggestions in the [respective issue](https://github.com/rancher/rancher/issues/28840). Some users were successful [creating a separate firewalld zone with a policy of ACCEPT for the Pod CIDR](https://github.com/rancher/rancher/issues/28840#issuecomment-787404822).
+If you don't feel comfortable doing so, you might check suggestions in the [respective issue](https://github.com/rancher/rancher/issues/28840). Some users were successful [creating a separate firewalld zone with a policy of ACCEPT for the Pod CIDR](https://github.com/rancher/rancher/issues/28840#issuecomment-787404822).
 
 If you plan to run Rancher on ARM64, see [Running on ARM64 (Experimental).](../getting-started/installation-and-upgrade/advanced-options/enable-experimental-features/rancher-on-arm64.md)
 
@@ -59,15 +59,11 @@ If you plan to run Rancher on ARM64, see [Running on ARM64 (Experimental).](../g
 
 For the container runtime, RKE should work with any modern Docker version.
 
-Note that the following sysctl setting must be applied:
-
-```
-net.bridge.bridge-nf-call-iptables=1
-```
+For more information see [Installing Docker,](../getting-started/installation-and-upgrade/installation-requirements/install-docker.md)
 
 ### K3s Specific Requirements
 
-For the container runtime, K3s should work with any modern version of Docker or containerd.
+For the container runtime, K3s bundles its own containerd by default. Alternatively, you can configure K3s to use an already installed Docker runtime. For more information on using K3s with Docker see to the [K3s documentation.](https://docs.k3s.io/advanced#using-docker-as-the-container-runtime)
 
 Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
 
@@ -75,17 +71,11 @@ If you are installing Rancher on a K3s cluster with **Raspbian Buster**, follow 
 
 If you are installing Rancher on a K3s cluster with Alpine Linux, follow [these steps](https://rancher.com/docs/k3s/latest/en/advanced/#additional-preparation-for-alpine-linux-setup) for additional setup.
 
-
-
 ### RKE2 Specific Requirements
 
+For the container runtime, RKE2 bundles its own containerd. Docker is not required for RKE2 installs.
+
 For details on which OS versions were tested with RKE2, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
-
-Docker is not required for RKE2 installs.
-
-### Installing Docker
-
-Docker is required for Helm chart installs, and it can be installed by following the steps in the official [Docker documentation.](https://docs.docker.com/) Rancher also provides [scripts](../getting-started/installation-and-upgrade/installation-requirements/install-docker.md) to install Docker with one command.
 
 # Hardware Requirements
 
@@ -150,9 +140,9 @@ Each node in the Kubernetes cluster that Rancher is installed on should run an I
 
 The Ingress should be deployed as DaemonSet to ensure your load balancer can successfully route traffic to all nodes.
 
-For RKE and K3s installations, you don't have to install the Ingress manually because it is installed by default.
+For RKE, RKE2 and K3s installations, you don't have to install the Ingress manually because it is installed by default.
 
-For hosted Kubernetes clusters (EKS, GKE, AKS) and RKE2 Kubernetes installations, you will need to set up the ingress.
+For hosted Kubernetes clusters (EKS, GKE, AKS), you will need to set up the ingress.
 
 - **Amazon EKS:** For details on how to install Rancher on Amazon EKS, including how to install an ingress so that the Rancher server can be accessed, refer to [this page.](../getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md)
 - **AKS:** For details on how to install Rancher with Azure Kubernetes Service, including how to install an ingress so that the Rancher server can be accessed, refer to [this page.](../getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md)


### PR DESCRIPTION
* Clarifies, that you only need Docker for RKE1 installs, not for K3s and RKE2
* Centralizes the Docker installation documentation on the already existing page
* Clarifies that the Dockershim docs do not apply for K3s and RKE2
* Simplifies the requirement to deactivate firewalld and fixes that it also applies to newer Kubernetes versions
* Clarifies UI browser support
* Clarifies Docker support for K3s
* Fixes ingress controller docs: RKE2 already installs an ingress controller as well

Fixes https://github.com/rancher/rancher-docs/issues/254