### PR TITLE
Follow-up to #548: convert to relative link

### DIFF
--- a/docs/reference-guides/best-practices/rancher-server/on-premises-rancher-in-vsphere.md
+++ b/docs/reference-guides/best-practices/rancher-server/on-premises-rancher-in-vsphere.md
@@ -39,7 +39,7 @@ Configure appropriate Firewall / ACL rules to only expose access to Rancher
 
 ### Size the VM's According to Rancher Documentation
 
-See [Installation Requirements](https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-requirements).
+See [Installation Requirements](../../../pages-for-subheaders/installation-requirements.md).
 
 ### Leverage VM Templates to Construct the Environment
 

--- a/versioned_docs/version-2.6/reference-guides/best-practices/rancher-server/on-premises-rancher-in-vsphere.md
+++ b/versioned_docs/version-2.6/reference-guides/best-practices/rancher-server/on-premises-rancher-in-vsphere.md
@@ -39,7 +39,7 @@ Configure appropriate Firewall / ACL rules to only expose access to Rancher
 
 ### Size the VM's According to Rancher Documentation
 
-https://rancher.com/docs/rancher/v2.6/en/installation/requirements/
+See [Installation Requirements](../../../pages-for-subheaders/installation-requirements.md).
 
 ### Leverage VM Templates to Construct the Environment
 


### PR DESCRIPTION
This is a follow-up to https://github.com/rancher/rancher-docs/pull/548. Since the modified link is an internal link, a relative link should be used to allow for future maintainability (e.g. versioning between pages, domain changes). 