### PR TITLE
532 link to PSA exemptions from custom/imported hardened cluster upgrade guide

### DIFF
--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrade-a-hardened-cluster-to-k8s-v1-25.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrade-a-hardened-cluster-to-k8s-v1-25.md
@@ -4,7 +4,13 @@ title: Upgrade a Hardened Custom/Imported Cluster to Kubernetes v1.25
 
 Kubernetes v1.25 changes how clusters describe and implement security policies. From this version forward, [Pod Security Policies (PSPs)](https://kubernetes.io/docs/concepts/security/pod-security-policy/) are no longer available. Kubernetes v1.25 replaces them with new security objects: [Pod Security Standards (PSS)](https://kubernetes.io/docs/concepts/security/pod-security-standards/), and [Pod Security Admissions (PSAs)](https://kubernetes.io/docs/concepts/security/pod-security-admission/). 
 
-If you have custom or imported hardened clusters, you must make special preparations to ensure that the upgrade from an earlier version of Kubernetes to v1.25 or later goes smoothly.
+If you have custom or imported hardened clusters, you must take special preparations to ensure that the upgrade from an earlier version of Kubernetes to v1.25 or later goes smoothly.
+
+:::note
+
+After you upgrade to v1.25, add the necessary Rancher namespace exemptions. See [Pod Security Admission (PSA) Configuration Templates](./psa-config-templates.md#exempting-required-rancher-namespaces) for more details.
+
+:::
 
 ## Upgrading Imported Hardened Clusters to Kubernetes v1.25 or Later
 

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md
@@ -79,25 +79,9 @@ If you want to allow other users to manage templates, you can bind that user to 
 Any user that is bound to the above permission will be able to change the restriction levels on _all_ managed clusters which use a given PSA template, including ones that they have no permissions on.
 :::
 
-## Exempting Namespaces
+## Required Rancher Namespaces
 
-If you assign the `rancher-restricted` template to a cluster, by default the restrictions are applied across the entire cluster at the namespace level. To exempt certain namespaces from this highly restricted policy, do the following:
-
-1. In the upper left corner, click **☰ > Cluster Management**.
-1. Click **Advanced** to open the dropdown menu.
-1. Select **Pod Security Admissions**.
-1. Find the template you want to modify, and click the **⋮**.
-1. Select **Edit Config**.
-1. Click the **Namespaces** checkbox under **Exemptions** to edit the **Namespaces** field.
-1. When you're done exempting namespaces, click **Save**.
-
-:::note
-You need to update the target cluster to make the new template take effect in that cluster. An update can be triggered by editing and saving the cluster without changing values.
-:::
-
-### Exempting Required Rancher Namespaces
-
-When you run Rancher on a Kubernetes cluster that enforces a restrictive security policy by default, you will need to [exempt the following namespaces](./psa-config-templates.md#exempting-namespaces), otherwise the policy might prevent Rancher system pods from properly running.
+When you run Rancher on a Kubernetes cluster that enforces a restrictive security policy by default, you'll need to [exempt the following namespaces](./psa-config-templates.md#exempting-namespaces), otherwise the policy might prevent Rancher system pods from  running properly.
 
 - `calico-apiserver`
 - `calico-system`
@@ -136,3 +120,19 @@ When you run Rancher on a Kubernetes cluster that enforces a restrictive securit
 - `tigera-operator`
 
 Rancher, some Rancher owned charts, and RKE2 and K3s distributions all use these namespaces. A subset of the listed namespaces are already exempt in the built-in Rancher `rancher-restricted` policy, for use in downstream clusters. For a complete template which has all the exemptions you need to run Rancher, please refer to this [sample Admission Configuration](../../../reference-guides/rancher-security/psa-restricted-exemptions.md).
+
+## Exempting Namespaces
+
+If you assign the `rancher-restricted` template to a cluster, by default the restrictions are applied across the entire cluster at the namespace level. To exempt certain namespaces from this highly restricted policy, do the following:
+
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Click **Advanced** to open the dropdown menu.
+1. Select **Pod Security Admissions**.
+1. Find the template you want to modify, and click the **⋮**.
+1. Select **Edit Config**.
+1. Click the **Namespaces** checkbox under **Exemptions** to edit the **Namespaces** field.
+1. When you're done exempting namespaces, click **Save**.
+
+:::note
+You need to update the target cluster to make the new template take effect in that cluster. An update can be triggered by editing and saving the cluster without changing values.
+:::


### PR DESCRIPTION
Fixes #532 

Page https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrade-a-hardened-cluster-to-k8s-v1-25#upgrading-imported-hardened-clusters-to-kubernetes-v125-or-later lacked a note about exempting certain namespaces.

I added the note and linked to the page where we list the namespaces and provide instructions for exempting them.

I also reorganized the page I linked to, so that instructions come after the list, instead of the list being a subsection of the instructions. I think that makes more sense, since the majority of readers will be seeking instructions to exempt the listed namespaces