### PR TITLE
#77 Part 2: Addressing backlog issue about imported registered RKE2 clusters

### DIFF
--- a/docs/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
+++ b/docs/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
@@ -32,7 +32,8 @@ The restore operation will work on a cluster that is not in a healthy or active 
 
 :::note Prerequisites:
 
-- The options below are available only for [Rancher-launched RKE Kubernetes clusters](../../pages-for-subheaders/launch-kubernetes-with-rancher.md) and [Registered K3s Kubernetes clusters.](../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md#additional-features-for-registered-k3s-clusters)
+- The options below are available for [Rancher-launched RKE Kubernetes clusters](../../pages-for-subheaders/launch-kubernetes-with-rancher.md) and [Registered K3s Kubernetes clusters](../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md#additional-features-for-registered-k3s-clusters).
+- The following options also apply to imported RKE2 clusters that you have registered. If you import a cluster from an external cloud platform but don't register it, you won't be able to upgrade the Kubernetes version from Rancher.
 - Before upgrading Kubernetes, [back up your cluster.](../../pages-for-subheaders/backup-restore-and-disaster-recovery.md)
 
 :::

--- a/docs/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
+++ b/docs/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
@@ -32,7 +32,7 @@ The restore operation will work on a cluster that is not in a healthy or active 
 
 :::note Prerequisites:
 
-- The options below are available for [Rancher-launched RKE Kubernetes clusters](../../pages-for-subheaders/launch-kubernetes-with-rancher.md) and [Registered K3s Kubernetes clusters](../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md#additional-features-for-registered-k3s-clusters).
+- The options below are available for [Rancher-launched Kubernetes clusters](../../pages-for-subheaders/launch-kubernetes-with-rancher.md) and [Registered K3s Kubernetes clusters](../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md#additional-features-for-registered-k3s-clusters).
 - The following options also apply to imported RKE2 clusters that you have registered. If you import a cluster from an external cloud platform but don't register it, you won't be able to upgrade the Kubernetes version from Rancher.
 - Before upgrading Kubernetes, [back up your cluster.](../../pages-for-subheaders/backup-restore-and-disaster-recovery.md)
 

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
@@ -32,7 +32,8 @@ The restore operation will work on a cluster that is not in a healthy or active 
 
 :::note Prerequisites:
 
-- The options below are available only for [Rancher-launched RKE Kubernetes clusters](../../pages-for-subheaders/launch-kubernetes-with-rancher.md) and [Registered K3s Kubernetes clusters.](../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md#additional-features-for-registered-k3s-clusters)
+- The options below are available for [Rancher-launched RKE Kubernetes clusters](../../pages-for-subheaders/launch-kubernetes-with-rancher.md) and [Registered K3s Kubernetes clusters.](../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md#additional-features-for-registered-k3s-clusters).
+- The following options also apply to imported RKE2 clusters that you have registered. If you import a cluster from an external cloud platform but don't register it, you won't be able to upgrade the Kubernetes version from Rancher.
 - Before upgrading Kubernetes, [back up your cluster.](../../pages-for-subheaders/backup-restore-and-disaster-recovery.md)
 
 :::

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
@@ -32,7 +32,7 @@ The restore operation will work on a cluster that is not in a healthy or active 
 
 :::note Prerequisites:
 
-- The options below are available for [Rancher-launched RKE Kubernetes clusters](../../pages-for-subheaders/launch-kubernetes-with-rancher.md) and [Registered K3s Kubernetes clusters.](../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md#additional-features-for-registered-k3s-clusters).
+- The options below are available for [Rancher-launched Kubernetes clusters](../../pages-for-subheaders/launch-kubernetes-with-rancher.md) and [Registered K3s Kubernetes clusters.](../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md#additional-features-for-registered-k3s-clusters).
 - The following options also apply to imported RKE2 clusters that you have registered. If you import a cluster from an external cloud platform but don't register it, you won't be able to upgrade the Kubernetes version from Rancher.
 - Before upgrading Kubernetes, [back up your cluster.](../../pages-for-subheaders/backup-restore-and-disaster-recovery.md)
 


### PR DESCRIPTION
Similar to #518, this addresses a comment from the thread inside issue #77.

Question from https://github.com/rancher/rancher-docs/issues/77#issuecomment-1245965086:
> [...] can a registered AKS cluster's version of Kubernetes be upgraded? Can the number of nodes be increased?
> [...] Here it says "The options below are available only for [Rancher-launched RKE Kubernetes clusters](https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/rke-clusters/) and [Registered K3s Kubernetes clusters](https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/registered-clusters/#additional-features-for-registered-k3s-clusters)": https://rancher.com/docs/rancher/v2.6/en/cluster-admin/upgrading-kubernetes/#upgrading-the-kubernetes-version

Answer from https://github.com/rancher/rancher-docs/issues/77#issuecomment-1245965089:
> As far as the third link you included, that is a little out of date. For example, the Kubernetes version of an imported RKE2 cluster can also be upgraded from Rancher. However, if you imported an AKS cluster as a generic cluster instead of registering it as an AKS cluster, then you would not be able to upgrade the Kubernetes version or configure the cluster really at all. Only by registering the cluster as an AKS cluster will you gain the additional functionality in Rancher.