### PR TITLE
#45 Request to improve the doc about fluentd buffer config and memory usage

### DIFF
--- a/docs/integrations-in-rancher/logging/custom-resource-configuration/flows-and-clusterflows.md
+++ b/docs/integrations-in-rancher/logging/custom-resource-configuration/flows-and-clusterflows.md
@@ -2,9 +2,9 @@
 title: Flows and ClusterFlows
 ---
 
-For the full details on configuring `Flows` and `ClusterFlows`, see the [Banzai Cloud Logging operator documentation.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/flow/).
+See the [Banzai Cloud Logging operator documentation](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/flow/) for the full details on how to configure  `Flows` and `ClusterFlows`.
 
-For memory problems with the logging buffer, see [Rancher Integration with Logging Services: Troubleshooting](../../../pages-for-subheaders/logging.md#The-Logging-Buffer-Overloads-Pods).
+See [Rancher Integration with Logging Services: Troubleshooting](../../../pages-for-subheaders/logging.md#The-Logging-Buffer-Overloads-Pods) for how to resolve memory problems with the logging buffer.
 
 ## Flows
 

--- a/docs/integrations-in-rancher/logging/custom-resource-configuration/flows-and-clusterflows.md
+++ b/docs/integrations-in-rancher/logging/custom-resource-configuration/flows-and-clusterflows.md
@@ -4,7 +4,7 @@ title: Flows and ClusterFlows
 
 For the full details on configuring `Flows` and `ClusterFlows`, see the [Banzai Cloud Logging operator documentation.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/flow/).
 
-For problems with the logging buffer configuration, see [Rancher Integration with Logging Services: Troubleshooting](../pages-for-subheaders/logging.md#Troubleshooting).
+For memory problems with the logging buffer, see [Rancher Integration with Logging Services: Troubleshooting](../pages-for-subheaders/logging.md#Troubleshooting).
 
 ## Flows
 

--- a/docs/integrations-in-rancher/logging/custom-resource-configuration/flows-and-clusterflows.md
+++ b/docs/integrations-in-rancher/logging/custom-resource-configuration/flows-and-clusterflows.md
@@ -4,6 +4,8 @@ title: Flows and ClusterFlows
 
 For the full details on configuring `Flows` and `ClusterFlows`, see the [Banzai Cloud Logging operator documentation.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/flow/).
 
+For problems with the logging buffer configuration, see [Rancher Integration with Logging Services: Troubleshooting](../pages-for-subheaders/logging.md#Troubleshooting).
+
 ## Flows
 
 A `Flow` defines which logs to collect and filter and which output to send the logs to.

--- a/docs/integrations-in-rancher/logging/custom-resource-configuration/flows-and-clusterflows.md
+++ b/docs/integrations-in-rancher/logging/custom-resource-configuration/flows-and-clusterflows.md
@@ -4,7 +4,7 @@ title: Flows and ClusterFlows
 
 For the full details on configuring `Flows` and `ClusterFlows`, see the [Banzai Cloud Logging operator documentation.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/flow/).
 
-For memory problems with the logging buffer, see [Rancher Integration with Logging Services: Troubleshooting](../../../pages-for-subheaders/logging.md#Troubleshooting).
+For memory problems with the logging buffer, see [Rancher Integration with Logging Services: Troubleshooting](../../../pages-for-subheaders/logging.md#The-Logging-Buffer-Overloads-Pods).
 
 ## Flows
 

--- a/docs/integrations-in-rancher/logging/custom-resource-configuration/flows-and-clusterflows.md
+++ b/docs/integrations-in-rancher/logging/custom-resource-configuration/flows-and-clusterflows.md
@@ -4,7 +4,7 @@ title: Flows and ClusterFlows
 
 For the full details on configuring `Flows` and `ClusterFlows`, see the [Banzai Cloud Logging operator documentation.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/flow/).
 
-For memory problems with the logging buffer, see [Rancher Integration with Logging Services: Troubleshooting](../pages-for-subheaders/logging.md#Troubleshooting).
+For memory problems with the logging buffer, see [Rancher Integration with Logging Services: Troubleshooting](../../../pages-for-subheaders/logging.md#Troubleshooting).
 
 ## Flows
 

--- a/docs/integrations-in-rancher/logging/custom-resource-configuration/flows-and-clusterflows.md
+++ b/docs/integrations-in-rancher/logging/custom-resource-configuration/flows-and-clusterflows.md
@@ -2,8 +2,7 @@
 title: Flows and ClusterFlows
 ---
 
-For the full details on configuring `Flows` and `ClusterFlows`, see the [Banzai Cloud Logging operator documentation.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/flow/)
-
+For the full details on configuring `Flows` and `ClusterFlows`, see the [Banzai Cloud Logging operator documentation.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/flow/).
 
 ## Flows
 

--- a/docs/integrations-in-rancher/logging/custom-resource-configuration/outputs-and-clusteroutputs.md
+++ b/docs/integrations-in-rancher/logging/custom-resource-configuration/outputs-and-clusteroutputs.md
@@ -4,7 +4,7 @@ title: Outputs and ClusterOutputs
 
 For the full details on configuring `Outputs` and `ClusterOutputs`, see the [Banzai Cloud Logging operator documentation.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/output/).
 
-For problems with the logging buffer configuration, see [Rancher Integration with Logging Services: Troubleshooting](../pages-for-subheaders/logging.md#Troubleshooting).
+For memory problems with the logging buffer, see [Rancher Integration with Logging Services: Troubleshooting](../pages-for-subheaders/logging.md#Troubleshooting).
 
 ## Outputs
 

--- a/docs/integrations-in-rancher/logging/custom-resource-configuration/outputs-and-clusteroutputs.md
+++ b/docs/integrations-in-rancher/logging/custom-resource-configuration/outputs-and-clusteroutputs.md
@@ -4,7 +4,7 @@ title: Outputs and ClusterOutputs
 
 For the full details on configuring `Outputs` and `ClusterOutputs`, see the [Banzai Cloud Logging operator documentation.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/output/).
 
-For memory problems with the logging buffer, see [Rancher Integration with Logging Services: Troubleshooting](../../../pages-for-subheaders/logging.md#Troubleshooting).
+For memory problems with the logging buffer, see [Rancher Integration with Logging Services: Troubleshooting](../../../pages-for-subheaders/logging.md#The-Logging-Buffer-Overloads-Pods).
 
 ## Outputs
 

--- a/docs/integrations-in-rancher/logging/custom-resource-configuration/outputs-and-clusteroutputs.md
+++ b/docs/integrations-in-rancher/logging/custom-resource-configuration/outputs-and-clusteroutputs.md
@@ -2,7 +2,9 @@
 title: Outputs and ClusterOutputs
 ---
 
-For the full details on configuring `Outputs` and `ClusterOutputs`, see the [Banzai Cloud Logging operator documentation.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/output/)
+For the full details on configuring `Outputs` and `ClusterOutputs`, see the [Banzai Cloud Logging operator documentation.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/output/).
+
+For problems with the logging buffer configuration, see [Rancher Integration with Logging Services: Troubleshooting](../pages-for-subheaders/logging.md#Troubleshooting).
 
 ## Outputs
 
@@ -14,7 +16,7 @@ You can use secrets in these definitions, but they must also be in the same name
 
 `Outputs` can be configured by filling out forms in the Rancher UI.
 
-For the details of `Output` custom resource, see [OutputSpec.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/crds/v1beta1/output_types/)
+For the details of `Output` custom resource, see [OutputSpec.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/crds/v1beta1/output_types/).
 
 The Rancher UI provides forms for configuring the following `Output` types:
 
@@ -38,7 +40,7 @@ The Rancher UI provides forms for configuring the following `Output` types:
 
 The Rancher UI provides forms for configuring the `Output` type, target, and access credentials if applicable.
 
-For example configuration for each logging plugin supported by the logging operator, see the [logging operator documentation.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/plugins/outputs/)
+For example configuration for each logging plugin supported by the logging operator, see the [logging operator documentation.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/plugins/outputs/).
 
 ## ClusterOutputs
 

--- a/docs/integrations-in-rancher/logging/custom-resource-configuration/outputs-and-clusteroutputs.md
+++ b/docs/integrations-in-rancher/logging/custom-resource-configuration/outputs-and-clusteroutputs.md
@@ -2,9 +2,9 @@
 title: Outputs and ClusterOutputs
 ---
 
-For the full details on configuring `Outputs` and `ClusterOutputs`, see the [Banzai Cloud Logging operator documentation.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/output/).
+See the [Banzai Cloud Logging operator documentation](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/flow/) for the full details on how to configure  `Flows` and `ClusterFlows`.
 
-For memory problems with the logging buffer, see [Rancher Integration with Logging Services: Troubleshooting](../../../pages-for-subheaders/logging.md#The-Logging-Buffer-Overloads-Pods).
+See [Rancher Integration with Logging Services: Troubleshooting](../../../pages-for-subheaders/logging.md#The-Logging-Buffer-Overloads-Pods) for how to resolve memory problems with the logging buffer.
 
 ## Outputs
 

--- a/docs/integrations-in-rancher/logging/custom-resource-configuration/outputs-and-clusteroutputs.md
+++ b/docs/integrations-in-rancher/logging/custom-resource-configuration/outputs-and-clusteroutputs.md
@@ -4,7 +4,7 @@ title: Outputs and ClusterOutputs
 
 For the full details on configuring `Outputs` and `ClusterOutputs`, see the [Banzai Cloud Logging operator documentation.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/output/).
 
-For memory problems with the logging buffer, see [Rancher Integration with Logging Services: Troubleshooting](../pages-for-subheaders/logging.md#Troubleshooting).
+For memory problems with the logging buffer, see [Rancher Integration with Logging Services: Troubleshooting](../../../pages-for-subheaders/logging.md#Troubleshooting).
 
 ## Outputs
 

--- a/docs/pages-for-subheaders/logging.md
+++ b/docs/pages-for-subheaders/logging.md
@@ -84,6 +84,12 @@ By default, Rancher collects logs for control plane components and node componen
 
 ## Troubleshooting
 
+### The Logging Buffer Overloads Pods
+
+Depending on your configuration, the default buffer size may be too large and cause pod failures. One way to reduce the load is to lower the logger's flush interval. This prevents logs from overfilling the buffer. You can also add more flush threads to handle moments when many logs are attempting to fill the buffer at once. 
+
+For a more complete description of how to configure the logging buffer to suit your organization's needs, see the official BanzaiCloud documentation on [buffers](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/plugins/outputs/buffer/) and on [Fluentd configuration](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/fluentd/).
+
 ### The `cattle-logging` Namespace Being Recreated
 
 If your cluster previously deployed logging from the global view in the legacy Rancher UI, you may encounter an issue where its `cattle-logging` namespace is continually being recreated.


### PR DESCRIPTION
Resolves #45 

There was a problem where the default logging buffer size was too large and caused pod failures.

After some investigation, it seems that the solution is situational to each user, depending on their configuration and how many logs they're receiving. I added some generic advice in a troubleshooting section and linked to the official external docs. I also added some lines about the issue to two pages that deal with logging outputs.

@btat @eliyamlevy  before I go in and update the corresponding versioned pages, how do you feel about the wording?