### PR TITLE
#351 Reference Support Matrix in install guides to inform users of possible version incompatibilities

### DIFF
--- a/docs/pages-for-subheaders/installation-requirements.md
+++ b/docs/pages-for-subheaders/installation-requirements.md
@@ -11,7 +11,7 @@ If you install Rancher on a Kubernetes cluster, requirements are different from 
 
 :::
 
-For a list of best practices for running the Rancher server in production, refer to the [best practices section.](../reference-guides/best-practices/rancher-server/tips-for-running-rancher.md).
+See our page on [best practices](../reference-guides/best-practices/rancher-server/tips-for-running-rancher.md) for a list of recommendations for running a Rancher server in production.
 
 The Rancher UI works best in Firefox or Chromium based browsers (Chrome, Edge, Opera, Brave, etc).
 

--- a/docs/pages-for-subheaders/installation-requirements.md
+++ b/docs/pages-for-subheaders/installation-requirements.md
@@ -11,9 +11,9 @@ If you install Rancher on a Kubernetes cluster, requirements are different from 
 
 :::
 
-See our page on [best practices](../reference-guides/best-practices/rancher-server/tips-for-running-rancher.md) for a list of recommendations for running a Rancher server in production.
-
 The Rancher UI works best in Firefox or Chromium based browsers (Chrome, Edge, Opera, Brave, etc).
+
+See our page on [best practices](../reference-guides/best-practices/rancher-server/tips-for-running-rancher.md) for a list of recommendations for running a Rancher server in production.
 
 ## Kubernetes Compatibility with Rancher
 

--- a/docs/pages-for-subheaders/installation-requirements.md
+++ b/docs/pages-for-subheaders/installation-requirements.md
@@ -25,7 +25,7 @@ All supported operating systems are 64-bit x86. Rancher should work with any mod
 
 The [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix) lists which OS and Docker versions were tested for each Rancher version.
 
-Docker is required for nodes that will run RKE Kubernetes clusters. It is not required for RKE2 or K3s clusters.
+Docker is required for nodes that will run RKE clusters. It is not required for RKE2 or K3s clusters.
 
 The `ntp` (Network Time Protocol) package should be installed. This prevents errors with certificate validation that can occur when the time is not synchronized between the client and server.
 

--- a/docs/pages-for-subheaders/installation-requirements.md
+++ b/docs/pages-for-subheaders/installation-requirements.md
@@ -11,41 +11,21 @@ If you install Rancher on a Kubernetes cluster, requirements are different from 
 
 :::
 
-Make sure the node(s) for the Rancher server fulfill the following requirements:
+For a list of best practices for running the Rancher server in production, refer to the [best practices section.](../reference-guides/best-practices/rancher-server/tips-for-running-rancher.md).
 
