### PR TITLE
Replace references to "docker registry" w "container registry" throughout

### DIFF
--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/infrastructure-private-registry.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/infrastructure-private-registry.md
@@ -84,7 +84,9 @@ Rancher supports air gap installs using a private registry. You must have your o
 
 In a later step, when you set up your K3s Kubernetes cluster, you will create a [private registries configuration file](https://rancher.com/docs/k3s/latest/en/installation/private-registry/) with details from this registry.
 
-If you need help with creating a private registry, please refer to the [official Docker documentation.](https://docs.docker.com/registry/deploying/#run-an-externally-accessible-registry)
+// If you need help with creating a private registry, please refer to the [official Docker documentation.](https://docs.docker.com/registry/deploying/#run-an-externally-accessible-registry)
+
+// Need to update link
 
 </TabItem>
 <TabItem value="RKE">
@@ -151,7 +153,9 @@ Rancher supports air gap installs using a secure private registry. You must have
 
 In a later step, when you set up your RKE Kubernetes cluster, you will create a [private registries configuration file](https://rancher.com/docs/rke/latest/en/config-options/private-registries/) with details from this registry.
 
-If you need help with creating a private registry, please refer to the [official Docker documentation.](https://docs.docker.com/registry/deploying/#run-an-externally-accessible-registry)
+// If you need help with creating a private registry, please refer to the [official Docker documentation.](https://docs.docker.com/registry/deploying/#run-an-externally-accessible-registry)
+
+// Need to update link
 
 </TabItem>
 <TabItem value="Docker">
@@ -176,7 +180,9 @@ For an example of one way to set up Linux nodes, refer to this [tutorial](../../
 
 Rancher supports air gap installs using a private registry on your bastion server. You must have your own private registry or other means of distributing container images to your machines.
 
-If you need help with creating a private registry, please refer to the [official Docker documentation.](https://docs.docker.com/registry/)
+// If you need help with creating a private registry, please refer to the [official Docker documentation.](https://docs.docker.com/registry/)
+
+// Need to update link
 
 </TabItem>
 </Tabs>

--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/infrastructure-private-registry.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/infrastructure-private-registry.md
@@ -2,7 +2,7 @@
 title: '1. Set up Infrastructure and Private Registry'
 ---
 
-In this section, you will provision the underlying infrastructure for your Rancher management server in an air gapped environment. You will also set up the private container registry that must be available to your Rancher node(s).
+In this section, you will provision the underlying infrastructure for your Rancher management server in an air gapped environment. You will also set up the private container image registry that must be available to your Rancher node(s).
 
 An air gapped environment is an environment where the Rancher server is installed offline or behind a firewall.
 
@@ -19,7 +19,7 @@ We recommend setting up the following infrastructure for a high-availability ins
 - **An external database** to store the cluster data. PostgreSQL, MySQL, and etcd are supported.
 - **A load balancer** to direct traffic to the two nodes.
 - **A DNS record** to map a URL to the load balancer. This will become the Rancher server URL, and downstream Kubernetes clusters will need to reach it.
-- **A private container registry** to distribute container images to your machines.
+- **A private image registry** to distribute container images to your machines.
 
 ### 1. Set up Linux Nodes
 
@@ -78,7 +78,7 @@ You will need to specify this hostname in a later step when you install Rancher,
 
 For a how-to guide for setting up a DNS record to route domain traffic to an Amazon ELB load balancer, refer to the [official AWS documentation.](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-elb-load-balancer)
 
-### 5. Set up a Private Container Registry
+### 5. Set up a Private Image Registry
 
 Rancher supports air gap installs using a private registry. You must have your own private registry or other means of distributing container images to your machines.
 
@@ -98,7 +98,7 @@ To install the Rancher management server on a high-availability RKE cluster, we 
 - **Three Linux nodes,** typically virtual machines, in an infrastructure provider such as Amazon's EC2, Google Compute Engine, or vSphere.
 - **A load balancer** to direct front-end traffic to the three nodes.
 - **A DNS record** to map a URL to the load balancer. This will become the Rancher server URL, and downstream Kubernetes clusters will need to reach it.
-- **A private container registry** to distribute container images to your machines.
+- **A private image registry** to distribute container images to your machines.
 
 These nodes must be in the same region/data center. You may place these servers in separate availability zones.
 
@@ -149,7 +149,7 @@ You will need to specify this hostname in a later step when you install Rancher,
 
 For a how-to guide for setting up a DNS record to route domain traffic to an Amazon ELB load balancer, refer to the [official AWS documentation.](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-elb-load-balancer)
 
-### 4. Set up a Private Container Registry
+### 4. Set up a Private Image Registry
 
 Rancher supports air gap installs using a secure private registry. You must have your own private registry or other means of distributing container images to your machines.
 

--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/infrastructure-private-registry.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/infrastructure-private-registry.md
@@ -84,9 +84,11 @@ Rancher supports air gap installs using a private registry. You must have your o
 
 In a later step, when you set up your K3s Kubernetes cluster, you will create a [private registries configuration file](https://rancher.com/docs/k3s/latest/en/installation/private-registry/) with details from this registry.
 
-// If you need help with creating a private registry, please refer to the [official Docker documentation.](https://docs.docker.com/registry/deploying/#run-an-externally-accessible-registry)
+If you need to create a private registry, refer to the documentation pages for your respective runtime:
 
-// Need to update link
+* [Containerd](https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration).
+  * [Nerdctl commands and managed registry services](https://github.com/containerd/nerdctl/blob/main/docs/registry.md). 
+* [Docker](https://docs.docker.com/registry/deploying/).
 
 </TabItem>
 <TabItem value="RKE">
@@ -153,9 +155,11 @@ Rancher supports air gap installs using a secure private registry. You must have
 
 In a later step, when you set up your RKE Kubernetes cluster, you will create a [private registries configuration file](https://rancher.com/docs/rke/latest/en/config-options/private-registries/) with details from this registry.
 
-// If you need help with creating a private registry, please refer to the [official Docker documentation.](https://docs.docker.com/registry/deploying/#run-an-externally-accessible-registry)
+If you need to create a private registry, refer to the documentation pages for your respective runtime:
 
-// Need to update link
+* [Containerd](https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration).
+  * [Nerdctl commands and managed registry services](https://github.com/containerd/nerdctl/blob/main/docs/registry.md). 
+* [Docker](https://docs.docker.com/registry/deploying/).
 
 </TabItem>
 <TabItem value="Docker">
@@ -180,9 +184,7 @@ For an example of one way to set up Linux nodes, refer to this [tutorial](../../
 
 Rancher supports air gap installs using a private registry on your bastion server. You must have your own private registry or other means of distributing container images to your machines.
 
-// If you need help with creating a private registry, please refer to the [official Docker documentation.](https://docs.docker.com/registry/)
-
-// Need to update link
+If you need help with creating a private registry, please refer to the [official Docker documentation.](https://docs.docker.com/registry/).
 
 </TabItem>
 </Tabs>

--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/infrastructure-private-registry.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/infrastructure-private-registry.md
@@ -2,7 +2,7 @@
 title: '1. Set up Infrastructure and Private Registry'
 ---
 
-In this section, you will provision the underlying infrastructure for your Rancher management server in an air gapped environment. You will also set up the private Docker registry that must be available to your Rancher node(s).
+In this section, you will provision the underlying infrastructure for your Rancher management server in an air gapped environment. You will also set up the private container registry that must be available to your Rancher node(s).
 
 An air gapped environment is an environment where the Rancher server is installed offline or behind a firewall.
 
@@ -19,7 +19,7 @@ We recommend setting up the following infrastructure for a high-availability ins
 - **An external database** to store the cluster data. PostgreSQL, MySQL, and etcd are supported.
 - **A load balancer** to direct traffic to the two nodes.
 - **A DNS record** to map a URL to the load balancer. This will become the Rancher server URL, and downstream Kubernetes clusters will need to reach it.
-- **A private Docker registry** to distribute Docker images to your machines.
+- **A private container registry** to distribute container images to your machines.
 
 ### 1. Set up Linux Nodes
 
@@ -78,9 +78,9 @@ You will need to specify this hostname in a later step when you install Rancher,
 
 For a how-to guide for setting up a DNS record to route domain traffic to an Amazon ELB load balancer, refer to the [official AWS documentation.](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-elb-load-balancer)
 
-### 5. Set up a Private Docker Registry
+### 5. Set up a Private Container Registry
 
-Rancher supports air gap installs using a private registry. You must have your own private registry or other means of distributing Docker images to your machines.
+Rancher supports air gap installs using a private registry. You must have your own private registry or other means of distributing container images to your machines.
 
 In a later step, when you set up your K3s Kubernetes cluster, you will create a [private registries configuration file](https://rancher.com/docs/k3s/latest/en/installation/private-registry/) with details from this registry.
 
@@ -94,7 +94,7 @@ To install the Rancher management server on a high-availability RKE cluster, we 
 - **Three Linux nodes,** typically virtual machines, in an infrastructure provider such as Amazon's EC2, Google Compute Engine, or vSphere.
 - **A load balancer** to direct front-end traffic to the three nodes.
 - **A DNS record** to map a URL to the load balancer. This will become the Rancher server URL, and downstream Kubernetes clusters will need to reach it.
-- **A private Docker registry** to distribute Docker images to your machines.
+- **A private container registry** to distribute container images to your machines.
 
 These nodes must be in the same region/data center. You may place these servers in separate availability zones.
 
@@ -145,9 +145,9 @@ You will need to specify this hostname in a later step when you install Rancher,
 
 For a how-to guide for setting up a DNS record to route domain traffic to an Amazon ELB load balancer, refer to the [official AWS documentation.](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-elb-load-balancer)
 
-### 4. Set up a Private Docker Registry
+### 4. Set up a Private Container Registry
 
-Rancher supports air gap installs using a secure Docker private registry. You must have your own private registry or other means of distributing Docker images to your machines.
+Rancher supports air gap installs using a secure private registry. You must have your own private registry or other means of distributing container images to your machines.
 
 In a later step, when you set up your RKE Kubernetes cluster, you will create a [private registries configuration file](https://rancher.com/docs/rke/latest/en/config-options/private-registries/) with details from this registry.
 
@@ -168,13 +168,13 @@ If you need help with creating a private registry, please refer to the [official
 
 This host will be disconnected from the Internet, but needs to be able to connect to your private registry.
 
-Make sure that your node fulfills the general installation requirements for [OS, Docker, hardware, and networking.](../../../../pages-for-subheaders/installation-requirements.md)
+Make sure that your node fulfills the general installation requirements for [OS, containers, hardware, and networking.](../../../../pages-for-subheaders/installation-requirements.md)
 
 For an example of one way to set up Linux nodes, refer to this [tutorial](../../../../how-to-guides/new-user-guides/infrastructure-setup/nodes-in-amazon-ec2.md) for setting up nodes as instances in Amazon EC2.
 
 ### 2. Set up a Private Docker Registry
 
-Rancher supports air gap installs using a Docker private registry on your bastion server. You must have your own private registry or other means of distributing Docker images to your machines.
+Rancher supports air gap installs using a private registry on your bastion server. You must have your own private registry or other means of distributing container images to your machines.
 
 If you need help with creating a private registry, please refer to the [official Docker documentation.](https://docs.docker.com/registry/)
 

--- a/docs/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
+++ b/docs/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
@@ -78,7 +78,7 @@ If you have an air gap setup, you might not be able to get the automatic periodi
 
 To sync Rancher with a local mirror of the RKE metadata, an administrator would configure the `rke-metadata-config` settings to point to the mirror. For details, refer to [Configuring the Metadata Synchronization.](#configuring-the-metadata-synchronization)
 
-After new Kubernetes versions are loaded into the Rancher setup, additional steps would be required in order to use them for launching clusters. Rancher needs access to updated system images. While the metadata settings can only be changed by administrators, any user can download the Rancher system images and prepare a private Docker registry for them.
+After new Kubernetes versions are loaded into the Rancher setup, additional steps would be required in order to use them for launching clusters. Rancher needs access to updated system images. While the metadata settings can only be changed by administrators, any user can download the Rancher system images and prepare a private container registry for them.
 
 1. To download the system images for the private registry, click the Rancher server version at the bottom left corner of the Rancher UI.
 1. Download the OS specific image lists for Linux or Windows.

--- a/docs/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
+++ b/docs/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
@@ -78,7 +78,7 @@ If you have an air gap setup, you might not be able to get the automatic periodi
 
 To sync Rancher with a local mirror of the RKE metadata, an administrator would configure the `rke-metadata-config` settings to point to the mirror. For details, refer to [Configuring the Metadata Synchronization.](#configuring-the-metadata-synchronization)
 
-After new Kubernetes versions are loaded into the Rancher setup, additional steps would be required in order to use them for launching clusters. Rancher needs access to updated system images. While the metadata settings can only be changed by administrators, any user can download the Rancher system images and prepare a private container registry for them.
+After new Kubernetes versions are loaded into the Rancher setup, additional steps would be required in order to use them for launching clusters. Rancher needs access to updated system images. While the metadata settings can only be changed by administrators, any user can download the Rancher system images and prepare a private container image registry for them.
 
 1. To download the system images for the private registry, click the Rancher server version at the bottom left corner of the Rancher UI.
 1. Download the OS specific image lists for Linux or Windows.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
@@ -2,7 +2,7 @@
 title: Configuring a Global Default Private Registry
 ---
 
-You might want to use a private container registry to share your custom base images within your organization. With a private registry, you can keep a private, consistent, and centralized source of truth for the container images that are used in your clusters.
+You might want to use a private container image registry to share your custom base images within your organization. With a private registry, you can keep a private, consistent, and centralized source of truth for the container images that are used in your clusters.
 
 There are two main ways to set up private registries in Rancher: by setting up the global default registry through the **Settings** tab in the global view, and by setting up a private registry in the advanced options in the cluster-level settings. The global default registry is intended to be used for air-gapped setups, for registries that do not require credentials. The cluster-level private registry is intended to be used in all setups in which the private registry requires credentials.
 

--- a/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
@@ -1,15 +1,15 @@
 ---
-title: Kubernetes Registry and Docker Registry
-description: Learn about the Docker registry and Kubernetes registry, their use cases and how to use a private registry with the Rancher UI
+title: Kubernetes Registry and Container Registry
+description: Learn about the Container registry and Kubernetes registry, their use cases and how to use a private registry with the Rancher UI
 ---
-Registries are Kubernetes secrets containing credentials used to authenticate with [private Docker registries](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+Registries are Kubernetes secrets containing credentials used to authenticate with [private container registries](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 
-The word "registry" can mean two things, depending on whether it is used to refer to a Docker or Kubernetes registry:
+The word "registry" can mean two things, depending on whether it is used to refer to a container or Kubernetes registry:
 
-- A **Docker registry** contains Docker images that you can pull in order to use them in your deployment. The registry is a stateless, scalable server side application that stores and lets you distribute Docker images.
-- The **Kubernetes registry** is an image pull secret that your deployment uses to authenticate with a Docker registry.
+- A **Container registry** (formerly "Docker registry") contains container images that you can pull and deploy. The registry is a stateless, scalable server side application that stores and lets you distribute container images.
+- The **Kubernetes registry** is an image pull secret that your deployment uses to authenticate with a container registry.
 
-Deployments use the Kubernetes registry secret to authenticate with a private Docker registry and then pull a Docker image hosted on it.
+Deployments use the Kubernetes registry secret to authenticate with a private container registry and then pull a container image hosted on it.
 
 Currently, deployments pull the private registry credentials automatically only if the workload is created in the Rancher UI and not when it is created via kubectl.
 
@@ -104,7 +104,7 @@ To deploy a workload with an image from your private registry,
 1. In the **Container Image** field, enter the URL of the path to the image in your private registry. For example, if your private registry is on Quay.io, you could use `quay.io/<Quay profile name>/<Image name>`.
 1. Click **Create**.
 
-**Result:** Your deployment should launch, authenticate using the private registry credentials you added in the Rancher UI, and pull the Docker image that you specified.
+**Result:** Your deployment should launch, authenticate using the private registry credentials you added in the Rancher UI, and pull the container image that you specified.
 
 ### Using the Private Registry with kubectl
 

--- a/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
@@ -150,15 +150,11 @@ kubectl create secret docker-registry testquay \
     --docker-password=<password>
 ```
 
-Need generic instructions
-
 To see how the secret is stored in Kubernetes, you can use this command:
 
 ```
 kubectl get secret testquay --output="jsonpath={.data.\.dockerconfigjson}" | base64 --decode
 ```
-
-Need generic instructions
 
 The result looks like this:
 

--- a/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
@@ -17,7 +17,8 @@ Currently, deployments pull the private registry credentials automatically only 
 
 :::note Prerequisite:
 
-You must have a [private registry](https://docs.docker.com/registry/deploying/) available to use.
+// You must have a [private registry](https://docs.docker.com/registry/deploying/) available to use.
+// Need appropriate replacement link
 
 :::
 
@@ -48,7 +49,8 @@ You must have a [private registry](https://docs.docker.com/registry/deploying/) 
 
 :::note Prerequisites:
 
-You must have a [private registry](https://docs.docker.com/registry/deploying/) available to use.
+// You must have a [private registry](https://docs.docker.com/registry/deploying/) available to use.
+// Need appropriate replacement link
 
 :::
 
@@ -131,18 +133,22 @@ In this example, the secret named `testquay` is in the default namespace.
 
 You can use `kubectl` to create the secret with the private registry credentials. This command creates the secret named `testquay`:
 
-```
-kubectl create secret docker-registry testquay \
-    --docker-server=quay.io \
-    --docker-username=<Profile name> \
-    --docker-password=<password>
-```
+// ```
+// kubectl create secret docker-registry testquay \
+//     --docker-server=quay.io \
+//     --docker-username=<Profile name> \
+//     --docker-password=<password>
+// ```
+
+// Need generic instructions
 
 To see how the secret is stored in Kubernetes, you can use this command:
 
-```
-kubectl get secret testquay --output="jsonpath={.data.\.dockerconfigjson}" | base64 --decode
-```
+// ```
+// kubectl get secret testquay --output="jsonpath={.data.\.dockerconfigjson}" | base64 --decode
+// ```
+
+// Need generic instructions
 
 The result looks like this:
 

--- a/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
@@ -17,8 +17,13 @@ Currently, deployments pull the private registry credentials automatically only 
 
 :::note Prerequisite:
 
-// You must have a [private registry](https://docs.docker.com/registry/deploying/) available to use.
-// Need appropriate replacement link
+You must have an available private registry already deployed.
+
+If you need to create a private registry, refer to the documentation pages for your respective runtime:
+
+* [Containerd](https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration).
+  * [Nerdctl commands and managed registry services](https://github.com/containerd/nerdctl/blob/main/docs/registry.md). 
+* [Docker](https://docs.docker.com/registry/deploying/).
 
 :::
 
@@ -49,8 +54,13 @@ Currently, deployments pull the private registry credentials automatically only 
 
 :::note Prerequisites:
 
-// You must have a [private registry](https://docs.docker.com/registry/deploying/) available to use.
-// Need appropriate replacement link
+You must have an available private registry already deployed.
+
+If you need to create a private registry, refer to the documentation pages for your respective runtime:
+
+* [Containerd](https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration).
+  * [Nerdctl commands and managed registry services](https://github.com/containerd/nerdctl/blob/main/docs/registry.md). 
+* [Docker](https://docs.docker.com/registry/deploying/).
 
 :::
 

--- a/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
@@ -1,15 +1,15 @@
 ---
-title: Kubernetes Registry and Container Registry
-description: Learn about the Container registry and Kubernetes registry, their use cases and how to use a private registry with the Rancher UI
+title: Kubernetes Registry and Container Image Registry
+description: Learn about the container image registry and Kubernetes registry, their use cases, and how to use a private registry with the Rancher UI
 ---
 Registries are Kubernetes secrets containing credentials used to authenticate with [private container registries](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 
 The word "registry" can mean two things, depending on whether it is used to refer to a container or Kubernetes registry:
 
-- A **Container registry** (formerly "Docker registry") contains container images that you can pull and deploy. The registry is a stateless, scalable server side application that stores and lets you distribute container images.
-- The **Kubernetes registry** is an image pull secret that your deployment uses to authenticate with a container registry.
+- A **Container image registry** (formerly "Docker registry") contains container images that you can pull and deploy. The registry is a stateless, scalable server side application that stores and lets you distribute container images.
+- The **Kubernetes registry** is an image pull secret that your deployment uses to authenticate with an image registry.
 
-Deployments use the Kubernetes registry secret to authenticate with a private container registry and then pull a container image hosted on it.
+Deployments use the Kubernetes registry secret to authenticate with a private image registry and then pull a container image hosted on it.
 
 Currently, deployments pull the private registry credentials automatically only if the workload is created in the Rancher UI and not when it is created via kubectl.
 
@@ -143,22 +143,22 @@ In this example, the secret named `testquay` is in the default namespace.
 
 You can use `kubectl` to create the secret with the private registry credentials. This command creates the secret named `testquay`:
 
-// ```
-// kubectl create secret docker-registry testquay \
-//     --docker-server=quay.io \
-//     --docker-username=<Profile name> \
-//     --docker-password=<password>
-// ```
+```
+kubectl create secret docker-registry testquay \
+    --docker-server=quay.io \
+    --docker-username=<Profile name> \
+    --docker-password=<password>
+```
 
-// Need generic instructions
+Need generic instructions
 
 To see how the secret is stored in Kubernetes, you can use this command:
 
-// ```
-// kubectl get secret testquay --output="jsonpath={.data.\.dockerconfigjson}" | base64 --decode
-// ```
+```
+kubectl get secret testquay --output="jsonpath={.data.\.dockerconfigjson}" | base64 --decode
+```
 
-// Need generic instructions
+Need generic instructions
 
 The result looks like this:
 

--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/rke1-vs-rke2-differences.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/rke1-vs-rke2-differences.md
@@ -8,7 +8,7 @@ RKE1 and RKE2 have several slight behavioral differences to note, and this page 
 
 ### Control Plane Components
 
-RKE1 uses Docker for deploying and managing control plane components, and it also uses Docker as the container runtime for Kubernetes. By contrast, RKE2 launches control plane components as static pods that are managed by the kubelet. RKE2's container runtime is containerd, which allows things such as container registry mirroring (RKE1 with Docker does not).
+RKE1 uses Docker for deploying and managing control plane components, and it also uses Docker as the container runtime for Kubernetes. By contrast, RKE2 launches control plane components as static pods that are managed by the kubelet. RKE2's container runtime is containerd, which allows things such as mirroring a container image registry. RKE1 with Docker does not allow mirroring.
 
 ### Cluster API
 

--- a/docs/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster.md
+++ b/docs/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster.md
@@ -309,7 +309,7 @@ Now that Rancher is deployed, see [Adding TLS Secrets](../getting-started/instal
 The Rancher chart configuration has many options for customizing the installation to suit your specific environment. Here are some common advanced scenarios.
 
 - [HTTP Proxy](../getting-started/installation-and-upgrade/installation-references/helm-chart-options.md#http-proxy)
-- [Private container image Registry](../getting-started/installation-and-upgrade/installation-references/helm-chart-options.md#private-registry-and-air-gap-installs)
+- [Private Container Image Registry](../getting-started/installation-and-upgrade/installation-references/helm-chart-options.md#private-registry-and-air-gap-installs)
 - [TLS Termination on an External Load Balancer](../getting-started/installation-and-upgrade/installation-references/helm-chart-options.md#external-tls-termination)
 
 See the [Chart Options](../getting-started/installation-and-upgrade/installation-references/helm-chart-options.md) for the full list of options.

--- a/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/amazon-ec2.md
+++ b/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/amazon-ec2.md
@@ -46,4 +46,4 @@ If you need to pass an **IAM Instance Profile Name** (not ARN), for example, whe
 
 ### Engine Options
 
-In the **Engine Options** section of the node template, you can configure the container daemon. You may want to specify the container version or a container registry mirror.
+In the **Engine Options** section of the node template, you can configure the container daemon. You may want to specify the container version or a container image registry mirror.

--- a/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/amazon-ec2.md
+++ b/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/amazon-ec2.md
@@ -46,4 +46,4 @@ If you need to pass an **IAM Instance Profile Name** (not ARN), for example, whe
 
 ### Engine Options
 
-In the **Engine Options** section of the node template, you can configure the Docker daemon. You may want to specify the docker version or a Docker registry mirror.
+In the **Engine Options** section of the node template, you can configure the container daemon. You may want to specify the container version or a container registry mirror.

--- a/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/azure.md
+++ b/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/azure.md
@@ -16,9 +16,11 @@ If using a VNet in a different Resource Group than the VMs, the VNet name should
 
 :::
 
-If you use Docker, the [Docker daemon](https://docs.docker.com/engine/docker-overview/#the-docker-daemon) configuration options include:
+// If you use Docker, the [Docker daemon](https://docs.docker.com/engine/docker-overview/#the-docker-daemon) configuration options include:
 
-- **Labels:** For information on labels, refer to the [Docker object label documentation.](https://docs.docker.com/config/labels-custom-metadata/)
-- **Docker Engine Install URL:** Determines what Docker version will be installed on the instance.
-- **Registry mirrors:** Docker Registry mirror to be used by the Docker daemon
-- **Other advanced options:** Refer to the [Docker daemon option reference](https://docs.docker.com/engine/reference/commandline/dockerd/)
+// - **Labels:** For information on labels, refer to the [Docker object label documentation.](https://docs.docker.com/config/labels-custom-metadata/)
+// - **Docker Engine Install URL:** Determines what Docker version will be installed on the instance.
+// - **Registry mirrors:** Docker Registry mirror to be used by the Docker daemon
+// - **Other advanced options:** Refer to the [Docker daemon option reference](https://docs.docker.com/engine/reference/commandline/dockerd/)
+
+// Do we update this section or keep it as-is re: references to Docker vs being more generic?

--- a/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/azure.md
+++ b/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/azure.md
@@ -16,11 +16,9 @@ If using a VNet in a different Resource Group than the VMs, the VNet name should
 
 :::
 
-// If you use Docker, the [Docker daemon](https://docs.docker.com/engine/docker-overview/#the-docker-daemon) configuration options include:
+If you use Docker, the [Docker daemon](https://docs.docker.com/engine/docker-overview/#the-docker-daemon) configuration options include:
 
-// - **Labels:** For information on labels, refer to the [Docker object label documentation.](https://docs.docker.com/config/labels-custom-metadata/)
-// - **Docker Engine Install URL:** Determines what Docker version will be installed on the instance.
-// - **Registry mirrors:** Docker Registry mirror to be used by the Docker daemon
-// - **Other advanced options:** Refer to the [Docker daemon option reference](https://docs.docker.com/engine/reference/commandline/dockerd/)
-
-// Do we update this section or keep it as-is re: references to Docker vs being more generic?
+- **Labels:** For information on labels, refer to the [Docker object label documentation.](https://docs.docker.com/config/labels-custom-metadata/).
+- **Docker Engine Install URL:** Determines what Docker version will be installed on the instance.
+- **Registry mirrors:** Docker Registry mirror to be used by the Docker daemon.
+- **Other advanced options:** Refer to the [Docker daemon option reference](https://docs.docker.com/engine/reference/commandline/dockerd/).

--- a/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/azure.md
+++ b/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/azure.md
@@ -16,7 +16,7 @@ If using a VNet in a different Resource Group than the VMs, the VNet name should
 
 :::
 
-The [Docker daemon](https://docs.docker.com/engine/docker-overview/#the-docker-daemon) configuration options include:
+If you use Docker, the [Docker daemon](https://docs.docker.com/engine/docker-overview/#the-docker-daemon) configuration options include:
 
 - **Labels:** For information on labels, refer to the [Docker object label documentation.](https://docs.docker.com/config/labels-custom-metadata/)
 - **Docker Engine Install URL:** Determines what Docker version will be installed on the instance.

--- a/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/digitalocean.md
+++ b/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/digitalocean.md
@@ -10,7 +10,7 @@ The **Droplet Options** provision your cluster's geographical region and specifi
 
 ### Docker Daemon
 
-The [Docker daemon](https://docs.docker.com/engine/docker-overview/#the-docker-daemon) configuration options include:
+If you use Docker, the [Docker daemon](https://docs.docker.com/engine/docker-overview/#the-docker-daemon) configuration options include:
 
 - **Labels:** For information on labels, refer to the [Docker object label documentation.](https://docs.docker.com/config/labels-custom-metadata/)
 - **Docker Engine Install URL:** Determines what Docker version will be installed on the instance.

--- a/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/digitalocean.md
+++ b/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/digitalocean.md
@@ -8,13 +8,11 @@ Account access information is stored as a cloud credential. Cloud credentials ar
 
 The **Droplet Options** provision your cluster's geographical region and specifications.
 
-// ### Docker Daemon
+### Docker Daemon
 
-// If you use Docker, the [Docker daemon](https://docs.docker.com/engine/docker-overview/#the-docker-daemon) configuration options include:
+If you use Docker, the [Docker daemon](https://docs.docker.com/engine/docker-overview/#the-docker-daemon) configuration options include:
 
-// - **Labels:** For information on labels, refer to the [Docker object label documentation.](https://docs.docker.com/config/labels-custom-metadata/)
-// - **Docker Engine Install URL:** Determines what Docker version will be installed on the instance.
-// - **Registry mirrors:** Docker Registry mirror to be used by the Docker daemon
-// - **Other advanced options:** Refer to the [Docker daemon option reference](https://docs.docker.com/engine/reference/commandline/dockerd/)
-
-// Do we update this section or keep it as-is re: references to Docker vs being more generic?
+- **Labels:** For information on labels, refer to the [Docker object label documentation.](https://docs.docker.com/config/labels-custom-metadata/)
+- **Docker Engine Install URL:** Determines what Docker version will be installed on the instance.
+- **Registry mirrors:** Docker Registry mirror to be used by the Docker daemon
+- **Other advanced options:** Refer to the [Docker daemon option reference](https://docs.docker.com/engine/reference/commandline/dockerd/)

--- a/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/digitalocean.md
+++ b/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/digitalocean.md
@@ -8,11 +8,13 @@ Account access information is stored as a cloud credential. Cloud credentials ar
 
 The **Droplet Options** provision your cluster's geographical region and specifications.
 
-### Docker Daemon
+// ### Docker Daemon
 
-If you use Docker, the [Docker daemon](https://docs.docker.com/engine/docker-overview/#the-docker-daemon) configuration options include:
+// If you use Docker, the [Docker daemon](https://docs.docker.com/engine/docker-overview/#the-docker-daemon) configuration options include:
 
-- **Labels:** For information on labels, refer to the [Docker object label documentation.](https://docs.docker.com/config/labels-custom-metadata/)
-- **Docker Engine Install URL:** Determines what Docker version will be installed on the instance.
-- **Registry mirrors:** Docker Registry mirror to be used by the Docker daemon
-- **Other advanced options:** Refer to the [Docker daemon option reference](https://docs.docker.com/engine/reference/commandline/dockerd/)
+// - **Labels:** For information on labels, refer to the [Docker object label documentation.](https://docs.docker.com/config/labels-custom-metadata/)
+// - **Docker Engine Install URL:** Determines what Docker version will be installed on the instance.
+// - **Registry mirrors:** Docker Registry mirror to be used by the Docker daemon
+// - **Other advanced options:** Refer to the [Docker daemon option reference](https://docs.docker.com/engine/reference/commandline/dockerd/)
+
+// Do we update this section or keep it as-is re: references to Docker vs being more generic?

--- a/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/digitalocean.md
+++ b/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/digitalocean.md
@@ -15,4 +15,4 @@ If you use Docker, the [Docker daemon](https://docs.docker.com/engine/docker-ove
 - **Labels:** For information on labels, refer to the [Docker object label documentation.](https://docs.docker.com/config/labels-custom-metadata/)
 - **Docker Engine Install URL:** Determines what Docker version will be installed on the instance.
 - **Registry mirrors:** Docker Registry mirror to be used by the Docker daemon
-- **Other advanced options:** Refer to the [Docker daemon option reference](https://docs.docker.com/engine/reference/commandline/dockerd/)
+- **Other advanced options:** Refer to the [Docker daemon option reference](https://docs.docker.com/engine/reference/commandline/dockerd/).


### PR DESCRIPTION
Addressing #229 

I made some simple changes.

I also marked lines with // where I need more help or technical review.

We have several links to the Docker docs, some docker-specific commands, and two Docker-specific subsections, all of which were marked.