### PR TITLE
Kubernetes >= v1.21, hostNetwork needs to be set to true on Ingress for TCP and UDP Services to work

### DIFF
--- a/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/ingress-configuration.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/ingress-configuration.md
@@ -5,9 +5,9 @@ description: Ingress configuration
 
 ### NGINX Ingress controller changes in Kubernetes v1.21
 
-For Kubernetes v1.21 and up, the NGINX Ingress controller no longer runs in hostNetwork. It instead uses hostPorts for port 80 and port 443. This was done so that you can configure the admission webhook to be accessible only through the ClusterIP. This makes the webhook inaccessible from outside the cluster.
+For Kubernetes v1.21 and up, the NGINX Ingress controller no longer runs in hostNetwork by default. It instead uses hostPorts for port 80 and port 443, so you can configure the admission webhook to be accessible only through the ClusterIP. This ensures that the webhook is only accessible from within the cluster.
 
-Because of this change, the controller no longer has `hostNetwork` set to `true` by default. However, you must set `hostNetwork` to `true` on the controller for TCP- and UDP-based Services to work.
+Because of this change to the controller, the default behavior no longer sets `hostNetwork` to `true`. However, you must set `hostNetwork` to `true` for TCP- and UDP-based Services to work.
 
 ## Ingress Rule Configuration
 
@@ -41,6 +41,6 @@ You must have an SSL certificate that Ingress can use to encrypt and decrypt com
 
 ### Labels and Annotations
 
-Add [Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) and/or [Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) to provide metadata for your ingress.
+Add [Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) and/or [Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) to provide metadata for your Ingress controller.
 
 For a list of annotations available for use, see the [Nginx Ingress Controller Documentation](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/).

--- a/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/ingress-configuration.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/ingress-configuration.md
@@ -3,20 +3,15 @@ title: Ingress Configuration
 description: Ingress configuration
 ---
 
-### NGINX Ingress controller changes in Kubernetes v1.21
+:::note
 
 For Kubernetes v1.21 and up, the NGINX Ingress controller no longer runs in hostNetwork by default. It instead uses hostPorts for port 80 and port 443, so you can configure the admission webhook to be accessible only through the ClusterIP. This ensures that the webhook is only accessible from within the cluster.
 
 Because of this change to the controller, the default behavior no longer sets `hostNetwork` to `true`. However, you must set `hostNetwork` to `true` for TCP- and UDP-based Services to work.
 
-## Ingress Rule Configuration
+:::note
 
