### PR TITLE
Version number link label is incorrect

### DIFF
--- a/versioned_docs/version-2.5/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/versioned_docs/version-2.5/reference-guides/cli-with-rancher/rancher-cli.md
@@ -10,7 +10,7 @@ The Rancher CLI (Command Line Interface) is a unified tool that you can use to i
 The binary can be downloaded directly from the UI. The link can be found in the right hand side of the footer in the UI. We have binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
 
 1. In the upper left corner, click **☰**.
-1. At the bottom, click **v2.6.x**, where **v2.6.x** is a hyperlinked text indicating the installed Rancher version.
+1. At the bottom, click **v2.5.x**, where **v2.5.x** is a hyperlinked text indicating the installed Rancher version.
 1. Under the **CLI Downloads section**, there are links to download the binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
 
 ### Requirements


### PR DESCRIPTION
The v2.5 version of this page states that the user will see a link labeled "v2.6" in the Rancher UI. This is clearly a typo. If the user is on 2.5.x, they'll see v2.5.x listed in that link. The link points to the /dashboard/about page in the Rancher UI which contains further information about the user's version of Rancher.