### PR TITLE
Updated reference to 2.6 installation requirements in the 2.7 docs

### DIFF
--- a/docs/reference-guides/best-practices/rancher-server/on-premises-rancher-in-vsphere.md
+++ b/docs/reference-guides/best-practices/rancher-server/on-premises-rancher-in-vsphere.md
@@ -39,7 +39,7 @@ Configure appropriate Firewall / ACL rules to only expose access to Rancher
 
 ### Size the VM's According to Rancher Documentation
 
-https://rancher.com/docs/rancher/v2.6/en/installation/requirements/
+https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-requirements
 
 ### Leverage VM Templates to Construct the Environment
 

--- a/docs/reference-guides/best-practices/rancher-server/on-premises-rancher-in-vsphere.md
+++ b/docs/reference-guides/best-practices/rancher-server/on-premises-rancher-in-vsphere.md
@@ -39,7 +39,7 @@ Configure appropriate Firewall / ACL rules to only expose access to Rancher
 
 ### Size the VM's According to Rancher Documentation
 
-https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-requirements
+See [Installation Requirements](https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-requirements).
 
 ### Leverage VM Templates to Construct the Environment
 


### PR DESCRIPTION

Replaced this url https://rancher.com/docs/rancher/v2.6/en/installation/requirements/ by the new one for Rancher 2.7: https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-requirements