-- [Specify a hostname to use](#specify-a-hostname-to-use)
-- [Use as the default backend](#use-as-the-default-backend)
-- [Certificates](#certificates)
-- [Labels and Annotations](#labels-and-annotations)
-
-### Specify a hostname to use
+## Specify a hostname to use
 
 If you use this option, Ingress routes requests for a hostname to the service or workload that you specify.
 
@@ -25,7 +20,7 @@ If you use this option, Ingress routes requests for a hostname to the service or
 1. **Optional:** If you want to specify a workload or service when a request is sent to a particular hostname path, add a **Path** for the target. For example, if you want requests for `www.mysite.com/contact-us` to be sent to a different service than `www.mysite.com`, enter `/contact-us` in the **Path**. The first rule that you create does not typically include a path.
 1. Enter the **Port** number that each target operates on.
 
-### Certificates
+## Certificates
 
 :::note
 
@@ -39,7 +34,7 @@ You must have an SSL certificate that Ingress can use to encrypt and decrypt com
 1. Enter the host using encrypted communication.
 1. To add additional hosts that use the certificate, click **Add Hosts**.
 
-### Labels and Annotations
+## Labels and Annotations
 
 Add [Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) and/or [Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) to provide metadata for your Ingress controller.
 

--- a/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/ingress-configuration.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/ingress-configuration.md
@@ -5,7 +5,9 @@ description: Ingress configuration
 
 ### NGINX Ingress controller changes in Kubernetes v1.21
 
-For Kubernetes v1.21 and up, the NGINX Ingress controller no longer runs in hostNetwork but uses hostPorts for port 80 and port 443. This was done so the admission webhook can be configured to be accessed using ClusterIP so it can only be reached inside the cluster.
+For Kubernetes v1.21 and up, the NGINX Ingress controller no longer runs in hostNetwork. It instead uses hostPorts for port 80 and port 443. This was done so that you can configure the admission webhook to be accessible only through the ClusterIP. This makes the webhook inaccessible from outside the cluster.
+
+Because of this change, the controller no longer has `hostNetwork` set to `true` by default. However, you must set `hostNetwork` to `true` on the controller for TCP- and UDP-based Services to work.
 
 ## Ingress Rule Configuration
 
@@ -16,21 +18,22 @@ For Kubernetes v1.21 and up, the NGINX Ingress controller no longer runs in host
 
 ### Specify a hostname to use
 
-If you use this option, ingress routes requests for a hostname to the service or workload that you specify.
+If you use this option, Ingress routes requests for a hostname to the service or workload that you specify.
 
-1. Enter the **Request Host** that your ingress will handle request forwarding for. For example, `www.mysite.com`.
+1. Enter the **Request Host** that your Ingress controller will handle request forwarding for. For example, `www.mysite.com`.
 1. Add a **Target Service**.
-1. **Optional:** If you want specify a workload or service when a request is sent to a particular hostname path, add a **Path** for the target. For example, if you want requests for `www.mysite.com/contact-us` to be sent to a different service than `www.mysite.com`, enter `/contact-us` in the **Path** field. Typically, the first rule that you create does not include a path.
+1. **Optional:** If you want to specify a workload or service when a request is sent to a particular hostname path, add a **Path** for the target. For example, if you want requests for `www.mysite.com/contact-us` to be sent to a different service than `www.mysite.com`, enter `/contact-us` in the **Path**. The first rule that you create does not typically include a path.
 1. Enter the **Port** number that each target operates on.
+
 ### Certificates
 
 :::note
 
-You must have an SSL certificate that the ingress can use to encrypt/decrypt communications. For more information see [Adding SSL Certificates](../encrypt-http-communication.md).
+You must have an SSL certificate that Ingress can use to encrypt and decrypt communications. For more information, see [Adding SSL Certificates](../encrypt-http-communication.md).
 
 :::
 
-1. When creating an ingress, click the **Certificates** tab.
+1. To create an Ingress controller, click the **Certificates** tab.
 1. Click **Add Certificate**.
 1. Select a **Certificate - Secret Name** from the drop-down list.
 1. Enter the host using encrypted communication.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/ingress-configuration.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/ingress-configuration.md
@@ -3,44 +3,46 @@ title: Ingress Configuration
 description: Ingress configuration
 ---
 
-### NGINX Ingress controller changes in Kubernetes v1.21
+:::note
 
 For Kubernetes v1.21 and up, the NGINX Ingress controller no longer runs in hostNetwork by default. It instead uses hostPorts for port 80 and port 443, so you can configure the admission webhook to be accessible only through the ClusterIP. This ensures that the webhook is only accessible from within the cluster.
 
 Because of this change to the controller, the default behavior no longer sets `hostNetwork` to `true`. However, you must set `hostNetwork` to `true` for TCP- and UDP-based Services to work.
 
-## Ingress Rule Configuration
+:::note
+
 
 - [Specify a hostname to use](#specify-a-hostname-to-use)
 - [Use as the default backend](#use-as-the-default-backend)
 - [Certificates](#certificates)
 - [Labels and Annotations](#labels-and-annotations)
 
-### Specify a hostname to use
+## Specify a hostname to use
 
-If you use this option, ingress routes requests for a hostname to the service or workload that you specify.
+If you use this option, Ingress routes requests for a hostname to the service or workload that you specify.
 
-1. Enter the **Request Host** that your ingress will handle request forwarding for. For example, `www.mysite.com`.
+1. Enter the **Request Host** that your Ingress controller will handle request forwarding for. For example, `www.mysite.com`.
 1. Specify a path of type `Prefix` and a specify a path such as `/`.
 2. Add a **Target Service**.
-3. **Optional:** If you want specify a workload or service when a request is sent to a particular hostname path, add a **Path** for the target. For example, if you want requests for `www.mysite.com/contact-us` to be sent to a different service than `www.mysite.com`, enter `/contact-us` in the **Path** field. Typically, the first rule that you create does not include a path.
+3. **Optional:** If you want to specify a workload or service when a request is sent to a particular hostname path, add a **Path** for the target. For example, if you want requests for `www.mysite.com/contact-us` to be sent to a different service than `www.mysite.com`, enter `/contact-us` in the **Path** field. The first rule that you create does not typically include a path.
 4. Enter the **Port** number that each target operates on.
-### Certificates
+
+## Certificates
 
 :::note
 
-You must have an SSL certificate that the ingress can use to encrypt/decrypt communications. For more information see [Adding SSL Certificates](../encrypt-http-communication.md).
+You must have an SSL certificate that the Ingress controller can use to encrypt/decrypt communications. For more information, see [Adding SSL Certificates](../encrypt-http-communication.md).
 
 :::
 
-1. When creating an ingress, click the **Certificates** tab.
+1. To create an Ingress controller, click the **Certificates** tab.
 1. Click **Add Certificate**.
 1. Select a **Certificate - Secret Name** from the drop-down list.
 1. Enter the host using encrypted communication.
 1. To add additional hosts that use the certificate, click **Add Hosts**.
 
-### Labels and Annotations
+## Labels and Annotations
 
-Add [Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) and/or [Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) to provide metadata for your ingress.
+Add [Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) and/or [Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) to provide metadata for your Ingress Controller.
 
 For a list of annotations available for use, see the [Nginx Ingress Controller Documentation](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/).

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/ingress-configuration.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/ingress-configuration.md
@@ -5,7 +5,9 @@ description: Ingress configuration
 
 ### NGINX Ingress controller changes in Kubernetes v1.21
 
-For Kubernetes v1.21 and up, the NGINX Ingress controller no longer runs in hostNetwork but uses hostPorts for port 80 and port 443. This was done so the admission webhook can be configured to be accessed using ClusterIP so it can only be reached inside the cluster.
+For Kubernetes v1.21 and up, the NGINX Ingress controller no longer runs in hostNetwork by default. It instead uses hostPorts for port 80 and port 443, so you can configure the admission webhook to be accessible only through the ClusterIP. This ensures that the webhook is only accessible from within the cluster.
+
+Because of this change to the controller, the default behavior no longer sets `hostNetwork` to `true`. However, you must set `hostNetwork` to `true` for TCP- and UDP-based Services to work.
 
 ## Ingress Rule Configuration
 


### PR DESCRIPTION
Addresses issue #378 
Related to PR [#3420](https://github.com/rancher/docs/pull/3459)

We also need to update a page in the RKE docset. See issue #378 for more context.