### PR TITLE
Include global.cattle.psp.enabled note on other examples

### DIFF
--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.md
@@ -137,7 +137,9 @@ If you are upgrading cert-manager to the latest version from v1.5 or below, foll
 
 Upgrade Rancher to the latest version with all your settings.
 
-Take all the values from the previous step and append them to the command using `--set key=value`:
+Take all the values from the previous step and append them to the command using `--set key=value`.
+
+For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false`.
 
 ```
 helm upgrade rancher rancher-<CHART_REPO>/rancher \
@@ -153,14 +155,20 @@ The above is an example, there may be more values from the previous step that ne
 
 Alternatively, it's possible to export the current values to a file and reference that file during upgrade. For example, to only change the Rancher version:
 
-```
-helm get values rancher -n cattle-system -o yaml > values.yaml
+1. Export the current values to a file:
+  ```
+  helm get values rancher -n cattle-system -o yaml > values.yaml
+  ```
+1. Update only the Rancher version:
 
-helm upgrade rancher rancher-<CHART_REPO>/rancher \
-  --namespace cattle-system \
-  -f values.yaml \
-  --version=2.6.8
-```
+  For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false`.
+
+  ```
+  helm upgrade rancher rancher-<CHART_REPO>/rancher \
+    --namespace cattle-system \
+    -f values.yaml \
+    --version=2.6.8
+  ```
 
 ### 4. Verify the Upgrade
 

--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
@@ -173,6 +173,8 @@ kubectl create namespace cattle-system
 
 Next, install Rancher, declaring your chosen options. Use the reference table below to replace each placeholder. Rancher needs to be configured to use the private registry in order to provision any Rancher launched Kubernetes clusters or Rancher tools.
 
+For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false`.
+
 Placeholder | Description
 ------------|-------------
 `<VERSION>` | The version number of the output tarball.
@@ -201,6 +203,8 @@ Create Kubernetes secrets from your own certificates for Rancher to use. The com
 ##### 2. Install Rancher
 
 Install Rancher, declaring your chosen options. Use the reference table below to replace each placeholder. Rancher needs to be configured to use the private registry in order to provision any Rancher launched Kubernetes clusters or Rancher tools.
+
+For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false`.
 
 | Placeholder                      | Description                                     |
 | -------------------------------- | ----------------------------------------------- |

--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli.md
@@ -125,6 +125,8 @@ The final command to install Rancher is below. The command requires a domain nam
 
 To install a specific Rancher version, use the `--version` flag (e.g., `--version 2.6.6`). Otherwise, the latest Rancher is installed by default. Refer to [Choosing a Rancher Version](../../installation-and-upgrade/resources/choose-a-rancher-version.md).
 
+For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false`.
+
 Note the password requires a minimum of 12 characters.
 
 ```

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -48,7 +48,7 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
      The above assumes an environment with outbound connectivity to Docker Hub
 
      For an **air-gapped environment**, use the Helm value below to pull the `backup-restore-operator` image from your private registry when installing the rancher-backup Helm chart.
-     
+
      ```bash
      --set image.repository $REGISTRY/rancher/backup-restore-operator
      ```
@@ -157,6 +157,8 @@ Follow the steps to [install cert-manager](../../../pages-for-subheaders/install
 ### 4. Bring up Rancher with Helm
 
 Use the same version of Helm to install Rancher, that was used on the first cluster.
+
+For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false`.
 
 ```bash
 helm install rancher rancher-latest/rancher \

--- a/docs/pages-for-subheaders/enable-experimental-features.md
+++ b/docs/pages-for-subheaders/enable-experimental-features.md
@@ -34,6 +34,8 @@ Values set from the Rancher API will override the value passed in through the co
 
 When installing Rancher with a Helm chart, use the `--set` option. In the below example, two features are enabled by passing the feature flag names in a comma separated list:
 
+For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false`.
+
 ```
 helm install rancher rancher-latest/rancher \
   --namespace cattle-system \

--- a/docs/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster.md
+++ b/docs/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster.md
@@ -201,8 +201,7 @@ Because `rancher` is the default option for `ingress.tls.source`, we are not spe
 - Set the `hostname` to the DNS name you pointed at your load balancer.
 - Set the `bootstrapPassword` to something unique for the `admin` user.
 - To install a specific Rancher version, use the `--version` flag, example: `--version 2.7.0`
-
-- For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false'.
+- For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false`.
 
 ```
 helm install rancher rancher-<CHART_REPO>/rancher \
@@ -243,8 +242,7 @@ In the following command,
 - `ingress.tls.source` is set to `letsEncrypt`
 - `letsEncrypt.email` is set to the email address used for communication about your certificate (for example, expiry notices)
 - Set `letsEncrypt.ingress.class` to whatever your ingress controller is, e.g., `traefik`, `nginx`, `haproxy`, etc.
-
-- For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false'.
+- For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false`.
 
 ```
 helm install rancher rancher-<CHART_REPO>/rancher \
@@ -287,8 +285,7 @@ If you want to check if your certificates are correct, see [How do I check Commo
 - Set the `hostname`.
 - Set the `bootstrapPassword` to something unique for the `admin` user.
 - Set `ingress.tls.source` to `secret`.
-
-- For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false'.
+- For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false`.
 
 ```
 helm install rancher rancher-<CHART_REPO>/rancher \


### PR DESCRIPTION
This is a follow-up to #567 so that the note is present on all examples that potentially involve Kubernetes v1.25.