### PR TITLE
rke2-for-rancher.md Kubernetes Versions differ

### DIFF
--- a/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke2-for-rancher.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke2-for-rancher.md
@@ -43,7 +43,7 @@ tls-san:
 After that, you need to run the install command and enable and start rke2:
 
 ```
-curl -sfL https://get.rke2.io | INSTALL_RKE2_CHANNEL=v1.20 sh -
+curl -sfL https://get.rke2.io | sh -
 systemctl enable rke2-server.service
 systemctl start rke2-server.service
 ```


### PR DESCRIPTION
If you install RKE2 on the first node as specified in 'curl -sfL https://get.rke2.io | INSTALL_RKE2_CHANNEL=v1.20 sh -' (line 46) and on the other nodes with 'curl -sfL https://get.rke2.io | sh -' (line 59) you end up with different Versions on the first Node compared to the others.  I think either specifying the Version in both cases, or just doing it without a Version specified should fix this.

My result:
linux15@linux15:~$ kubectl get nodes
NAME      STATUS   ROLES                       AGE   VERSION
linux15   Ready    control-plane,etcd,master   18h   v1.20.15+rke2r2
linux16   Ready    control-plane,etcd,master   18h   v1.24.8+rke2r1