### PR TITLE
Update CLI download steps

### DIFF
--- a/docs/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/docs/reference-guides/cli-with-rancher/rancher-cli.md
@@ -7,7 +7,7 @@ The Rancher CLI (Command Line Interface) is a unified tool that you can use to i
 
 ### Download Rancher CLI
 
-The binary can be downloaded directly from the UI. The link can be found in the right hand side of the footer in the UI. We have binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
+The binary can be downloaded directly from the UI.
 
 1. In the upper left corner, click **☰**.
 1. At the bottom, click **v2.6.x**, where **v2.6.x** is a hyperlinked text indicating the installed Rancher version.

--- a/versioned_docs/version-2.5/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/versioned_docs/version-2.5/reference-guides/cli-with-rancher/rancher-cli.md
@@ -9,10 +9,6 @@ The Rancher CLI (Command Line Interface) is a unified tool that you can use to i
 
 The binary can be downloaded directly from the UI. The link can be found in the right hand side of the footer in the UI. We have binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
 
-1. In the upper left corner, click **☰**.
-1. At the bottom, click **v2.5.x**, where **v2.5.x** is a hyperlinked text indicating the installed Rancher version.
-1. Under the **CLI Downloads section**, there are links to download the binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
-
 ### Requirements
 
 After you download the Rancher CLI, you need to make a few configurations. Rancher CLI requires:

--- a/versioned_docs/version-2.6/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/versioned_docs/version-2.6/reference-guides/cli-with-rancher/rancher-cli.md
@@ -7,7 +7,7 @@ The Rancher CLI (Command Line Interface) is a unified tool that you can use to i
 
 ### Download Rancher CLI
 
-The binary can be downloaded directly from the UI. The link can be found in the right hand side of the footer in the UI. We have binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
+The binary can be downloaded directly from the UI.
 
 1. In the upper left corner, click **☰**.
 1. At the bottom, click **v2.6.x**, where **v2.6.x** is a hyperlinked text indicating the installed Rancher version.


### PR DESCRIPTION
This is a follow-up to #594 which identified a v2.6 label was applied to v2.5 docs.

In addition to the version label, the set of numbered steps as a whole is not applicable to v2.5 as it did not have a hamburger menu in the UI. The v2.6 content was introduced during the Docusaurus migration in https://github.com/rancher/rancher-docs/blob/a2c2284a7d7fa848f5fa0198f804883ba17e5a95/versioned_docs/version-2.5/reference-guides/cli-with-rancher/rancher-cli.md, but referring to the original source content for v2.5 at https://github.com/rancher/docs/blob/master/content/rancher/v2.5/en/cli/_index.md, only the first paragraph is present for the `Download Rancher CLI` portion.

Similarly, the first paragraph of that section is not applicable to v2.6+ as there is no footer in the UI. 