### PR TITLE
[release/v2.7.2] Update rancher-cis-benchmark installation guide.

### DIFF
--- a/docs/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark.md
+++ b/docs/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark.md
@@ -9,3 +9,5 @@ title: Install Rancher CIS Benchmark
 1. Click **Install**.
 
 **Result:** The CIS scan application is deployed on the Kubernetes cluster.
+
+**Note:** CIS Benchmark 4.0.0 and above have PSPs disabled by default. To install CIS Benchmark on a hardened cluster, set `golbal.psp.enabled` to `true` in the values before installing the chart.

--- a/docs/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark.md
+++ b/docs/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark.md
@@ -10,4 +10,8 @@ title: Install Rancher CIS Benchmark
 
 **Result:** The CIS scan application is deployed on the Kubernetes cluster.
 
-**Note:** CIS Benchmark 4.0.0 and above have PSPs disabled by default. To install CIS Benchmark on a hardened cluster, set `golbal.psp.enabled` to `true` in the values before installing the chart.
+:::note
+
+CIS Benchmark 4.0.0 and above have PSPs disabled by default. To install CIS Benchmark on a hardened cluster, set `golbal.psp.enabled` to `true` in the values before installing the chart.
+
+:::


### PR DESCRIPTION
Added an additional step that when a cluster is being hardened, the values for cis-benchmark chart 4.0.0 and up should be updated by setting `global.psp.enabled=true` - this would ensure that with PSP's are enabled, so the chart installation and scans will succeed.

Linked issue: https://github.com/rancher/rancher-docs/issues/495