### PR TITLE
Update Rancher charts repository

### DIFF
--- a/docs/getting-started/installation-and-upgrade/resources/local-system-charts.md
+++ b/docs/getting-started/installation-and-upgrade/resources/local-system-charts.md
@@ -2,7 +2,7 @@
 title: Setting up Local System Charts for Air Gapped Installations
 ---
 
-The [System Charts](https://github.com/rancher/system-charts) repository contains all the catalog items required for features such as monitoring, logging, alerting and global DNS.
+The [Charts](https://github.com/rancher/charts) repository contains all the helm catalog items required for features such as monitoring, logging, alerting and istio.
 
 In an air gapped installation of Rancher, you will need to configure Rancher to use a local copy of the system charts. This section describes how to use local system charts using a CLI flag.
 
@@ -11,4 +11,3 @@ In an air gapped installation of Rancher, you will need to configure Rancher to 
 A local copy of `system-charts` has been packaged into the `rancher/rancher` container. To be able to use these features in an air gap install, you will need to run the Rancher install command with an extra environment variable, `CATTLE_SYSTEM_CATALOG=bundled`, which tells Rancher to use the local copy of the charts instead of attempting to fetch them from GitHub.
 
 Example commands for a Rancher installation with a bundled `system-charts` are included in the [air gap installation](../../../pages-for-subheaders/air-gapped-helm-cli-install.md) instructions for Docker and Helm installs.
-

--- a/docs/getting-started/installation-and-upgrade/resources/local-system-charts.md
+++ b/docs/getting-started/installation-and-upgrade/resources/local-system-charts.md
@@ -2,7 +2,7 @@
 title: Setting up Local System Charts for Air Gapped Installations
 ---
 
-The [Charts](https://github.com/rancher/charts) repository contains all the helm catalog items required for features such as monitoring, logging, alerting and istio.
+The [Charts](https://github.com/rancher/charts) repository contains all the Helm catalog items required for features such as monitoring, logging, alerting and Istio.
 
 In an air gapped installation of Rancher, you will need to configure Rancher to use a local copy of the system charts. This section describes how to use local system charts using a CLI flag.
 


### PR DESCRIPTION
- Update URL to match the [new v2 charts](https://github.com/rancher/charts) maintained for v2.6 and onwards. The [system-charts repo](https://github.com/rancher/system-charts) contains legacy apps.

- Update mention of global DNS as this is now a deprecated feature, proposing istio as another mention.