### PR TITLE
Add port 80 for hosted k8s port requirements between Rancher nodes

### DIFF
--- a/src/components/PortsImportedHosted.js
+++ b/src/components/PortsImportedHosted.js
@@ -13,7 +13,10 @@ const PortsImportedHosted = () => (
     <tbody>
         <tr>
         <td rowspan="3">Rancher Nodes <sup>(1)</sup></td>
-        <td></td>
+        <td rowspan="3" style={{
+            "background-color": "#3497DA",
+            color: "#ffffff"
+          }}>80 TCP</td>
         <td style={{
             "background-color": "#3497DA",
             color: "#ffffff"

--- a/src/components/PortsImportedHosted.js
+++ b/src/components/PortsImportedHosted.js
@@ -28,7 +28,6 @@ const PortsImportedHosted = () => (
           }}>git.rancher.io</td>
         </tr>
         <tr>
-        <td></td>
         <td style={{
             "background-color": "#3497DA",
             color: "#ffffff"
@@ -36,7 +35,6 @@ const PortsImportedHosted = () => (
         <td></td>
         </tr>
         <tr>
-        <td></td>
         <td style={{
             "background-color": "#3497DA",
             color: "#ffffff"


### PR DESCRIPTION
When @frank-at-suse and I were troubleshooting a Rancher cluster on a GKE cluster, when the number of replicas of rancher pods were scaled from 1 to 3 then the pods would not start.
Upon looking into the ingress logs, it had an error when trying to communicate to Rancher on port 80 
This PR updates the port requirements table for Hosted Kubernetes clusters and adds port 80 between Rancher nodes located https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-requirements/port-requirements#ports-for-hosted-kubernetes-clusters
cc: @frank-at-suse 