### PR TITLE
Update instructions about how to run with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This command generates static content into the `build` directory and can be serv
 
 You can also use [Docker](https://www.docker.com/) to launch the website.
 
-The below command can be use to install the dependencies and run the site inside a container:
+The below command can be used to install the dependencies and run the site inside a container:
 
 ```
 docker run --rm -it -v $PWD:$PWD -w $PWD -p 3000:3000 node /bin/sh -c "yarn install && yarn start -h 0.0.0.0"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ First, install Docusaurus 2:
 yarn start
 ```
 
-This command starts a local development server for Docusuarus 2, and opens up a browser window. Most changes are reflected live without having to restart the server.
+This command starts a local development server for Docusaurus 2, and opens up a browser window. Most changes are reflected live without having to restart the server.
 
 **Note:** The `yarn start` command won't include some important static site features. For example, switching between languages from the site's dropdown menu is not available. If you need these features, use `yarn build`.
 
@@ -52,17 +52,13 @@ This command generates static content into the `build` directory and can be serv
 
 You can also use [Docker](https://www.docker.com/) to launch the website.
 
-The first time you launch the site this way, use this command to install Yarn and start the server:
+The below command can be use to install the dependencies and run the site inside a container:
 
 ```
-docker run --rm -it -v $PWD:$PWD -w $PWD -p 3000:3000 node yarn install && yarn start -h 0.0.0.0
+docker run --rm -it -v $PWD:$PWD -w $PWD -p 3000:3000 node /bin/sh -c "yarn install && yarn start -h 0.0.0.0"
 ```
 
-On subsequent launches, use this command:
-
-```
-docker run --rm -it -v $PWD:$PWD -w $PWD -p 3000:3000 node yarn start -h 0.0.0.0
-```
+Subsequent executions will check for updated dependencies, if there are none, it will skip the updates and quickly start the server.
 
 License
 =======


### PR DESCRIPTION
The current command to run the docs site locally with Docker for the first time doesn't work properly. Only `yarn install` is passed as argument to the running container. `&& yarn start -h 0.0.0.0` is actually executed locally in the host (i.e., outside the container). It will only work if the user has `yarn` installed locally (which is not my case, see error below).

```shell
% docker run --rm -it -v $PWD:$PWD -w $PWD -p 3000:3000 node yarn install && yarn start -h 0.0.0.0
yarn install v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning "@docusaurus/core > react-loadable-ssr-addon-v5-slorber@1.0.1" has unmet peer dependency "react-loadable@*".
warning "@docusaurus/core > react-dev-utils > fork-ts-checker-webpack-plugin@6.5.2" has unmet peer dependency "typescript@>= 2.7".
warning "@docusaurus/preset-classic > @docusaurus/theme-search-algolia > @docsearch/react > @algolia/autocomplete-preset-algolia@1.7.2" has unmet peer dependency "@algolia/client-search@>= 4.9.1 < 6".
[4/4] Building fresh packages...
Done in 127.35s.
zsh: command not found: yarn
```

The updated command will properly install the dependencies and run Docusaurus.

I also suggest removing the second instruction `On subsequent launches, use this command:`, because since the packages should already be cached locally, by running only the first command it's enough.

```shell
% docker run --rm -it -v $PWD:$PWD -w $PWD -p 3000:3000 node /bin/sh -c "yarn install && yarn start -h 0.0.0.0"
yarn install v1.22.19
[1/4] Resolving packages...
success Already up-to-date.
Done in 0.45s.
yarn run v1.22.19
$ docusaurus start -h 0.0.0.0
[INFO] Starting the development server...
```