### PR TITLE
Add support matrix reference to RKE installation page

### DIFF
--- a/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher.md
@@ -40,6 +40,8 @@ If your node has public and internal addresses, it is recommended to set the `in
 
 RKE will need to connect to each node over SSH, and it will look for a private key in the default location of `~/.ssh/id_rsa`. If your private key for a certain node is in a different location than the default, you will also need to configure the `ssh_key_path` option for that node.
 
+When choosing a Kubernetes version, be sure to first consult the [support matrix](https://rancher.com/support-matrix/) to find the highest version of Kubernetes that has been validated for your Rancher version.
+
 ```yaml
 nodes:
   - address: 165.227.114.63
@@ -67,6 +69,8 @@ ingress:
   provider: nginx
   options:
     use-forwarded-headers: "true"
+
+kubernetes_version: v1.25.6-rancher4-1
 ```
 
 <figcaption>Common RKE Nodes Options</figcaption>

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher.md
@@ -33,6 +33,8 @@ If your node has public and internal addresses, it is recommended to set the `in
 
 RKE will need to connect to each node over SSH, and it will look for a private key in the default location of `~/.ssh/id_rsa`. If your private key for a certain node is in a different location than the default, you will also need to configure the `ssh_key_path` option for that node.
 
+When choosing a Kubernetes version, be sure to first consult the [support matrix](https://rancher.com/support-matrix/) to find the highest version of Kubernetes that has been validated for your Rancher version.
+
 ```yaml
 nodes:
   - address: 165.227.114.63
@@ -60,6 +62,8 @@ ingress:
   provider: nginx
   options:
     use-forwarded-headers: "true"
+
+kubernetes_version: v1.20.15-rancher2-1
 ```
 
 <figcaption>Common RKE Nodes Options</figcaption>

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher.md
@@ -40,6 +40,8 @@ If your node has public and internal addresses, it is recommended to set the `in
 
 RKE will need to connect to each node over SSH, and it will look for a private key in the default location of `~/.ssh/id_rsa`. If your private key for a certain node is in a different location than the default, you will also need to configure the `ssh_key_path` option for that node.
 
+When choosing a Kubernetes version, be sure to first consult the [support matrix](https://rancher.com/support-matrix/) to find the highest version of Kubernetes that has been validated for your Rancher version.
+
 ```yaml
 nodes:
   - address: 165.227.114.63
@@ -67,6 +69,8 @@ ingress:
   provider: nginx
   options:
     use-forwarded-headers: "true"
+
+kubernetes_version: v1.24.13-rancher2-1
 ```
 
 <figcaption>Common RKE Nodes Options</figcaption>


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher-docs/issues/152.

This is the remaining K8s cluster setup page without the note pointing users to the support matrix to identify compatible versions. Reusing same note that's already present.