### PR TITLE
Fixes #552 - Update helm-chart-options.md with PSP Helm value

### DIFF
--- a/docs/getting-started/installation-and-upgrade/installation-references/helm-chart-options.md
+++ b/docs/getting-started/installation-and-upgrade/installation-references/helm-chart-options.md
@@ -57,7 +57,7 @@ For information on enabling experimental features, refer to [this page.](../../.
 | `systemDefaultRegistry`        | ""                                                    | `string` - private registry to be used for all system container images, e.g., http://registry.example.com/                   |
 | `tls`                          | "ingress"                                             | `string` - See [External TLS Termination](#external-tls-termination) for details. - "ingress, external"                                           |
 | `useBundledSystemChart`        | `false`                                               | `bool` - select to use the system-charts packaged with Rancher server. This option is used for air gapped installations.  |
-| `global.cattle.psp.enabled`        | `true`                                               | `bool` - select 'false' to disable PSP for RKE/RKE2 (K8S) versions `v1.25` and higher.  |
+| `global.cattle.psp.enabled`        | `true`                                               | `bool` - select 'false' to disable PSP for RKE/RKE2 (K8s) versions `v1.25` and higher.  |
 
 
 ### Bootstrap Password

--- a/docs/getting-started/installation-and-upgrade/installation-references/helm-chart-options.md
+++ b/docs/getting-started/installation-and-upgrade/installation-references/helm-chart-options.md
@@ -57,7 +57,7 @@ For information on enabling experimental features, refer to [this page.](../../.
 | `systemDefaultRegistry`        | ""                                                    | `string` - private registry to be used for all system container images, e.g., http://registry.example.com/                   |
 | `tls`                          | "ingress"                                             | `string` - See [External TLS Termination](#external-tls-termination) for details. - "ingress, external"                                           |
 | `useBundledSystemChart`        | `false`                                               | `bool` - select to use the system-charts packaged with Rancher server. This option is used for air gapped installations.  |
-
+| `global.cattle.psp.enabled`        | `true`                                               | `bool` - select 'false' to disable PSP for RKE/RKE2 (K8S) versions `v1.25` and higher.  |
 
 
 ### Bootstrap Password


### PR DESCRIPTION
when the transition to v1.25 disabling the PSP is needed to install.