-- [Operating Systems and Container Runtime Requirements](#operating-systems-and-container-runtime-requirements)
-  - [RKE Specific Requirements](#rke-specific-requirements)
-  - [K3s Specific Requirements](#k3s-specific-requirements)
-  - [RKE2 Specific Requirements](#rke2-specific-requirements)
-  - [Installing Docker](#installing-docker)
-- [Hardware Requirements](#hardware-requirements)
-- [CPU and Memory](#cpu-and-memory)
-  - [RKE and Hosted Kubernetes](#rke-and-hosted-kubernetes)
-  - [K3s Kubernetes](#k3s-kubernetes)
-  - [RKE2 Kubernetes](#rke2-kubernetes)
-  - [Docker](#docker)
-- [Ingress](#ingress)
-- [Disks](#disks)
-- [Networking Requirements](#networking-requirements)
-  - [Node IP Addresses](#node-ip-addresses)
-  - [Port Requirements](#port-requirements)
-- [Dockershim Support](#dockershim-support)
+The Rancher UI works best in Firefox or Chromium based browsers (Chrome, Edge, Opera, Brave, etc).
 
-For a list of best practices that we recommend for running the Rancher server in production, refer to the [best practices section.](../reference-guides/best-practices/rancher-server/tips-for-running-rancher.md)
+## Kubernetes Compatibility with Rancher
 
-The Rancher UI works best in Firefox or Chromium based browsers (Chrome, Edge, Opera, Brave, ...).
+Rancher needs to be installed on a supported Kubernetes version. Consult the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix) to ensure that your intended version of Kubernetes is supported.
 
 ## Operating Systems and Container Runtime Requirements
 
-Rancher should work with any modern Linux distribution.
+All supported operating systems are 64-bit x86. Rancher should work with any modern Linux distribution.
+
+The [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix) lists which OS and Docker versions were tested for each Rancher version.
 
 Docker is required for nodes that will run RKE Kubernetes clusters. It is not required for RKE2 or K3s clusters.
-
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
-
-For details on which OS and Docker versions were tested with each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
-
-All supported operating systems are 64-bit x86.
 
 The `ntp` (Network Time Protocol) package should be installed. This prevents errors with certificate validation that can occur when the time is not synchronized between the client and server.
 
@@ -65,7 +45,7 @@ For more information see [Installing Docker,](../getting-started/installation-an
 
 For the container runtime, K3s bundles its own containerd by default. Alternatively, you can configure K3s to use an already installed Docker runtime. For more information on using K3s with Docker see the [K3s documentation.](https://docs.k3s.io/advanced#using-docker-as-the-container-runtime)
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix). To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
 
 If you are installing Rancher on a K3s cluster with **Raspbian Buster**, follow [these steps](https://rancher.com/docs/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster) to switch to legacy iptables.
 
@@ -75,7 +55,7 @@ If you are installing Rancher on a K3s cluster with Alpine Linux, follow [these 
 
 For the container runtime, RKE2 bundles its own containerd. Docker is not required for RKE2 installs.
 
-For details on which OS versions were tested with RKE2, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
+For details on which OS versions were tested with RKE2, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix).
 
 ## Hardware Requirements
 

--- a/versioned_docs/version-2.5/pages-for-subheaders/installation-requirements.md
+++ b/versioned_docs/version-2.5/pages-for-subheaders/installation-requirements.md
@@ -17,13 +17,13 @@ See our page on [best practices](../reference-guides/best-practices/rancher-serv
 
 ## Kubernetes Compatibility with Rancher
 
-Rancher needs to be installed on a supported Kubernetes version. Consult the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/rancher-v2-5-0/) to ensure that your intended version of Kubernetes is supported.
+Rancher needs to be installed on a supported Kubernetes version. Consult the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-5-16/) to ensure that your intended version of Kubernetes is supported.
 
 ## Operating Systems and Container Runtime Requirements
 
 All supported operating systems are 64-bit x86. Rancher should work with any modern Linux distribution.
 
-The [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/rancher-v2-5-0/) lists which OS and Docker versions were tested for each Rancher version.
+The [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-5-16/) lists which OS and Docker versions were tested for each Rancher version.
 
 Docker is required for nodes that will run RKE clusters. It is not required for RKE2 or K3s clusters.
 
@@ -49,7 +49,7 @@ net.bridge.bridge-nf-call-iptables=1
 
 For the container runtime, K3s should work with any modern version of Docker or containerd.
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/rancher-v2-5-0/). To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-5-16/). To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
 
 If you are installing Rancher on a K3s cluster with **Raspbian Buster**, follow [these steps](https://rancher.com/docs/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster) to switch to legacy iptables.
 
@@ -69,7 +69,7 @@ Docker is not required for RancherD installs.
 
 _The RKE2 install is available as of v2.5.6._
 
-For details on which OS versions were tested with RKE2, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/rancher-v2-5-0/).
+For details on which OS versions were tested with RKE2, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-5-16/).
 
 Docker is not required for RKE2 installs.
 

--- a/versioned_docs/version-2.5/pages-for-subheaders/installation-requirements.md
+++ b/versioned_docs/version-2.5/pages-for-subheaders/installation-requirements.md
@@ -5,47 +5,27 @@ description: Learn the node requirements for each node running Rancher server wh
 
 This page describes the software, hardware, and networking requirements for the nodes where the Rancher server will be installed. The Rancher server can be installed on a single node or a high-availability Kubernetes cluster.
 
-> It is important to note that if you install Rancher on a Kubernetes cluster, requirements are different from the [node requirements for downstream user clusters,](../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/node-requirements-for-rancher-managed-clusters.md) which will run your apps and services.
+:::note Important:
 
-Make sure the node(s) for the Rancher server fulfill the following requirements:
+If you install Rancher on a Kubernetes cluster, requirements are different from the [node requirements for downstream user clusters,](../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/node-requirements-for-rancher-managed-clusters.md) which will run your apps and services.
 
-- [Operating Systems and Container Runtime Requirements](#operating-systems-and-container-runtime-requirements)
-    - [RKE Specific Requirements](#rke-specific-requirements)
-    - [K3s Specific Requirements](#k3s-specific-requirements)
-    - [RancherD Specific Requirements](#rancherd-specific-requirements)
-    - [RKE2 Specific Requirements](#rke2-specific-requirements)
-    - [Installing Docker](#installing-docker)
-- [Hardware Requirements](#hardware-requirements)
-- [CPU and Memory](#cpu-and-memory)
-    - [RKE and Hosted Kubernetes](#rke-and-hosted-kubernetes)
-    - [K3s Kubernetes](#k3s-kubernetes)
-    - [RancherD](#rancherd)
-    - [RKE2 Kubernetes](#rke2-kubernetes)
-    - [Docker](#docker)
-- [Ingress](#ingress)
-    - [Ingress for RKE2](#ingress-for-rke2)
-    - [Ingress for EKS](#ingress-for-eks)
-- [Disks](#disks)
-- [Networking Requirements](#networking-requirements)
-    - [Node IP Addresses](#node-ip-addresses)
-    - [Port Requirements](#port-requirements)
-- [RancherD on SELinux Enforcing CentOS 8 or RHEL 8 Nodes](#rancherd-on-selinux-enforcing-centos-8-or-rhel-8-nodes)
+:::
 
-For a list of best practices that we recommend for running the Rancher server in production, refer to the [best practices section.](../reference-guides/best-practices/rancher-server/tips-for-running-rancher.md)
+The Rancher UI works best in Firefox or Chromium based browsers (Chrome, Edge, Opera, Brave, etc).
 
-The Rancher UI works best in Firefox or Chrome.
+See our page on [best practices](../reference-guides/best-practices/rancher-server/tips-for-running-rancher.md) for a list of recommendations for running a Rancher server in production.
+
+## Kubernetes Compatibility with Rancher
+
+Rancher needs to be installed on a supported Kubernetes version. Consult the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/rancher-v2-5-0/) to ensure that your intended version of Kubernetes is supported.
 
 ## Operating Systems and Container Runtime Requirements
 
-Rancher should work with any modern Linux distribution.
+All supported operating systems are 64-bit x86. Rancher should work with any modern Linux distribution.
 
-Docker is required for nodes that will run RKE Kubernetes clusters. It is not required for RancherD or RKE2 Kubernetes installs.
+The [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/rancher-v2-5-0/) lists which OS and Docker versions were tested for each Rancher version.
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
-
-For details on which OS and Docker versions were tested with each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
-
-All supported operating systems are 64-bit x86.
+Docker is required for nodes that will run RKE clusters. It is not required for RKE2 or K3s clusters.
 
 The `ntp` (Network Time Protocol) package should be installed. This prevents errors with certificate validation that can occur when the time is not synchronized between the client and server.
 
@@ -69,7 +49,7 @@ net.bridge.bridge-nf-call-iptables=1
 
 For the container runtime, K3s should work with any modern version of Docker or containerd.
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/rancher-v2-5-0/). To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
 
 If you are installing Rancher on a K3s cluster with **Raspbian Buster**, follow [these steps](https://rancher.com/docs/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster) to switch to legacy iptables.
 
@@ -89,7 +69,7 @@ Docker is not required for RancherD installs.
 
 _The RKE2 install is available as of v2.5.6._
 
-For details on which OS versions were tested with RKE2, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
+For details on which OS versions were tested with RKE2, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/rancher-v2-5-0/).
 
 Docker is not required for RKE2 installs.
 

--- a/versioned_docs/version-2.5/pages-for-subheaders/installation-requirements.md
+++ b/versioned_docs/version-2.5/pages-for-subheaders/installation-requirements.md
@@ -156,7 +156,7 @@ The Ingress should be deployed as DaemonSet to ensure your load balancer can suc
 
 For RKE, K3s and RancherD installations, you don't have to install the Ingress manually because it is installed by default.
 
-For hosted Kubernetes clusters (EKS, GKE, AKS) and RKE2 Kubernetes installations, you will need to set up the ingress.
+For hosted Kubernetes clusters (EKS, GKE, AKS) and RKE2  installations, you will need to set up the ingress.
 
 ### Ingress for RKE2
 

--- a/versioned_docs/version-2.6/pages-for-subheaders/installation-requirements.md
+++ b/versioned_docs/version-2.6/pages-for-subheaders/installation-requirements.md
@@ -17,13 +17,13 @@ See our page on [best practices](../reference-guides/best-practices/rancher-serv
 
 ## Kubernetes Compatibility with Rancher
 
-Rancher needs to be installed on a supported Kubernetes version. Consult the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/rancher-v2-6-0/) to ensure that your intended version of Kubernetes is supported.
+Rancher needs to be installed on a supported Kubernetes version. Consult the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-6-10/) to ensure that your intended version of Kubernetes is supported.
 
 ## Operating Systems and Container Runtime Requirements
 
 All supported operating systems are 64-bit x86. Rancher should work with any modern Linux distribution.
 
-The [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/rancher-v2-6-0/) lists which OS and Docker versions were tested for each Rancher version.
+The [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-6-10/) lists which OS and Docker versions were tested for each Rancher version.
 
 Docker is required for nodes that will run RKE clusters. It is not required for RKE2 or K3s clusters.
 
@@ -45,7 +45,7 @@ For more information see [Installing Docker,](../getting-started/installation-an
 
 For the container runtime, K3s bundles its own containerd by default. Alternatively, you can configure K3s to use an already installed Docker runtime. For more information on using K3s with Docker see the [K3s documentation.](https://docs.k3s.io/advanced#using-docker-as-the-container-runtime)
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/rancher-v2-6-0/). To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-6-10/). To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
 
 If you are installing Rancher on a K3s cluster with **Raspbian Buster**, follow [these steps](https://rancher.com/docs/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster) to switch to legacy iptables.
 
@@ -55,7 +55,7 @@ If you are installing Rancher on a K3s cluster with Alpine Linux, follow [these 
 
 For the container runtime, RKE2 bundles its own containerd. Docker is not required for RKE2 installs.
 
-For details on which OS versions were tested with RKE2, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/rancher-v2-6-0/).
+For details on which OS versions were tested with RKE2, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-6-10/).
 
 ## Hardware Requirements
 

--- a/versioned_docs/version-2.6/pages-for-subheaders/installation-requirements.md
+++ b/versioned_docs/version-2.6/pages-for-subheaders/installation-requirements.md
@@ -11,41 +11,21 @@ If you install Rancher on a Kubernetes cluster, requirements are different from 
 
 :::
 
-Make sure the node(s) for the Rancher server fulfill the following requirements:
+The Rancher UI works best in Firefox or Chromium based browsers (Chrome, Edge, Opera, Brave, etc).
 
-- [Operating Systems and Container Runtime Requirements](#operating-systems-and-container-runtime-requirements)
-  - [RKE Specific Requirements](#rke-specific-requirements)
-  - [K3s Specific Requirements](#k3s-specific-requirements)
-  - [RKE2 Specific Requirements](#rke2-specific-requirements)
-  - [Installing Docker](#installing-docker)
-- [Hardware Requirements](#hardware-requirements)
-- [CPU and Memory](#cpu-and-memory)
-  - [RKE and Hosted Kubernetes](#rke-and-hosted-kubernetes)
-  - [K3s Kubernetes](#k3s-kubernetes)
-  - [RKE2 Kubernetes](#rke2-kubernetes)
-  - [Docker](#docker)
-- [Ingress](#ingress)
-- [Disks](#disks)
-- [Networking Requirements](#networking-requirements)
-  - [Node IP Addresses](#node-ip-addresses)
-  - [Port Requirements](#port-requirements)
-- [Dockershim Support](#dockershim-support)
+See our page on [best practices](../reference-guides/best-practices/rancher-server/tips-for-running-rancher.md) for a list of recommendations for running a Rancher server in production.
 
-For a list of best practices that we recommend for running the Rancher server in production, refer to the [best practices section.](../reference-guides/best-practices/rancher-server/tips-for-running-rancher.md)
+## Kubernetes Compatibility with Rancher
 
-The Rancher UI works best in Firefox or Chromium based browsers (Chrome, Edge, Opera, Brave, ...).
+Rancher needs to be installed on a supported Kubernetes version. Consult the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/rancher-v2-6-0/) to ensure that your intended version of Kubernetes is supported.
 
 ## Operating Systems and Container Runtime Requirements
 
-Rancher should work with any modern Linux distribution.
+All supported operating systems are 64-bit x86. Rancher should work with any modern Linux distribution.
 
-Docker is required for nodes that will run RKE Kubernetes clusters. It is not required for RKE2 or K3s clusters.
+The [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/rancher-v2-6-0/) lists which OS and Docker versions were tested for each Rancher version.
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
-
-For details on which OS and Docker versions were tested with each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
-
-All supported operating systems are 64-bit x86.
+Docker is required for nodes that will run RKE clusters. It is not required for RKE2 or K3s clusters.
 
 The `ntp` (Network Time Protocol) package should be installed. This prevents errors with certificate validation that can occur when the time is not synchronized between the client and server.
 
@@ -65,7 +45,7 @@ For more information see [Installing Docker,](../getting-started/installation-an
 
 For the container runtime, K3s bundles its own containerd by default. Alternatively, you can configure K3s to use an already installed Docker runtime. For more information on using K3s with Docker see the [K3s documentation.](https://docs.k3s.io/advanced#using-docker-as-the-container-runtime)
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/rancher-v2-6-0/). To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
 
 If you are installing Rancher on a K3s cluster with **Raspbian Buster**, follow [these steps](https://rancher.com/docs/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster) to switch to legacy iptables.
 
@@ -75,7 +55,7 @@ If you are installing Rancher on a K3s cluster with Alpine Linux, follow [these 
 
 For the container runtime, RKE2 bundles its own containerd. Docker is not required for RKE2 installs.
 
-For details on which OS versions were tested with RKE2, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
+For details on which OS versions were tested with RKE2, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/rancher-v2-6-0/).
 
 ## Hardware Requirements
 


### PR DESCRIPTION
Resolves #351 

Our docs already did reference the support matrix, in a roundabout way. We had links to a page that now redirects to the support matrix. The advice wasn't very prominent either, so I decided to give it its own heading, before the OS requirements. I changed the links to the old page to reference the support matrix instead. I also did some style edits on the intro and removed the in-text table of contents, since Docusaurus now gives our users a table of contents off to the side of any page with multiple headings.

Let me know how these changes look and then we can apply them to versioned_docs.