### PR TITLE
Apply PR #588 password length note to other providers

### DIFF
--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/aws.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/aws.md
@@ -52,7 +52,7 @@ The AWS module just creates an EC2 KeyPair, an EC2 SecurityGroup and an EC2 inst
 
     - `aws_access_key` - Amazon AWS Access Key
     - `aws_secret_key` - Amazon AWS Secret Key
-    - `rancher_server_admin_password` - Admin password for created Rancher server
+    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
 
 5. **Optional:** Modify optional variables within `terraform.tfvars`. See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [AWS Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/aws) for more information.
 Suggestions include:

--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/azure.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/azure.md
@@ -39,7 +39,7 @@ Deploying to Microsoft Azure will incur charges.
     - `azure_client_id` - Microsoft Azure Client ID
     - `azure_client_secret` - Microsoft Azure Client Secret
     - `azure_tenant_id` - Microsoft Azure Tenant ID
-    - `rancher_server_admin_password` - Admin password for created Rancher server
+    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
 
 5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Azure Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/azure) for more information. Suggestions include:

--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/digitalocean.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/digitalocean.md
@@ -33,7 +33,7 @@ Deploying to DigitalOcean will incur charges.
 
 4. Edit `terraform.tfvars` and customize the following variables:
     - `do_token` - DigitalOcean access key
-    - `rancher_server_admin_password` - Admin password for created Rancher server
+    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
 
 5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [DO Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/do) for more information. Suggestions include:

--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli.md
@@ -125,6 +125,8 @@ The final command to install Rancher is below. The command requires a domain nam
 
 To install a specific Rancher version, use the `--version` flag (e.g., `--version 2.6.6`). Otherwise, the latest Rancher is installed by default. Refer to [Choosing a Rancher Version](../../installation-and-upgrade/resources/choose-a-rancher-version.md).
 
+Note the password requires a minimum of 12 characters.
+
 ```
 helm install rancher rancher-latest/rancher \
   --namespace cattle-system \

--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/hetzner-cloud.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/hetzner-cloud.md
@@ -33,7 +33,7 @@ Deploying to Hetzner Cloud will incur charges.
 
 4. Edit `terraform.tfvars` and customize the following variables:
     - `hcloud_token` - Hetzner API access key
-    - `rancher_server_admin_password` - Admin password for created Rancher server
+    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
 
 5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Hetzner Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/hcloud) for more information.

--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/outscale-qs.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/outscale-qs.md
@@ -34,7 +34,7 @@ Deploying to Outscale will incur charges.
 4. Edit `terraform.tfvars` and customize the following variables:
     - `access_key_id` - Outscale access key
     - `secret_key_id` - Outscale secret key
-    - `rancher_server_admin_password` - Admin password for created Rancher server
+    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
 
 5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Outscale Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/outscale) for more information.

--- a/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/aws.md
+++ b/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/aws.md
@@ -52,7 +52,7 @@ The AWS module just creates an EC2 KeyPair, an EC2 SecurityGroup and an EC2 inst
 
     - `aws_access_key` - Amazon AWS Access Key
     - `aws_secret_key` - Amazon AWS Secret Key
-    - `rancher_server_admin_password` - Admin password for created Rancher server
+    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
 
 5. **Optional:** Modify optional variables within `terraform.tfvars`. See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [AWS Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/aws) for more information.
 Suggestions include:

--- a/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/azure.md
+++ b/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/azure.md
@@ -39,7 +39,7 @@ Deploying to Microsoft Azure will incur charges.
     - `azure_client_id` - Microsoft Azure Client ID
     - `azure_client_secret` - Microsoft Azure Client Secret
     - `azure_tenant_id` - Microsoft Azure Tenant ID
-    - `rancher_server_admin_password` - Admin password for created Rancher server
+    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
 
 5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Azure Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/azure) for more information. Suggestions include:

--- a/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/digitalocean.md
+++ b/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/digitalocean.md
@@ -33,7 +33,7 @@ Deploying to DigitalOcean will incur charges.
 
 4. Edit `terraform.tfvars` and customize the following variables:
     - `do_token` - DigitalOcean access key
-    - `rancher_server_admin_password` - Admin password for created Rancher server
+    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
 
 5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [DO Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/do) for more information. Suggestions include:

--- a/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli.md
+++ b/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli.md
@@ -123,6 +123,8 @@ The final command to install Rancher is below. The command requires a domain nam
 
 To install a specific Rancher version, use the `--version` flag (e.g., `--version 2.6.6`). Otherwise, the latest Rancher is installed by default. Refer to [Choosing a Rancher Version](../../installation-and-upgrade/resources/choose-a-rancher-version.md).
 
+Note the password requires a minimum of 12 characters.
+
 ```
 helm install rancher rancher-latest/rancher \
   --namespace cattle-system \

--- a/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/hetzner-cloud.md
+++ b/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/hetzner-cloud.md
@@ -33,7 +33,7 @@ Deploying to Hetzner Cloud will incur charges.
 
 4. Edit `terraform.tfvars` and customize the following variables:
     - `hcloud_token` - Hetzner API access key
-    - `rancher_server_admin_password` - Admin password for created Rancher server
+    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
 
 5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Hetzner Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/hcloud) for more information.

--- a/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/outscale-qs.md
+++ b/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/outscale-qs.md
@@ -34,7 +34,7 @@ Deploying to Outscale will incur charges.
 4. Edit `terraform.tfvars` and customize the following variables:
     - `access_key_id` - Outscale access key
     - `secret_key_id` - Outscale secret key
-    - `rancher_server_admin_password` - Admin password for created Rancher server
+    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
 
 5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Outscale Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/outscale) for more information.

--- a/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/vagrant.md
+++ b/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/vagrant.md
@@ -31,7 +31,7 @@ The intent of these guides is to quickly launch a sandbox that you can use to ev
 3. **Optional:** Edit `config.yaml` to:
 
     - Change the number of nodes and the memory allocations, if required. (`node.count`, `node.cpus`, `node.memory`)
-    - Change the password of the `admin` user for logging into Rancher. (`admin_password`)
+    - Change the password of the `admin` user for logging into Rancher. (`admin_password`, minimum 12 characters)
 
 4. To initiate the creation of the environment run, `vagrant up --provider=virtualbox`.
 


### PR DESCRIPTION
Adding these updates as a temporarily so there's consistency between the pages. The password requirements are provider agnostic so a better solution is to list out the password requirements in a central area and link to it rather than repeating them on each provider's page.