### PR TITLE
installation-requirements.md: point to latest support matrix

### DIFF
--- a/docs/pages-for-subheaders/installation-requirements.md
+++ b/docs/pages-for-subheaders/installation-requirements.md
@@ -55,7 +55,7 @@ If you are installing Rancher on a K3s cluster with Alpine Linux, follow [these 
 
 For the container runtime, RKE2 bundles its own containerd. Docker is not required for RKE2 installs.
 
-For details on which OS versions were tested with RKE2, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix).
+For details on which OS versions were tested with RKE2, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-7-1/).
 
 ## Hardware Requirements
 


### PR DESCRIPTION
Current link points to 2.6.3, which is confusing coming from the 2.7 version of the docs.

https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-requirements

points to:

https://www.suse.com/suse-rancher/support-matrix

which redirects to:

https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-6-3/


Perhaps a better solution would be to change the redirect - up to you to close this PR in that case.