### PR TITLE
updating links to support matrix in installation-requirements

### DIFF
--- a/docs/pages-for-subheaders/installation-requirements.md
+++ b/docs/pages-for-subheaders/installation-requirements.md
@@ -17,13 +17,13 @@ See our page on [best practices](../reference-guides/best-practices/rancher-serv
 
 ## Kubernetes Compatibility with Rancher
 
-Rancher needs to be installed on a supported Kubernetes version. Consult the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix) to ensure that your intended version of Kubernetes is supported.
+Rancher needs to be installed on a supported Kubernetes version. Consult the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions) to ensure that your intended version of Kubernetes is supported.
 
 ## Operating Systems and Container Runtime Requirements
 
 All supported operating systems are 64-bit x86. Rancher should work with any modern Linux distribution.
 
-The [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix) lists which OS and Docker versions were tested for each Rancher version.
+The [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions) lists which OS and Docker versions were tested for each Rancher version.
 
 Docker is required for nodes that will run RKE clusters. It is not required for RKE2 or K3s clusters.
 
@@ -45,7 +45,7 @@ For more information see [Installing Docker,](../getting-started/installation-an
 
 For the container runtime, K3s bundles its own containerd by default. Alternatively, you can configure K3s to use an already installed Docker runtime. For more information on using K3s with Docker see the [K3s documentation.](https://docs.k3s.io/advanced#using-docker-as-the-container-runtime)
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix). To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions). To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
 
 If you are installing Rancher on a K3s cluster with **Raspbian Buster**, follow [these steps](https://rancher.com/docs/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster) to switch to legacy iptables.
 
@@ -55,7 +55,7 @@ If you are installing Rancher on a K3s cluster with Alpine Linux, follow [these 
 
 For the container runtime, RKE2 bundles its own containerd. Docker is not required for RKE2 installs.
 
-For details on which OS versions were tested with RKE2, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix).
+For details on which OS versions were tested with RKE2, refer to the [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions).
 
 ## Hardware Requirements
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/pages-for-subheaders/installation-requirements.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/pages-for-subheaders/installation-requirements.md
@@ -17,13 +17,13 @@ Rancher UI 在基于 Firefox 或 Chromium 的浏览器（Chrome、Edge、Opera�
 
 ## Kubernetes 与 Rancher 的兼容性
 
-Rancher 需要安装在支持的 Kubernetes 版本上。请查阅 [Rancher 支持矩阵](https://www.suse.com/suse-rancher/support-matrix)，确保你的 Kubernetes 版本受支持。
+Rancher 需要安装在支持的 Kubernetes 版本上。请查阅 [Rancher 支持矩阵](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions)，确保你的 Kubernetes 版本受支持。
 
 ## 操作系统和容器运行时要求
 
 所有支持的操作系统都使用 64-bit x86 架构。Rancher 兼容当前所有的主流 Linux 发行版。
 
-[Rancher 支持矩阵](https://www.suse.com/suse-rancher/support-matrix)列出了每个 Rancher 版本测试过的操作系统和 Docker 版本。
+[Rancher 支持矩阵](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions)列出了每个 Rancher 版本测试过的操作系统和 Docker 版本。
 
 运行 RKE 集群的节点需要安装 Docker。RKE2 或 K3s 集群不需要它。
 
@@ -45,7 +45,7 @@ Rancher 需要安装在支持的 Kubernetes 版本上。请查阅 [Rancher 支�
 
 对于容器运行时，K3s 默认附带了自己的 containerd。你也可以将 K3s 配置为使用已安装的 Docker 运行时。有关在 Docker 中使用 K3s 的更多信息，请参阅 [K3s 文档](https://docs.k3s.io/advanced#using-docker-as-the-container-runtime)。
 
-Rancher 需要安装在支持的 Kubernetes 版本上。如需了解你使用的 Rancher 版本支持哪些 Kubernetes 版本，请参见 [Rancher 支持矩阵](https://www.suse.com/suse-rancher/support-matrix)。如需指定 K3s 版本，在运行 K3s 安装脚本时，使用 `INSTALL_K3S_VERSION` 环境变量。
+Rancher 需要安装在支持的 Kubernetes 版本上。如需了解你使用的 Rancher 版本支持哪些 Kubernetes 版本，请参见 [Rancher 支持矩阵](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions)。如需指定 K3s 版本，在运行 K3s 安装脚本时，使用 `INSTALL_K3S_VERSION` 环境变量。
 
 如果你使用 **Raspbian Buster** 在 K3s 集群上安装 Rancher，请按照[这些步骤](https://rancher.com/docs/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster)切换到旧版 iptables。
 
@@ -55,7 +55,7 @@ Rancher 需要安装在支持的 Kubernetes 版本上。如需了解你使用的
 
 对于容器运行时，RKE2 附带了自己的 containerd。RKE2 安装不需要 Docker。
 
-如需了解 RKE2 通过了哪些操作系统版本的测试，请参见 [Rancher 支持矩阵](https://www.suse.com/suse-rancher/support-matrix)。
+如需了解 RKE2 通过了哪些操作系统版本的测试，请参见 [Rancher 支持矩阵](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions)。
 
 ## 硬件要求
 


### PR DESCRIPTION
A user recently opened https://github.com/rancher/rancher-docs/pull/485 because a link to the support matrix was redirecting to an old release. 

https://www.suse.com/suse-rancher/support-matrix/all-supported-versions redirects to the latest release, whereas https://www.suse.com/suse-rancher/support-matrix redirects to 2.6.3. 

I updated the few references to https://www.suse.com/suse-rancher/support-matrix to point to https://www.suse.com/suse-rancher/support-matrix/all-supported-versions instead.

