### PR TITLE
Add back AWS Marketplace quick start

### DIFF
--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace.md
@@ -1,0 +1,6 @@
+---
+title: Rancher AWS Marketplace Quick Start
+description: Use Amazon EKS to deploy Rancher server.
+---
+
+Amazon Elastic Kubernetes Service (EKS) can quickly [deploy Rancher to Amazon Web Services (AWS)](https://documentation.suse.com/trd/kubernetes/single-html/gs_rancher_aws-marketplace/). To learn more, see our [Amazon Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-go7ent7goo5ae). Watch the [demo](https://youtu.be/9dznJ7Ons0M) for a walkthrough of AWS Marketplace SUSE Rancher setup.

--- a/docs/pages-for-subheaders/deploy-rancher-manager.md
+++ b/docs/pages-for-subheaders/deploy-rancher-manager.md
@@ -5,6 +5,7 @@ title: Deploying Rancher Server
 Use one of the following guides to deploy and provision Rancher and a Kubernetes cluster in the provider of your choice.
 
 - [AWS](../getting-started/quick-start-guides/deploy-rancher-manager/aws.md) (uses Terraform)
+- [AWS Marketplace](../getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace.md) (uses Amazon EKS)
 - [Azure](../getting-started/quick-start-guides/deploy-rancher-manager/azure.md) (uses Terraform)
 - [DigitalOcean](../getting-started/quick-start-guides/deploy-rancher-manager/digitalocean.md) (uses Terraform)
 - [GCP](../getting-started/quick-start-guides/deploy-rancher-manager/gcp.md) (uses Terraform)
@@ -12,7 +13,6 @@ Use one of the following guides to deploy and provision Rancher and a Kubernetes
 - [Vagrant](../getting-started/quick-start-guides/deploy-rancher-manager/vagrant.md)
 - [Equinix Metal](../getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md)
 - [Outscale](../getting-started/quick-start-guides/deploy-rancher-manager/outscale-qs.md) (uses Terraform)
-
 
 If you prefer, the following guide will take you through the same process in individual steps. Use this if you want to run Rancher in a different provider, on prem, or if you would just like to see how easy it is.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -42,6 +42,7 @@ const sidebars = {
               },
               items: [
                 "getting-started/quick-start-guides/deploy-rancher-manager/aws",
+                "getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace",
                 "getting-started/quick-start-guides/deploy-rancher-manager/azure",
                 "getting-started/quick-start-guides/deploy-rancher-manager/digitalocean",
                 "getting-started/quick-start-guides/deploy-rancher-manager/gcp",


### PR DESCRIPTION
Resolves https://github.com/rancher/rancher-docs/issues/454.

These pages were originally removed in #421 due to the note about deploying Rancher v2.6.10 mentioned on https://documentation.suse.com/trd/kubernetes/single-html/gs_rancher_aws-marketplace/. This note is still present, but the page now has a `Upgrade to latest version` section and the reference to Prime suggests this is applicable to v2.7 and can be added back.