### PR TITLE
Update cert-manager version to 1.11.0

### DIFF
--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
@@ -104,12 +104,12 @@ Fetch the latest cert-manager chart available from the [Helm chart repository](h
 
 :::note
 
-New in v2.6.4, cert-manager versions 1.6.2 and 1.7.1 are compatible. We recommend v1.7.x because v 1.6.x will reach end-of-life on March 30, 2022.
+We recommend cert-manager v1.11.0 for rancher v2.7.
 
 :::
 
 ```plain
-helm fetch jetstack/cert-manager --version v1.7.1
+helm fetch jetstack/cert-manager --version v1.11.0
 ```
 
 
@@ -117,7 +117,7 @@ helm fetch jetstack/cert-manager --version v1.7.1
 
 Download the required CRD file for cert-manager:
    ```plain
-   curl -L -o cert-manager/cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.crds.yaml
+   curl -L -o cert-manager/cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.crds.yaml
    ```
 
 ### 4. Install Rancher
@@ -148,7 +148,7 @@ If you are using self-signed certificates, install cert-manager:
 3. Install cert-manager.
 
     ```plain
-    helm install cert-manager ./cert-manager-v1.7.1.tgz \
+    helm install cert-manager ./cert-manager-v1.11.0.tgz \
         --namespace cert-manager \
         --set image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-controller \
         --set webhook.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-webhook \

--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images.md
@@ -59,7 +59,7 @@ In a Kubernetes Install, if you elect to use the Rancher default self-signed TLS
 
 :::note
 
-New in v2.6.4, cert-manager versions 1.6.2 and 1.7.1 are compatible. We recommend v1.7.x because v 1.6.x will reach end-of-life on March 30, 2022.
+We recommend cert-manager v1.11.0 for rancher v2.7.
 
 :::
 
@@ -74,7 +74,7 @@ New in v2.6.4, cert-manager versions 1.6.2 and 1.7.1 are compatible. We recommen
     ```plain
     helm repo add jetstack https://charts.jetstack.io
     helm repo update
-    helm fetch jetstack/cert-manager --version v1.7.1
+    helm fetch jetstack/cert-manager --version v1.11.0
     helm template ./cert-manager-<version>.tgz | awk '$1 ~ /image:/ {print $2}' | sed s/\"//g >> ./rancher-images.txt
     ```
 
@@ -253,7 +253,7 @@ The workstation must have Docker 18.02+ in order to support manifests, which are
    ```plain
    helm repo add jetstack https://charts.jetstack.io
    helm repo update
-   helm fetch jetstack/cert-manager --version v0.12.0
+   helm fetch jetstack/cert-manager --version v1.11.0
    helm template ./cert-manager-<version>.tgz | awk '$1 ~ /image:/ {print $2}' | sed s/\"//g >> ./rancher-images.txt
    ```
 

--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher.md
@@ -32,19 +32,19 @@ Install the CustomResourceDefinitions of cert-manager:
 
 :::note
 
-New in v2.6.4, cert-manager versions 1.6.2 and 1.7.1 are compatible. We recommend v1.7.x because v 1.6.x will reach end-of-life on March 30, 2022.
+We recommend cert-manager v1.11.0 for rancher v2.7.
 
 :::
 
 ```
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.crds.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.crds.yaml
 ```
 
 And install it with Helm. Note that cert-manager also needs your proxy configured in case it needs to communicate with Let's Encrypt or other external certificate issuers:
 
 ```
 helm upgrade --install cert-manager jetstack/cert-manager \
-  --namespace cert-manager --version v1.7.1 \
+  --namespace cert-manager --version v1.11.0 \
   --set http_proxy=http://${proxy_host} \
   --set https_proxy=http://${proxy_host} \
   --set no_proxy=127.0.0.0/8\\,10.0.0.0/8\\,cattle-system.svc\\,172.16.0.0/12\\,192.168.0.0/16\\,.svc\\,.cluster.local

--- a/docs/getting-started/installation-and-upgrade/resources/upgrade-cert-manager.md
+++ b/docs/getting-started/installation-and-upgrade/resources/upgrade-cert-manager.md
@@ -93,7 +93,7 @@ In order to upgrade cert-manager, follow these instructions:
     helm install \
       cert-manager jetstack/cert-manager \
       --namespace cert-manager \
-      --version v0.12.0
+      --version v1.11.0
     ```
 
 1. [Restore back up resources](https://cert-manager.io/docs/tutorials/backup/#restoring-resources)
@@ -125,7 +125,7 @@ Before you can perform the upgrade, you must prepare your air gapped environment
 1. Fetch the latest cert-manager chart available from the [Helm chart repository](https://artifacthub.io/packages/helm/cert-manager/cert-manager).
 
     ```plain
-    helm fetch jetstack/cert-manager --version v0.12.0
+    helm fetch jetstack/cert-manager --version v1.11.0
     ```
 
 1. Render the cert manager template with the options you would like to use to install the chart. Remember to set the `image.repository` option to pull the image from your private registry. This will create a `cert-manager` directory with the Kubernetes manifest files.
@@ -133,7 +133,7 @@ Before you can perform the upgrade, you must prepare your air gapped environment
     The Helm 3 command is as follows:
 
     ```plain
-    helm template cert-manager ./cert-manager-v0.12.0.tgz --output-dir . \
+    helm template cert-manager ./cert-manager-v1.11.0.tgz --output-dir . \
     --namespace cert-manager \
     --set image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-controller
     --set webhook.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-webhook
@@ -143,7 +143,7 @@ Before you can perform the upgrade, you must prepare your air gapped environment
     The Helm 2 command is as follows:
 
     ```plain
-    helm template ./cert-manager-v0.12.0.tgz --output-dir . \
+    helm template ./cert-manager-v1.11.0.tgz --output-dir . \
     --name cert-manager --namespace cert-manager \
     --set image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-controller
     --set webhook.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-webhook
@@ -260,9 +260,9 @@ cert-manager-webhook-787858fcdb-nlzsq      1/1     Running   0          2m
 ## Cert-Manager API change and data migration
 
 ---
-_New in v2.6.4_
+_New in v2.7.1_
 
-Rancher now supports cert-manager versions 1.6.2 and 1.7.1. We recommend v1.7.x because v 1.6.x will reach end-of-life on March 30, 2022. To read more, see the [cert-manager docs](../../../pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster.md#4-install-cert-manager). For instructions on upgrading cert-manager from version 1.5 to 1.6, see the upstream cert-manager documentation [here](https://cert-manager.io/docs/installation/upgrading/upgrading-1.5-1.6/). For instructions on upgrading cert-manager from version 1.6 to 1.7, see the upstream cert-manager documentation [here](https://cert-manager.io/docs/installation/upgrading/upgrading-1.6-1.7/).
+We recommend cert-manager v1.11.0 for rancher v2.7. To read more, see the [cert-manager docs](../../../pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster.md#4-install-cert-manager). For instructions on upgrading cert-manager, see the upstream cert-manager documentation [here](https://cert-manager.io/docs/installation/upgrading/).
 
 ---
 

--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli.md
@@ -97,7 +97,7 @@ helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
 
 kubectl create namespace cattle-system
 
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.crds.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.crds.yaml
 
 helm repo add jetstack https://charts.jetstack.io
 
@@ -106,13 +106,13 @@ helm repo update
 helm install cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.7.1
+  --version v1.11.0
 
 # Windows Powershell
 helm install cert-manager jetstack/cert-manager `
   --namespace cert-manager `
   --create-namespace `
-  --version v1.7.1
+  --version v1.11.0
 ```
 
 The final command to install Rancher is below. The command requires a domain name that forwards traffic to the Linux machine. For the sake of simplicity in this tutorial, you can use a fake domain name to create your proof-of-concept. An example of a fake domain name would be `<IP_OF_LINUX_NODE>.sslip.io`.

--- a/docs/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster.md
+++ b/docs/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster.md
@@ -145,7 +145,7 @@ These instructions are adapted from the [official cert-manager documentation](ht
 
 ```
 # If you have installed the CRDs manually instead of with the `--set installCRDs=true` option added to your Helm install command, you should upgrade your CRD resources before upgrading the Helm chart:
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.crds.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.crds.yaml
 
 # Add the Jetstack Helm repository
 helm repo add jetstack https://charts.jetstack.io
@@ -157,7 +157,7 @@ helm repo update
 helm install cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.7.1
+  --version v1.11.0
 ```
 
 Once you’ve installed cert-manager, you can verify it is deployed correctly by checking the cert-manager namespace for running pods:


### PR DESCRIPTION
Now that the supported cert-manager version is 1.11.0 the docs need to be updated to reflect that. Updated where relevant and removed outdated instructions.

Issue: https://github.com/rancher/rancher-docs/issues/511

Discussion: https://github.com/rancher/rancher/issues/40880#issuecomment-1475493876