### PR TITLE
Add a note about re-configuring a previously set up auth provider

### DIFF
--- a/docs/pages-for-subheaders/about-authentication.md
+++ b/docs/pages-for-subheaders/about-authentication.md
@@ -101,3 +101,11 @@ Configuration of external authentication affects how principal users are managed
     ![Sign In External Principal](/img/users-page.png)
 
 6. The external principal and the local principal share the same access rights.
+
+:::note Reconfiguring a previously set up auth provider
+
+If you need to reconfigure or disable then re-enable a provider that had been previously set up, ensure that the user who attempts to do so
+is logged in to Rancher as an external user, not the local admin.
+
+:::
+


### PR DESCRIPTION
A note to warn users about the condition that might lead to the issue https://github.com/rancher/rancher/issues/37948.
2.7 already has the note.