### PR TITLE
Adding GPU limit/reservation to set-container-default-resource-limits.md

### DIFF
--- a/docs/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/set-container-default-resource-limits.md
+++ b/docs/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/set-container-default-resource-limits.md
@@ -37,5 +37,4 @@ The following resource limits can be configured:
 | CPU Reservation          | The minimum amount of CPU (in millicores) guaranteed to the container.                                                                                                       |
 | Memory Limit             | The maximum amount of memory (in bytes) allocated to the container.                                                                                                          |
 | Memory Reservation       | The minimum amount of memory (in bytes) guaranteed to the container.
-
-| NVIDIA GPU Limit/Reservation | 
+| NVIDIA GPU Limit/Reservation | The amount of GPUs allocated to the container. The limit and reservation are always the same for GPUs. |

--- a/docs/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/set-container-default-resource-limits.md
+++ b/docs/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/set-container-default-resource-limits.md
@@ -37,3 +37,5 @@ The following resource limits can be configured:
 | CPU Reservation          | The minimum amount of CPU (in millicores) guaranteed to the container.                                                                                                       |
 | Memory Limit             | The maximum amount of memory (in bytes) allocated to the container.                                                                                                          |
 | Memory Reservation       | The minimum amount of memory (in bytes) guaranteed to the container.
+
+| NVIDIA GPU Limit/Reservation | 

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/set-container-default-resource-limits.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/set-container-default-resource-limits.md
@@ -37,3 +37,4 @@ The following resource limits can be configured:
 | CPU Reservation          | The minimum amount of CPU (in millicores) guaranteed to the container.                                                                                                       |
 | Memory Limit             | The maximum amount of memory (in bytes) allocated to the container.                                                                                                          |
 | Memory Reservation       | The minimum amount of memory (in bytes) guaranteed to the container.
+| NVIDIA GPU Limit/Reservation | The amount of GPUs allocated to the container. The limit and reservation are always the same for GPUs. |


### PR DESCRIPTION
From Rancher UI > Project > Create > Container Default Resource limit  I can see already that NVIDIA GPU limit/reservation is available, although from the resource type section, there is not mention to the GPU