### PR TITLE
Update copyright year in ZH docs

### DIFF
--- a/i18n/zh/docusaurus-theme-classic/footer.json
+++ b/i18n/zh/docusaurus-theme-classic/footer.json
@@ -1,6 +1,6 @@
 {
   "copyright": {
-    "message": "Copyright © 2022 SUSE Rancher. All Rights Reserved.",
+    "message": "Copyright © 2023 SUSE Rancher. All Rights Reserved.",
     "description": "The footer copyright"
   }
 }


### PR DESCRIPTION
Changes the year from 2022 to 2023 at the footer