### PR TITLE
#77 Addressing backlog issue about registered AKS clusters

### DIFF
--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -17,9 +17,7 @@ For more information on RKE node roles, see the [best practices.](../../../pages
 
 ### Permissions
 
-If your existing Kubernetes cluster already has a `cluster-admin` role defined, you must have this `cluster-admin` privilege to register the cluster in Rancher.
-
-In order to apply the privilege, you need to run:
+To register a cluster in Rancher, you must define a `cluster-admin` role within that cluster. If you haven't defined the role already, run the following:
 
 ```plain
 kubectl create clusterrolebinding cluster-admin-binding \
@@ -27,13 +25,11 @@ kubectl create clusterrolebinding cluster-admin-binding \
   --user [USER_ACCOUNT]
 ```
 
-before running the `kubectl` command to register the cluster.
-
-By default, GKE users are not given this privilege, so you will need to run the command before registering GKE clusters. To learn more about role-based access control for GKE, please click [here](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
+Since, by default, Google Kubernetes Engine (GKE) doesn't define the `cluster-admin` role, you must run these commands on GKE clusters before you can register them. To learn more about role-based access control for GKE, please see [the official Google documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
 
 ### EKS, AKS and GKE Clusters
 
-EKS, AKS and GKE clusters must have at least one managed node group to be imported into Rancher or provisioned from Rancher successfully.
+To successfully import them into or provision them from Rancher, Elastic Kubernetes Service (EKS), Azure Kubernetes Service (AKS), and Google Kubernetes Engine (GKE) clusters must have at least one managed node group.
 
 ## Registering a Cluster
 
@@ -128,7 +124,7 @@ When an RKE2 or K3s cluster is registered in Rancher, Rancher will recognize it.
 
 ### Additional Features for Registered EKS, AKS, and GKE Clusters
 
-When you register an Elastic Kubernetes Service (EKS), Azure Kubernetes Service (AKS), or Google Kubernetes Engine (GKE) cluster, Rancher handles the cluster similarly to clusters created in Rancher. However, Rancher doesn't destroy registered clusters when you delete them through the Rancher UI.
+Rancher handles registered EKS, AKS, or GKE clusters similarly to clusters created in Rancher. However, Rancher doesn't destroy registered clusters when you delete them through the Rancher UI.
 
 When you create an EKS, AKS, or GKE cluster in Rancher, then delete it, Rancher destroys the cluster. When you delete a registered cluster through Rancher, the Rancher server _disconnects_ from the cluster. The cluster remains live, although it's no longer in Rancher. You can still access the deregistered cluster in the same way you did before you registered it.
 

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -126,15 +126,13 @@ When an RKE2 or K3s cluster is registered in Rancher, Rancher will recognize it.
 - The ability to configure the maximum number of nodes that will be upgraded concurrently
 - The ability to see a read-only version of the cluster's configuration arguments and environment variables used to launch each node in the cluster
 
-### Additional Features for Registered EKS, AKS and GKE Clusters
+### Additional Features for Registered EKS, AKS, and GKE Clusters
 
-Registering an Amazon EKS, Azure AKS or GKE cluster allows Rancher to treat it as though it were created in Rancher.
+When you register an Elastic Kubernetes Service (EKS), Azure Kubernetes Service (AKS), or Google Kubernetes Engine (GKE) cluster, Rancher handles the cluster similarly to clusters created in Rancher. However, Rancher doesn't destroy registered clusters when you delete them through the Rancher UI.
 
-Amazon EKS, Azure AKS and GKE clusters can now be registered in Rancher. For the most part, these registered clusters are treated the same way as clusters created in the Rancher UI, except for deletion.
+When you create an EKS, AKS, or GKE cluster in Rancher, then delete it, Rancher destroys the cluster. When you delete a registered cluster through Rancher, the Rancher server _disconnects_ from the cluster. The cluster remains live, although it's no longer in Rancher. You can still access the deregistered cluster in the same way you did before you registered it.
 
-When you delete an EKS, AKS or GKE cluster that was created in Rancher, the cluster is destroyed. When you delete a cluster that was registered in Rancher, it is disconnected from the Rancher server, but it still exists, and you can still access it in the same way you did before it was registered in Rancher.
-
-The capabilities for registered clusters are listed in the table on [this page.](../../../pages-for-subheaders/kubernetes-clusters-in-rancher-setup.md)
+See [Cluster Management Capabilities by Cluster Type](../../../pages-for-subheaders/kubernetes-clusters-in-rancher-setup.md) for more information about what features are available for managing registered clusters.
 
 ## Configuring RKE2 and K3s Cluster Upgrades
 

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -17,7 +17,7 @@ For more information on RKE node roles, see the [best practices.](../../../pages
 
 ### Permissions
 
-To register a cluster in Rancher, you must define a `cluster-admin` role within that cluster. If you haven't defined the role already, run the following:
+To register a cluster in Rancher, you must have `cluster-admin` privileges within that cluster. If you don't, grant these privileges to your user by running:
 
 ```plain
 kubectl create clusterrolebinding cluster-admin-binding \
@@ -25,7 +25,7 @@ kubectl create clusterrolebinding cluster-admin-binding \
   --user [USER_ACCOUNT]
 ```
 
-Since, by default, Google Kubernetes Engine (GKE) doesn't define the `cluster-admin` role, you must run these commands on GKE clusters before you can register them. To learn more about role-based access control for GKE, please see [the official Google documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
+Since, by default, Google Kubernetes Engine (GKE) doesn't grant the `cluster-admin` role, you must run these commands on GKE clusters before you can register them. To learn more about role-based access control for GKE, please see [the official Google documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
 
 ### EKS, AKS and GKE Clusters
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -142,15 +142,13 @@ When a K3s cluster is registered in Rancher, Rancher will recognize it as K3s. T
 - The ability to configure the maximum number of nodes that will be upgraded concurrently
 - The ability to see a read-only version of the K3s cluster's configuration arguments and environment variables used to launch each node in the cluster
 
-### Additional Features for Registered EKS and GKE Clusters
+### Additional Features for Registered EKS, AKS, and GKE Clusters
 
-Registering an Amazon EKS cluster or GKE cluster allows Rancher to treat it as though it were created in Rancher.
+When you register an Elastic Kubernetes Service (EKS), Azure Kubernetes Service (AKS), or Google Kubernetes Engine (GKE) cluster, Rancher handles the cluster similarly to clusters created in Rancher. However, Rancher doesn't destroy registered clusters when you delete them through the Rancher UI.
 
-Amazon EKS clusters and GKE clusters can now be registered in Rancher. For the most part, these registered clusters are treated the same way as clusters created in the Rancher UI, except for deletion.
+When you create an EKS, AKS, or GKE cluster in Rancher, then delete it, Rancher destroys the cluster. When you delete a registered cluster through Rancher, the Rancher server _disconnects_ from the cluster. The cluster remains live, although it's no longer in Rancher. You can still access the deregistered cluster in the same way you did before you registered it.
 
-When you delete an EKS cluster or GKE cluster that was created in Rancher, the cluster is destroyed. When you delete a cluster that was registered in Rancher, it is disconnected from the Rancher server, but it still exists and you can still access it in the same way you did before it was registered in Rancher.
-
-The capabilities for registered clusters are listed in the table on [this page.](../../../pages-for-subheaders/kubernetes-clusters-in-rancher-setup.md)
+See [Cluster Management Capabilities by Cluster Type](../../../pages-for-subheaders/kubernetes-clusters-in-rancher-setup.md) for more information about what features are available for managing registered clusters.
 
 ## Configuring K3s Cluster Upgrades
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -17,9 +17,7 @@ For more information on RKE node roles, see the [best practices.](../../../pages
 
 ### Permissions
 
-If your existing Kubernetes cluster already has a `cluster-admin` role defined, you must have this `cluster-admin` privilege to register the cluster in Rancher.
-
-In order to apply the privilege, you need to run:
+To register a cluster in Rancher, you must have `cluster-admin` privileges within that cluster. If you don't, grant these privileges to your user by running:
 
 ```plain
 kubectl create clusterrolebinding cluster-admin-binding \
@@ -29,7 +27,7 @@ kubectl create clusterrolebinding cluster-admin-binding \
 
 before running the `kubectl` command to register the cluster.
 
-By default, GKE users are not given this privilege, so you will need to run the command before registering GKE clusters. To learn more about role-based access control for GKE, please click [here](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
+Since, by default, Google Kubernetes Engine (GKE) doesn't grant the `cluster-admin` role, you must run these commands on GKE clusters before you can register them. To learn more about role-based access control for GKE, please see [the official Google documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
 
 If you are registering a K3s cluster, make sure the `cluster.yml` is readable. It is protected by default. For details, refer to [Configuring a K3s cluster to enable importation to Rancher.](#configuring-a-k3s-cluster-to-enable-registration-in-rancher)
 
@@ -144,7 +142,7 @@ When a K3s cluster is registered in Rancher, Rancher will recognize it as K3s. T
 
 ### Additional Features for Registered EKS, AKS, and GKE Clusters
 
-When you register an Elastic Kubernetes Service (EKS), Azure Kubernetes Service (AKS), or Google Kubernetes Engine (GKE) cluster, Rancher handles the cluster similarly to clusters created in Rancher. However, Rancher doesn't destroy registered clusters when you delete them through the Rancher UI.
+Rancher handles registered EKS, AKS, or GKE clusters similarly to clusters created in Rancher. However, Rancher doesn't destroy registered clusters when you delete them through the Rancher UI.
 
 When you create an EKS, AKS, or GKE cluster in Rancher, then delete it, Rancher destroys the cluster. When you delete a registered cluster through Rancher, the Rancher server _disconnects_ from the cluster. The cluster remains live, although it's no longer in Rancher. You can still access the deregistered cluster in the same way you did before you registered it.
 


### PR DESCRIPTION
While going through backlog, I did a review of #77. Some, but not all, of the problems mentioned in the issue have been addressed. Rather than creating a PR for the entire issue, I'm going to pick through it to make sure that the problems are still relevant to the current state of the docs.

In https://github.com/rancher/rancher-docs/issues/77#issuecomment-1245965075 from the thread:

> Please also look at https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/registered-clusters/#additional-features-for-registered-eks-and-gke-clusters where it does not mention AKS clusters (my understanding is that AKS clusters can be registered too):
> 
> > Additional Features for Registered EKS and GKE Clusters
> > Registering an Amazon EKS cluster or GKE cluster allows Rancher to treat it as though it were created in Rancher.
> > Amazon EKS clusters and GKE clusters can now be registered in Rancher. For the most part, these registered clusters are treated the same way as clusters created in the Rancher UI, except for deletion.
> > When you delete an EKS cluster or GKE cluster that was created in Rancher, the cluster is destroyed. When you delete a cluster that was registered in Rancher, it is disconnected from the Rancher server, but it still exists and you can still access it in the same way you did before it was registered in Rancher.
> > The capabilities for registered clusters are listed in the table on [this page.](https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/)

This was answered with https://github.com/rancher/rancher-docs/issues/77#issuecomment-1245965081:
> > https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/
> 
> Thanks for your contribution. AKS came along a little later and can be registered as well, as you noted.
> 
> [...] add "AKS" to the verbiage, tables, and sections wherein we only mention EKS and GKE cluster registration in the links  provided. Thanks!

 At the time, this related to Rancher v2.6, but the v2.6 page wasn't updated. v2.7 does mention AKS, but referred to it as "Azure AKS," which is inaccurate. The section also needed a style refresh.

I updated v2.6 and 2.7 to match. v2.5 was left alone as I'm not sure if it was intended to be updated in the original thread.