### PR TITLE
Remove outdated reference to members tab

### DIFF
--- a/docs/how-to-guides/new-user-guides/add-users-to-projects.md
+++ b/docs/how-to-guides/new-user-guides/add-users-to-projects.md
@@ -22,9 +22,8 @@ Following project creation, you can add users as project members so that they ca
 
 1. In the upper left corner, click **☰ > Cluster Management**.
 1. On the **Clusters** page, go to the cluster where you want to add members to a project and click **Explore**.
-1. Click **Cluster > Projects/Namespaces**.
-1. Go to the project where you want to add members and click **⋮ > Edit Config**.
-1. In the **Members** tab, click **Add**.
+1. In the sidebar, click **Cluster Members**.
+1. On the **Cluster Members** page, click **Add**.
 1. Search for the user or group that you want to add to the project.
 
     If external authentication is configured:

--- a/docs/how-to-guides/new-user-guides/add-users-to-projects.md
+++ b/docs/how-to-guides/new-user-guides/add-users-to-projects.md
@@ -22,8 +22,9 @@ Following project creation, you can add users as project members so that they ca
 
 1. In the upper left corner, click **☰ > Cluster Management**.
 1. On the **Clusters** page, go to the cluster where you want to add members to a project and click **Explore**.
-1. In the sidebar, click **Cluster Members**.
-1. On the **Cluster Members** page, click **Add**.
+1. Click **Cluster > Projects/Namespaces**.
+1. Go to the project where you want to add members. Next to the **Create Namespace** button above the project name, click **☰**. Select **Edit Config**.
+1. In the **Members** tab, click **Add**.
 1. Search for the user or group that you want to add to the project.
 
     If external authentication is configured:

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/add-users-to-projects.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/add-users-to-projects.md
@@ -22,9 +22,8 @@ Following project creation, you can add users as project members so that they ca
 
 1. In the upper left corner, click **☰ > Cluster Management**.
 1. On the **Clusters** page, go to the cluster where you want to add members to a project and click **Explore**.
-1. Click **Cluster > Projects/Namespaces**.
-1. Go to the project where you want to add members and click **⋮ > Edit Config**.
-1. In the **Members** tab, click **Add**.
+1. In the sidebar, click **Cluster Members**.
+1. On the **Cluster Members** page, click **Add**.
 1. Search for the user or group that you want to add to the project.
 
     If external authentication is configured:

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/add-users-to-projects.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/add-users-to-projects.md
@@ -22,8 +22,9 @@ Following project creation, you can add users as project members so that they ca
 
 1. In the upper left corner, click **☰ > Cluster Management**.
 1. On the **Clusters** page, go to the cluster where you want to add members to a project and click **Explore**.
-1. In the sidebar, click **Cluster Members**.
-1. On the **Cluster Members** page, click **Add**.
+1. Click **Cluster > Projects/Namespaces**.
+1. Go to the project where you want to add members. Next to the **Create Namespace** button above the project name, click **☰**. Select **Edit Config**.
+1. In the **Members** tab, click **Add**.
 1. Search for the user or group that you want to add to the project.
 
     If external authentication is configured:


### PR DESCRIPTION
Addressing #57

I updated the latest page and the one pertaining to 2.6.

Older versions of the page (2.5, and 2.0 - 2.4) were left alone.