### PR TITLE
Update vsphere storage class steps 274

### DIFF
--- a/docs/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/vsphere-storage.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/vsphere-storage.md
@@ -20,8 +20,8 @@ The following steps can also be performed using the `kubectl` command line tool.
 :::
 
 1. Click **☰ > Cluster Management**.
-1. Go to the cluster where you want to provide vSphere storage.
-1. In the left navigation bar, click **Storage > StorageClasses**.
+1. Choose the cluster you want to provide vSphere storage to and click **Exlpore**. 
+1. In the left navigation bar, select **Storage > StorageClasses**.
 1. Click **Create**.
 3. Enter a **Name** for the StorageClass.
 4. Under **Provisioner**, select **VMWare vSphere Volume**.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/vsphere-storage.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/vsphere-storage.md
@@ -20,8 +20,8 @@ The following steps can also be performed using the `kubectl` command line tool.
 :::
 
 1. Click **☰ > Cluster Management**.
-1. Go to the cluster where you want to provide vSphere storage.
-1. In the left navigation bar, click **Storage > StorageClasses**.
+1. Choose the cluster you want to provide vSphere storage to and click **Exlpore**. 
+1. In the left navigation bar, select **Storage > StorageClasses**.
 1. Click **Create**.
 3. Enter a **Name** for the StorageClass.
 4. Under **Provisioner**, select **VMWare vSphere Volume**.


### PR DESCRIPTION
Resolves #274 

- **Issue:** Selecting a cluster by clicking the cluster Name vs clicking the **Explore** button results in a different UI experience making these instructions wrong (https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/vsphere-storage#creating-a-storageclass)
- **Changes:** Made small update to instructions for _provisioning vSphere volumes in a cluster_ to include selecting the **Explore** button in step 2