### PR TITLE
Update note about upstream CIS K8s v1.25 benchmark

### DIFF
--- a/docs/pages-for-subheaders/k3s-hardening-guide.md
+++ b/docs/pages-for-subheaders/k3s-hardening-guide.md
@@ -15,7 +15,7 @@ This hardening guide is intended to be used for K3s clusters and is associated w
 | Rancher v2.7    | Benchmark v1.23       | Kubernetes v1.23 up to v1.25 |
 
 :::note
-At the time of writing, the official Kubernetes v1.25 benchmark is still in draft status by CIS. At this time Rancher is using the CIS v1.23 benchmark when scanning Kubernetes v1.25 clusters.
+At the time of writing, the upstream CIS Kubernetes v1.25 benchmark is not yet available in Rancher. At this time Rancher is using the CIS v1.23 benchmark when scanning Kubernetes v1.25 clusters.
 :::
 
 For more details on how to evaluate a hardened K3s cluster against the official CIS benchmark, refer to the K3s self-assessment guides for specific Kubernetes and CIS benchmark versions.

--- a/docs/pages-for-subheaders/rke1-hardening-guide.md
+++ b/docs/pages-for-subheaders/rke1-hardening-guide.md
@@ -15,7 +15,7 @@ This hardening guide is intended to be used for RKE clusters and is associated w
 | Rancher v2.7    | Benchmark v1.23       | Kubernetes v1.23 up to v1.25 |
 
 :::note
-At the time of writing, the official Kubernetes v1.25 benchmark is still in draft status by CIS. At this time Rancher is using the CIS v1.23 benchmark when scanning Kubernetes v1.25 clusters. Due to that, the CIS checks 5.2.3, 5.2.4, 5.2.5 and 5.2.6 might fail.
+At the time of writing, the upstream CIS Kubernetes v1.25 benchmark is not yet available in Rancher. At this time Rancher is using the CIS v1.23 benchmark when scanning Kubernetes v1.25 clusters. Due to that, the CIS checks 5.2.3, 5.2.4, 5.2.5 and 5.2.6 might fail.
 :::
 
 For more details on how to evaluate a hardened RKE cluster against the official CIS benchmark, refer to the RKE self-assessment guides for specific Kubernetes and CIS benchmark versions.

--- a/docs/pages-for-subheaders/rke2-hardening-guide.md
+++ b/docs/pages-for-subheaders/rke2-hardening-guide.md
@@ -15,7 +15,7 @@ This hardening guide is intended to be used for RKE2 clusters and is associated 
 | Rancher v2.7    | Benchmark v1.23       | Kubernetes v1.23 up to v1.25 |
 
 :::note
-At the time of writing, the official Kubernetes v1.25 benchmark is still in draft status by CIS. At this time Rancher is using the CIS v1.23 benchmark when scanning Kubernetes v1.25 clusters. Due to that, the CIS checks 5.2.2, 5.2.3, 5.2.5, 5.2.6, 5.2.7 and 5.2.8 might fail.
+At the time of writing, the upstream CIS Kubernetes v1.25 benchmark is not yet available in Rancher. At this time Rancher is using the CIS v1.23 benchmark when scanning Kubernetes v1.25 clusters. Due to that, the CIS checks 5.2.2, 5.2.3, 5.2.5, 5.2.6, 5.2.7 and 5.2.8 might fail.
 :::
 
 For more details on how to evaluate a hardened RKE2 cluster against the official CIS benchmark, refer to the RKE2 self-assessment guides for specific Kubernetes and CIS benchmark versions.


### PR DESCRIPTION
Update note about upstream CIS K8s v1.25 benchmark availability in Rancher and the hardening guides.

When the hardening guides were updated, the official benchmark for K8s v1.25 was in draft mode by CIS. Now it's already available (it was released 2-3 week ago).