### PR TITLE
Adding fleet-default to list of exceptions for restricted clusters

### DIFF
--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/pod-security-standards.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/pod-security-standards.md
@@ -62,6 +62,7 @@ When you run Rancher on a Kubernetes cluster that enforces a restrictive securit
 - `cattle-windows-gmsa-system`
 - `cert-manager`
 - `cis-operator-system`
+- `fleet-default`
 - `ingress-nginx`
 - `istio-system`
 - `kube-node-lease`


### PR DESCRIPTION
Update for issue:  https://github.com/rancher/rancher/issues/40149