### PR TITLE
Add admonition for caveat on finding PSPs in use

### DIFF
--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/pod-security-standards.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/pod-security-standards.md
@@ -25,7 +25,7 @@ You must perform the following steps _while still in Kubernetes v1.24_:
 1. Map your active PSPs to Pod Security Standards:
     1. See which PSPs are still active in your cluster:
        :::caution
-       This strategy may miss workloads that are not currently running, such as CronJobs, workloads that scale to zero, or workloads that have not rolled out yet.
+       This strategy may miss workloads that aren't currently running, such as CronJobs, workloads that scale to zero, or workloads that haven't rolled out yet.
        :::
        
        ```shell

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/pod-security-standards.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/pod-security-standards.md
@@ -24,6 +24,10 @@ You must perform the following steps _while still in Kubernetes v1.24_:
 
 1. Map your active PSPs to Pod Security Standards:
     1. See which PSPs are still active in your cluster:
+       :::caution
+       This strategy might miss workloads that are not currently running, such as CronJobs, workloads that scale to zero, or workloads that have not rolled out yet.
+       :::
+       
        ```shell
        kubectl get pods \
          --all-namespaces \

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/pod-security-standards.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/pod-security-standards.md
@@ -25,7 +25,7 @@ You must perform the following steps _while still in Kubernetes v1.24_:
 1. Map your active PSPs to Pod Security Standards:
     1. See which PSPs are still active in your cluster:
        :::caution
-       This strategy might miss workloads that are not currently running, such as CronJobs, workloads that scale to zero, or workloads that have not rolled out yet.
+       This strategy may miss workloads that are not currently running, such as CronJobs, workloads that scale to zero, or workloads that have not rolled out yet.
        :::
        
        ```shell

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/pod-security-standards.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/pod-security-standards.md
@@ -25,7 +25,7 @@ You must perform the following steps _while still in Kubernetes v1.24_:
 1. Map your active PSPs to Pod Security Standards:
     1. See which PSPs are still active in your cluster:
        :::caution
-       This strategy may miss workloads that aren't currently running, such as CronJobs, workloads that scale to zero, or workloads that haven't rolled out yet.
+       This strategy may miss workloads that aren't currently running, such as CronJobs, workloads currently scaled to zero, or workloads that haven't rolled out yet.
        :::
        
        ```shell


### PR DESCRIPTION
Add a caution admonition for a caveat on using the `kubectl get psp` strategy to find which PSPs are still in use in the cluster.