### PR TITLE
Fixed the Kubernetes and Docker sub-headings

### DIFF
--- a/docs/troubleshooting/other-troubleshooting-tips/logging.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/logging.md
@@ -12,8 +12,8 @@ The following log levels are used in Rancher:
 
 ### How to configure a log level
 
-* Kubernetes install
- * Configure debug log level
+#### Kubernetes install
+* Configure debug log level
 ```
 $ KUBECONFIG=./kube_config_cluster.yml
 $ kubectl -n cattle-system get pods -l app=rancher --no-headers -o custom-columns=name:.metadata.name | while read rancherpod; do kubectl -n cattle-system exec $rancherpod -c rancher -- loglevel --set debug; done
@@ -23,7 +23,7 @@ OK
 $ kubectl -n cattle-system logs -l app=rancher -c rancher
 ```
 
- * Configure info log level
+* Configure info log level
 ```
 $ KUBECONFIG=./kube_config_cluster.yml
 $ kubectl -n cattle-system get pods -l app=rancher --no-headers -o custom-columns=name:.metadata.name | while read rancherpod; do kubectl -n cattle-system exec $rancherpod -c rancher -- loglevel --set info; done
@@ -32,15 +32,15 @@ OK
 OK
 ```
 
-* Docker Install
- * Configure debug log level
+#### Docker Install
+* Configure debug log level
 ```
 $ docker exec -ti <container_id> loglevel --set debug
 OK
 $ docker logs -f <container_id>
 ```
 
- * Configure info log level
+* Configure info log level
 ```
 $ docker exec -ti <container_id> loglevel --set info
 OK


### PR DESCRIPTION
The current subheadings are indented wrong. Rather than fixing the indentation, this commit makes them as markdown sub-headings for a better reading experience.