### PR TITLE
#536 Updating info about nginx helm charts

### DIFF
--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -79,7 +79,7 @@ This command merges your cluster's credentials into the existing kubeconfig and 
 
 The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription.
 
-The following command installs an `nginx-ingress-controller` with a Kubernetes load balancer service.
+The following command installs an `nginx-ingress-controller` with a Kubernetes load balancer service. 
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
@@ -88,9 +88,11 @@ helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \
   --set controller.service.type=LoadBalancer \
-  --version 4.0.18 \
+  --version 4.6.0 \
   --create-namespace
 ```
+
+Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes. For older versions of nginx or Kubernetes, see the [official nginx documentation]((https://docs.nginx.com/nginx-ingress-controller/technical-specifications/#supported-kubernetes-versions)) listing supported Kubernetes versions.
 
 ## 6. Get Load Balancer IP
 

--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -85,6 +85,7 @@ Then, list the helm charts available to you by running the following command:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
 helm search repo ingress-nginx -l
 ```
 
@@ -93,8 +94,6 @@ Select a chart version that bundles an app compatible with your Kubernetes insta
 Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
 ```
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
 helm search repo ingress-nginx -l
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \

--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -79,11 +79,23 @@ This command merges your cluster's credentials into the existing kubeconfig and 
 
 The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription.
 
-The following command installs an `nginx-ingress-controller` with a Kubernetes load balancer service. 
+To make sure that you choose the correct Ingress-NGINX helm chart, first find an app version that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
+
+Then, list the helm charts available to you by running the following command:
+
+```
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm search repo ingress-nginx -l
+```
+
+Select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.24, you can select the v4.6.0 helm chart, since Ingress-NGINX v1.70 comes bundled with that chart, and v1.70 is compatible with Kubernetes v1.24. When in doubt, select the most recent compatible version.
+
+Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo update
+helm search repo ingress-nginx -l
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \
@@ -91,8 +103,6 @@ helm upgrade --install \
   --version 4.6.0 \
   --create-namespace
 ```
-
-Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes.
 
 ## 6. Get Load Balancer IP
 

--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -81,7 +81,7 @@ The cluster needs an Ingress so that Rancher can be accessed from outside the cl
 
 To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
 
-Then, list the helm charts available to you by running the following command:
+Then, list the Helm charts available to you by running the following command:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx

--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -92,7 +92,7 @@ helm upgrade --install \
   --create-namespace
 ```
 
-Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes. For older versions of nginx or Kubernetes, see the [official nginx documentation]((https://docs.nginx.com/nginx-ingress-controller/technical-specifications/#supported-kubernetes-versions)) listing supported Kubernetes versions.
+Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes. For older versions of ingress-nginx or Kubernetes, see the [official NGINX documentation](https://docs.nginx.com/nginx-ingress-controller/technical-specifications/#supported-kubernetes-versions) listing supported Kubernetes versions.
 
 ## 6. Get Load Balancer IP
 

--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -79,7 +79,7 @@ This command merges your cluster's credentials into the existing kubeconfig and 
 
 The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription.
 
-To make sure that you choose the correct Ingress-NGINX helm chart, first find an app version that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
+To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
 
 Then, list the helm charts available to you by running the following command:
 
@@ -89,9 +89,9 @@ helm repo update
 helm search repo ingress-nginx -l
 ```
 
-Select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.24, you can select the v4.6.0 helm chart, since Ingress-NGINX v1.70 comes bundled with that chart, and v1.70 is compatible with Kubernetes v1.24. When in doubt, select the most recent compatible version.
+The `helm search` command's output contains a `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.24, you can select the v4.6.0 Helm chart, since Ingress-NGINX v1.70 comes bundled with that chart, and v1.70 is compatible with Kubernetes v1.24. When in doubt, select the most recent compatible version.
 
-Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
+Now that you know which Helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
 ```
 helm search repo ingress-nginx -l

--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -92,7 +92,7 @@ helm upgrade --install \
   --create-namespace
 ```
 
-Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes. For older versions of ingress-nginx or Kubernetes, see the [official NGINX documentation](https://docs.nginx.com/nginx-ingress-controller/technical-specifications/#supported-kubernetes-versions) listing supported Kubernetes versions.
+Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes.
 
 ## 6. Get Load Balancer IP
 

--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -89,7 +89,7 @@ helm repo update
 helm search repo ingress-nginx -l
 ```
 
-The `helm search` command's output contains a `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.24, you can select the v4.6.0 Helm chart, since Ingress-NGINX v1.70 comes bundled with that chart, and v1.70 is compatible with Kubernetes v1.24. When in doubt, select the most recent compatible version.
+The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.24, you can select the v4.6.0 Helm chart, since Ingress-NGINX v1.7.0 comes bundled with that chart, and v1.7.0 is compatible with Kubernetes v1.24. When in doubt, select the most recent compatible version.
 
 Now that you know which Helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 

--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -123,6 +123,7 @@ Then, list the helm charts available to you by running the following command:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
 helm search repo ingress-nginx -l
 ```
 
@@ -131,8 +132,6 @@ Select a chart version that bundles an app compatible with your Kubernetes insta
 Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
 ```
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \

--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -119,7 +119,7 @@ The cluster needs an Ingress so that Rancher can be accessed from outside the cl
 
 To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
 
-Then, list the helm charts available to you by running the following command:
+Then, list the Helm charts available to you by running the following command:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
@@ -127,9 +127,9 @@ helm repo update
 helm search repo ingress-nginx -l
 ```
 
-The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.6.0 helm chart, since Ingress-NGINX v1.7.0 comes bundled with that chart, and v1.7.0 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
+The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.6.0 Helm chart, since Ingress-NGINX v1.7.0 comes bundled with that chart, and v1.7.0 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
 
-Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
+Now that you know which Helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
 ```
 helm upgrade --install \

--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -130,6 +130,8 @@ helm upgrade --install \
   --create-namespace
 ```
 
+Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes. For older versions of ingress-nginx or Kubernetes, see the [official NGINX documentation](https://docs.nginx.com/nginx-ingress-controller/technical-specifications/#supported-kubernetes-versions) listing supported Kubernetes versions.
+
 ### 6. Get Load Balancer IP
 
 To get the address of the load balancer, run:

--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -117,7 +117,18 @@ rancher-server-cluster		us-west-2	True
 
 The cluster needs an Ingress so that Rancher can be accessed from outside the cluster.
 
-The following command installs an `nginx-ingress-controller` with a LoadBalancer service. This will result in an ELB (Elastic Load Balancer) in front of NGINX:
+To make sure that you choose the correct Ingress-NGINX helm chart, first find an app version that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
+
+Then, list the helm charts available to you by running the following command:
+
+```
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm search repo ingress-nginx -l
+```
+
+Select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.0.18 helm chart, since Ingress-NGINX v1.70 comes bundled with that chart, and v1.70 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
+
+Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
@@ -129,8 +140,6 @@ helm upgrade --install \
   --version 4.0.18 \
   --create-namespace
 ```
-
-Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes.
 
 ### 6. Get Load Balancer IP
 

--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -117,7 +117,7 @@ rancher-server-cluster		us-west-2	True
 
 The cluster needs an Ingress so that Rancher can be accessed from outside the cluster.
 
-To make sure that you choose the correct Ingress-NGINX helm chart, first find an app version that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
+To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
 
 Then, list the helm charts available to you by running the following command:
 
@@ -127,7 +127,7 @@ helm repo update
 helm search repo ingress-nginx -l
 ```
 
-Select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.0.18 helm chart, since Ingress-NGINX v1.70 comes bundled with that chart, and v1.70 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
+The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.6.0 helm chart, since Ingress-NGINX v1.7.0 comes bundled with that chart, and v1.7.0 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
 
 Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
@@ -136,7 +136,7 @@ helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \
   --set controller.service.type=LoadBalancer \
-  --version 4.0.18 \
+  --version 4.6.0 \
   --create-namespace
 ```
 

--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -130,7 +130,7 @@ helm upgrade --install \
   --create-namespace
 ```
 
-Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes. For older versions of ingress-nginx or Kubernetes, see the [official NGINX documentation](https://docs.nginx.com/nginx-ingress-controller/technical-specifications/#supported-kubernetes-versions) listing supported Kubernetes versions.
+Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes.
 
 ### 6. Get Load Balancer IP
 

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -72,7 +72,7 @@ The cluster needs an Ingress so that Rancher can be accessed from outside the cl
 
 To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
 
-Then, list the helm charts available to you by running the following command:
+Then, list the Helm charts available to you by running the following command:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
@@ -80,9 +80,9 @@ helm repo update
 helm search repo ingress-nginx -l
 ```
 
-The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.20, you can select the v4.2.5 helm chart, since Ingress-NGINX v1.3.1 comes bundled with that chart, and v1.3.1 is compatible with Kubernetes v1.20. When in doubt, select the most recent compatible version.
+The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.20, you can select the v4.2.5 Helm chart, since Ingress-NGINX v1.3.1 comes bundled with that chart, and v1.3.1 is compatible with Kubernetes v1.20. When in doubt, select the most recent compatible version.
 
-Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
+Now that you know which Helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
 ```
 helm upgrade --install \

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -70,7 +70,7 @@ This command merges your cluster's credentials into the existing kubeconfig and 
 
 The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription.
 
-To choose the correct Ingress-NGINX helm chart, first find an app version that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
+To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
 
 Then, list the helm charts available to you by running the following command:
 
@@ -80,15 +80,16 @@ helm repo update
 helm search repo ingress-nginx -l
 ```
 
-Select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.0.18 helm chart, since Ingress-NGINX v1.70 comes bundled with that chart, and v1.70 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
+The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.20, you can select the v4.2.5 helm chart, since Ingress-NGINX v1.3.1 comes bundled with that chart, and v1.3.1 is compatible with Kubernetes v1.20. When in doubt, select the most recent compatible version.
 
 Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
+
 ```
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \
   --set controller.service.type=LoadBalancer \
-  --version 3.12.0 \
+  --version 4.2.5 \
   --create-namespace
 ```
 

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -45,7 +45,20 @@ az group create --name rancher-rg --location eastus
 
 To create an AKS cluster, run the following command. Use a VM size that applies to your use case. Refer to [this article](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes) for available sizes and options. 
 
-When choosing a Kubernetes version, be sure to first consult the [support matrix](https://rancher.com/support-matrix/) to find the highest version of Kubernetes that has been validated for your Rancher version. See the [official NGINX helm chart documentation](https://docs.nginx.com/nginx-ingress-controller/technical-specifications/#supported-kubernetes-versions) listing supported Kubernetes versions for ingress-nginx.
+When choosing a Kubernetes version, be sure to first consult the [support matrix](https://rancher.com/support-matrix/) to find the highest version of Kubernetes that has been validated for your Rancher version. 
+
+To choose the correct Ingress-NGINX helm chart, first find an app version that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
+
+Then, list the helm charts available to you by running the following command:
+
+```
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm search repo ingress-nginx -l
+```
+
+Select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.0.18 helm chart, since Ingress-NGINX v1.70 comes bundled with that chart, and v1.70 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
+
+Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
 ```
 az aks create \

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -45,20 +45,7 @@ az group create --name rancher-rg --location eastus
 
 To create an AKS cluster, run the following command. Use a VM size that applies to your use case. Refer to [this article](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes) for available sizes and options. 
 
-When choosing a Kubernetes version, be sure to first consult the [support matrix](https://rancher.com/support-matrix/) to find the highest version of Kubernetes that has been validated for your Rancher version. 
-
-To choose the correct Ingress-NGINX helm chart, first find an app version that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
-
-Then, list the helm charts available to you by running the following command:
-
-```
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm search repo ingress-nginx -l
-```
-
-Select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.0.18 helm chart, since Ingress-NGINX v1.70 comes bundled with that chart, and v1.70 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
-
-Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
+When choosing a Kubernetes version, be sure to first consult the [support matrix](https://rancher.com/support-matrix/) to find the highest version of Kubernetes that has been validated for your Rancher version.
 
 ```
 az aks create \
@@ -85,11 +72,20 @@ This command merges your cluster's credentials into the existing kubeconfig and 
 
 The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription.
 
-The following command installs an `nginx-ingress-controller` with a Kubernetes load balancer service.
+To choose the correct Ingress-NGINX helm chart, first find an app version that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
+
+Then, list the helm charts available to you by running the following command:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo update
+helm search repo ingress-nginx -l
+```
+
+Select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.0.18 helm chart, since Ingress-NGINX v1.70 comes bundled with that chart, and v1.70 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
+
+Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
+```
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -43,7 +43,9 @@ az group create --name rancher-rg --location eastus
 
 ## 3. Create the AKS Cluster
 
-To create an AKS cluster, run the following command. Use a VM size that applies to your use case. Refer to [this article](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes) for available sizes and options. When choosing a Kubernetes version, be sure to first consult the [support matrix](https://rancher.com/support-matrix/) to find the highest version of Kubernetes that has been validated for your Rancher version.
+To create an AKS cluster, run the following command. Use a VM size that applies to your use case. Refer to [this article](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes) for available sizes and options. 
+
+When choosing a Kubernetes version, be sure to first consult the [support matrix](https://rancher.com/support-matrix/) to find the highest version of Kubernetes that has been validated for your Rancher version. See the [official NGINX helm chart documentation](https://docs.nginx.com/nginx-ingress-controller/technical-specifications/#supported-kubernetes-versions) listing supported Kubernetes versions for ingress-nginx.
 
 ```
 az aks create \

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -43,9 +43,7 @@ az group create --name rancher-rg --location eastus
 
 ## 3. Create the AKS Cluster
 
-To create an AKS cluster, run the following command. Use a VM size that applies to your use case. Refer to [this article](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes) for available sizes and options. 
-
-When choosing a Kubernetes version, be sure to first consult the [support matrix](https://rancher.com/support-matrix/) to find the highest version of Kubernetes that has been validated for your Rancher version.
+To create an AKS cluster, run the following command. Use a VM size that applies to your use case. Refer to [this article](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes) for available sizes and options. When choosing a Kubernetes version, be sure to first consult the [support matrix](https://rancher.com/support-matrix/) to find the highest version of Kubernetes that has been validated for your Rancher version.
 
 ```
 az aks create \

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -121,6 +121,7 @@ Then, list the helm charts available to you by running the following command:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
 helm search repo ingress-nginx -l
 ```
 
@@ -129,8 +130,6 @@ Select a chart version that bundles an app compatible with your Kubernetes insta
 Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
 ```
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -128,6 +128,8 @@ helm upgrade --install \
   --create-namespace
 ```
 
+Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the Helm chart `--version` that supports your version of Kubernetes. For older versions of ingress-nginx or Kubernetes, see the [official NGINX documentation](https://docs.nginx.com/nginx-ingress-controller/technical-specifications/#supported-kubernetes-versions) listing supported Kubernetes versions.
+
 ### 6. Get Load Balancer IP
 
 To get the address of the load balancer, run:

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -115,7 +115,7 @@ rancher-server-cluster		us-west-2	True
 
 The cluster needs an Ingress so that Rancher can be accessed from outside the cluster.
 
-To make sure that you choose the correct Ingress-NGINX helm chart, first find an app version that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
+To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
 
 Then, list the helm charts available to you by running the following command:
 
@@ -125,7 +125,7 @@ helm repo update
 helm search repo ingress-nginx -l
 ```
 
-Select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.0.18 helm chart, since Ingress-NGINX v1.70 comes bundled with that chart, and v1.70 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
+The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.20, you can select the v4.2.5 helm chart, since Ingress-NGINX v1.3.1 comes bundled with that chart, and v1.3.1 is compatible with Kubernetes v1.20. When in doubt, select the most recent compatible version.
 
 Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
@@ -134,7 +134,7 @@ helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \
   --set controller.service.type=LoadBalancer \
-  --version 3.12.0 \
+  --version 4.2.5 \
   --create-namespace
 ```
 

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -117,7 +117,7 @@ The cluster needs an Ingress so that Rancher can be accessed from outside the cl
 
 To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
 
-Then, list the helm charts available to you by running the following command:
+Then, list the Helm charts available to you by running the following command:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
@@ -125,9 +125,9 @@ helm repo update
 helm search repo ingress-nginx -l
 ```
 
-The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.20, you can select the v4.2.5 helm chart, since Ingress-NGINX v1.3.1 comes bundled with that chart, and v1.3.1 is compatible with Kubernetes v1.20. When in doubt, select the most recent compatible version.
+The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.20, you can select the v4.2.5 Helm chart, since Ingress-NGINX v1.3.1 comes bundled with that chart, and v1.3.1 is compatible with Kubernetes v1.20. When in doubt, select the most recent compatible version.
 
-Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
+Now that you know which Helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
 ```
 helm upgrade --install \

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -115,7 +115,18 @@ rancher-server-cluster		us-west-2	True
 
 The cluster needs an Ingress so that Rancher can be accessed from outside the cluster.
 
-The following command installs an `nginx-ingress-controller` with a LoadBalancer service. This will result in an ELB (Elastic Load Balancer) in front of NGINX:
+To make sure that you choose the correct Ingress-NGINX helm chart, first find an app version that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
+
+Then, list the helm charts available to you by running the following command:
+
+```
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm search repo ingress-nginx -l
+```
+
+Select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.0.18 helm chart, since Ingress-NGINX v1.70 comes bundled with that chart, and v1.70 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
+
+Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
@@ -127,8 +138,6 @@ helm upgrade --install \
   --version 3.12.0 \
   --create-namespace
 ```
-
-Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the Helm chart `--version` that supports your version of Kubernetes.
 
 ### 6. Get Load Balancer IP
 

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -128,7 +128,7 @@ helm upgrade --install \
   --create-namespace
 ```
 
-Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the Helm chart `--version` that supports your version of Kubernetes. For older versions of ingress-nginx or Kubernetes, see the [official NGINX documentation](https://docs.nginx.com/nginx-ingress-controller/technical-specifications/#supported-kubernetes-versions) listing supported Kubernetes versions.
+Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the Helm chart `--version` that supports your version of Kubernetes.
 
 ### 6. Get Load Balancer IP
 

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -92,6 +92,8 @@ helm upgrade --install \
   --create-namespace
 ```
 
+Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes. For older versions of ingress-nginx or Kubernetes, see the [official NGINX documentation](https://docs.nginx.com/nginx-ingress-controller/technical-specifications/#supported-kubernetes-versions) listing supported Kubernetes versions.
+
 ## 6. Get Load Balancer IP
 
 To get the address of the load balancer, run:

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -79,7 +79,18 @@ This command merges your cluster's credentials into the existing kubeconfig and 
 
 The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription.
 
-The following command installs an `nginx-ingress-controller` with a Kubernetes load balancer service.
+To make sure that you choose the correct Ingress-NGINX helm chart, first find an app version that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
+
+Then, list the helm charts available to you by running the following command:
+
+```
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm search repo ingress-nginx -l
+```
+
+Select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.0.18 helm chart, since Ingress-NGINX v1.70 comes bundled with that chart, and v1.70 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
+
+Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
@@ -91,8 +102,6 @@ helm upgrade --install \
   --version 4.0.18 \
   --create-namespace
 ```
-
-Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes.
 
 ## 6. Get Load Balancer IP
 

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -81,7 +81,7 @@ The cluster needs an Ingress so that Rancher can be accessed from outside the cl
 
 To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
 
-Then, list the helm charts available to you by running the following command:
+Then, list the Helm charts available to you by running the following command:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
@@ -89,9 +89,9 @@ helm repo update
 helm search repo ingress-nginx -l
 ```
 
-The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.5.2 helm chart, since Ingress-NGINX v1.6.4 comes bundled with that chart, and v1.6.4 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
+The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.5.2 Helm chart, since Ingress-NGINX v1.6.4 comes bundled with that chart, and v1.6.4 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
 
-Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
+Now that you know which Helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
 ```
 helm upgrade --install \

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -92,7 +92,7 @@ helm upgrade --install \
   --create-namespace
 ```
 
-Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes. For older versions of ingress-nginx or Kubernetes, see the [official NGINX documentation](https://docs.nginx.com/nginx-ingress-controller/technical-specifications/#supported-kubernetes-versions) listing supported Kubernetes versions.
+Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes.
 
 ## 6. Get Load Balancer IP
 

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -79,7 +79,7 @@ This command merges your cluster's credentials into the existing kubeconfig and 
 
 The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription.
 
-To make sure that you choose the correct Ingress-NGINX helm chart, first find an app version that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
+To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
 
 Then, list the helm charts available to you by running the following command:
 
@@ -89,7 +89,7 @@ helm repo update
 helm search repo ingress-nginx -l
 ```
 
-Select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.0.18 helm chart, since Ingress-NGINX v1.70 comes bundled with that chart, and v1.70 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
+The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.5.2 helm chart, since Ingress-NGINX v1.6.4 comes bundled with that chart, and v1.6.4 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
 
 Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
@@ -98,7 +98,7 @@ helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \
   --set controller.service.type=LoadBalancer \
-  --version 4.0.18 \
+  --version 4.5.2 \
   --create-namespace
 ```
 

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md
@@ -85,6 +85,7 @@ Then, list the helm charts available to you by running the following command:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
 helm search repo ingress-nginx -l
 ```
 
@@ -93,8 +94,6 @@ Select a chart version that bundles an app compatible with your Kubernetes insta
 Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
 ```
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -123,6 +123,7 @@ Then, list the helm charts available to you by running the following command:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
 helm search repo ingress-nginx -l
 ```
 
@@ -131,8 +132,6 @@ Select a chart version that bundles an app compatible with your Kubernetes insta
 Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
 ```
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -117,7 +117,18 @@ rancher-server-cluster		us-west-2	True
 
 The cluster needs an Ingress so that Rancher can be accessed from outside the cluster.
 
-The following command installs an `nginx-ingress-controller` with a LoadBalancer service. This will result in an ELB (Elastic Load Balancer) in front of NGINX:
+To make sure that you choose the correct Ingress-NGINX helm chart, first find an app version that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
+
+Then, list the helm charts available to you by running the following command:
+
+```
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm search repo ingress-nginx -l
+```
+
+Select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.0.18 helm chart, since Ingress-NGINX v1.70 comes bundled with that chart, and v1.70 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
+
+Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -117,7 +117,7 @@ rancher-server-cluster		us-west-2	True
 
 The cluster needs an Ingress so that Rancher can be accessed from outside the cluster.
 
-To make sure that you choose the correct Ingress-NGINX helm chart, first find an app version that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
+To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
 
 Then, list the helm charts available to you by running the following command:
 
@@ -127,7 +127,7 @@ helm repo update
 helm search repo ingress-nginx -l
 ```
 
-Select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.0.18 helm chart, since Ingress-NGINX v1.70 comes bundled with that chart, and v1.70 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
+The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.5.2 helm chart, since Ingress-NGINX v1.6.4 comes bundled with that chart, and v1.6.4 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
 
 Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
@@ -136,7 +136,7 @@ helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \
   --set controller.service.type=LoadBalancer \
-  --version 4.0.18 \
+  --version 4.5.2 \
   --create-namespace
 ```
 

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -130,6 +130,8 @@ helm upgrade --install \
   --create-namespace
 ```
 
+Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes. For older versions of ingress-nginx or Kubernetes, see the [official NGINX documentation](https://docs.nginx.com/nginx-ingress-controller/technical-specifications/#supported-kubernetes-versions) listing supported Kubernetes versions.
+
 ### 6. Get Load Balancer IP
 
 To get the address of the load balancer, run:

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -119,7 +119,7 @@ The cluster needs an Ingress so that Rancher can be accessed from outside the cl
 
 To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the [Kubernetes/ingress-nginx support table](https://github.com/kubernetes/ingress-nginx#supported-versions-table). 
 
-Then, list the helm charts available to you by running the following command:
+Then, list the Helm charts available to you by running the following command:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
@@ -127,9 +127,9 @@ helm repo update
 helm search repo ingress-nginx -l
 ```
 
-The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.5.2 helm chart, since Ingress-NGINX v1.6.4 comes bundled with that chart, and v1.6.4 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
+The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kuberntes v1.23, you can select the v4.5.2 Helm chart, since Ingress-NGINX v1.6.4 comes bundled with that chart, and v1.6.4 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
 
-Now that you know which helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
+Now that you know which Helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
 
 ```
 helm upgrade --install \
@@ -139,8 +139,6 @@ helm upgrade --install \
   --version 4.5.2 \
   --create-namespace
 ```
-
-Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes.
 
 ### 6. Get Load Balancer IP
 

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md
@@ -130,7 +130,7 @@ helm upgrade --install \
   --create-namespace
 ```
 
-Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes. For older versions of ingress-nginx or Kubernetes, see the [official NGINX documentation](https://docs.nginx.com/nginx-ingress-controller/technical-specifications/#supported-kubernetes-versions) listing supported Kubernetes versions.
+Consult the [official ingress-nginx Helm chart changelog](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md) to find the  Helm chart `--version` that supports your version of Kubernetes.
 
 ### 6. Get Load Balancer IP
 


### PR DESCRIPTION
Fixes #536

The situation is still kind of confusing. Nginx has a compatibility table at https://docs.nginx.com/nginx-ingress-controller/technical-specifications/#supported-kubernetes-versions but the latest charts (4.x) aren't listed, and it's not clear to me why. 

Development on 3.x continues and supported Kubernetes versions for 3.x charts overlap with 4.x charts. 

Information about which Kubernetes versions are supported by 4.x can be found in https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.6.0/charts/ingress-nginx/CHANGELOG.md, but only as far back as 4.2. 

Finally, the latest version of AKS only supports Kubernetes v1.22 and later, but who knows what users might be actually running.

I think we could merge in some changes regarding the latest chart, Rancher, and Kubernetes versions as a stop gap, then update again later once we have a clearer answer. 

So, 

- I'll be updating 2.7 with the latest nginx helm chart version and a note about finding the helm chart that corresponds to your Kubernetes version.
- Older Rancher versioned_docs just get the note about finding their supported nginx-Kubernetes combo.