### PR TITLE
Updated misleading Docker command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ This command generates static content into the `build` directory and can be serv
 
 ### Launch With Docker
 
-You can Use [Docker](https://www.docker.com/) to launch the website without needing to configure Yarn.
+You can also use [Docker](https://www.docker.com/) to launch the website.
 
-The first time you launch the site, use this command to install yarn and start the server:
+The first time you launch the site this way, use this command to install Yarn and start the server:
 
 ```
 docker run --rm -it -v $PWD:$PWD -w $PWD -p 3000:3000 node yarn install && yarn start -h 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The first time you launch the site this way, use this command to install Yarn an
 docker run --rm -it -v $PWD:$PWD -w $PWD -p 3000:3000 node yarn install && yarn start -h 0.0.0.0
 ```
 
-On subsequent runs, use this command:
+On subsequent launches, use this command:
 
 ```
 docker run --rm -it -v $PWD:$PWD -w $PWD -p 3000:3000 node yarn start -h 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -50,7 +50,15 @@ This command generates static content into the `build` directory and can be serv
 
 ### Launch With Docker
 
-Use [Docker](https://www.docker.com/) to launch the website without needing to install and configure Yarn:
+You can Use [Docker](https://www.docker.com/) to launch the website without needing to configure Yarn.
+
+The first time you launch the site, use this command to install yarn and start the server:
+
+```
+docker run --rm -it -v $PWD:$PWD -w $PWD -p 3000:3000 node yarn install && yarn start -h 0.0.0.0
+```
+
+On subsequent runs, use this command:
 
 ```
 docker run --rm -it -v $PWD:$PWD -w $PWD -p 3000:3000 node yarn start -h 0.0.0.0


### PR DESCRIPTION
We claimed to have a command that could allow a user to launch a local version of the site without needing to install and configure Yarn.

However, Jiaqi Luo reported that the command actually returned the following:

```
/bin/sh: 1: docusaurus: not found                                                                                       
error Command failed with exit code 127.
```

@btat tested this and found that users still need to install Yarn if they have a fresh clone of the repo.