### PR TITLE
Document the new OpenLDAP configuration feature for Okta auth providers

### DIFF
--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-okta-saml.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-okta-saml.md
@@ -4,8 +4,6 @@ title: Configure Okta (SAML)
 
 If your organization uses Okta Identity Provider (IdP) for user authentication, you can configure Rancher to allow your users to log in using their IdP credentials.
 
-If you configure Okta with an OpenLAD backend, authenticated users can access Rancher resources through their group permissions.
-
 :::note
 
 Okta integration only supports Service Provider initiated logins.
@@ -22,10 +20,12 @@ Setting | Value
 
 ## Configuring Okta in Rancher
 
-1.	In the top left corner, click **☰ > Users & Authentication**.
+You can integrate Okta with Rancher, so that authenticated users can access Rancher resources through their group permissions. Okta returns a SAML assertion that authenticates a user, including which groups a user belongs to.
+
+1. In the top left corner, click **☰ > Users & Authentication**.
 1. In the left navigation menu, click **Auth Provider**.
 1. Click **Okta**.
-1.	Complete the **Configure Okta Account** form. The examples below describe how you can map Okta attributes from attribute statements to fields within Rancher.
+1. Complete the **Configure Okta Account** form. The examples below describe how you can map Okta attributes from attribute statements to fields within Rancher.
 
     | Field                     | Description                                                                   |
     | ------------------------- | ----------------------------------------------------------------------------- |
@@ -71,11 +71,9 @@ If you configure Okta without OpenLDAP, you won't be able to search for or direc
 
 :::
 
-To enable group and user lookup when assigning permissions in Rancher, you will need to configure a back end for the SAML provider that supports groups, such as OpenLDAP.
+## Okta with OpenLDAP search
 
-## Setting up OpenLDAP in Rancher
-
-You can set up OpenLDAP within Rancher, so that authenticated users can access Rancher resources through their group permissions. OpenLDAP returns a SAML assertion that lists user attributes, including which groups a user belongs to.
+You can add an OpenLDAP backend to assist with user and group search. Rancher will display additional users and groups from the OpenLDAP service. This allows assigning permissions to groups that the logged-in user is not already a member of.
 
 ### OpenLDAP Prerequisites
 
@@ -85,7 +83,7 @@ You must configure Rancher with a LDAP bind account (aka service account) so tha
 
 > **Using TLS?**
 >
-> If the certificate used by the OpenLDAP server is self-signed or not from a recognized certificate authority, make sure have at hand the CA certificate (concatenated with any intermediate certificates) in PEM format. You will have to paste in this certificate during the configuration so that Rancher is able to validate the certificate chain.
+> If the certificate used by the OpenLDAP server is self-signed or not from a recognized certificate authority, Rancher needs the CA certificate (concatenated with any intermediate certificates) in PEM format. You will have to provide this certificate during the configuration so that Rancher is able to validate the certificate chain.
 
 ### Configure OpenLDAP in Rancher
 

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-okta-saml.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-okta-saml.md
@@ -4,6 +4,8 @@ title: Configure Okta (SAML)
 
 If your organization uses Okta Identity Provider (IdP) for user authentication, you can configure Rancher to allow your users to log in using their IdP credentials.
 
+If you also configure OpenLDAP as the back end to Okta, it will return a SAML assertion to Rancher with user attributes that include groups. Then the authenticated user will be able to access resources in Rancher that their groups have permissions for.
+
 :::note
 
 Okta integration only supports Service Provider initiated logins.
@@ -60,9 +62,41 @@ Setting | Value
 
 :::note SAML Provider Caveats:
 
-- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+If you configure Okta without OpenLDAP, the following caveats apply due to the fact that SAML Protocol does not support search or lookup for users or groups.
+
+- There is no validation on users or groups when assigning permissions to them in Rancher.
 - When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
 - When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
 - The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
 
 :::
+
+To enable searching for groups when assigning permissions in Rancher, you will need to configure a back end for the SAML provider that supports groups, such as OpenLDAP.
+
+## Setting up OpenLDAP in Rancher
+
+If you also configure OpenLDAP as the back end to Okta, it will return a SAML assertion to Rancher with user attributes that include groups. Then authenticated users will be able to access resources in Rancher that their groups have permissions for.
+
+### OpenLDAP Prerequisites
+
+If you use an Okta Directory as your IdP, you can setup an LDAP Interface for Rancher to use. See the [Okta Documentation](https://help.okta.com/en-us/Content/Topics/Directory/LDAP-interface-main.htm). You can also configure an external OpenLDAP server.
+
+Rancher must be configured with a LDAP bind account (aka service account) to search and retrieve LDAP entries pertaining to users and groups that should have access. It is recommended to not use an administrator account or personal account for this purpose and instead create a dedicated account in OpenLDAP with read-only access to users and groups under the configured search base (see below).
+
+> **Using TLS?**
+>
+> If the certificate used by the OpenLDAP server is self-signed or not from a recognized certificate authority, make sure have at hand the CA certificate (concatenated with any intermediate certificates) in PEM format. You will have to paste in this certificate during the configuration so that Rancher is able to validate the certificate chain.
+
+### Configure OpenLDAP in Rancher
+
+Configure the settings for the OpenLDAP server, groups and users. For help filling out each field, refer to the [configuration reference.](/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap/openldap-config-reference.md) Note that nested group membership is not available.
+
+> Before you proceed with the configuration, please familiarise yourself with the concepts of [External Authentication Configuration and Principal Users](/pages-for-subheaders/authentication-config.md#external-authentication-configuration-and-principal-users).
+
+1. Log into the Rancher UI using the initial local `admin` account.
+1. In the top left corner, click **☰ > Users & Authentication**.
+1. In the left navigation menu, click **Auth Provider**.
+1. Click **Okta** or, if SAML is already configured, **Edit Config**
+1. Under **User and Group Search**, check **Configure an OpenLDAP server**
+
+If you are experiencing issues while testing the connection to the OpenLDAP server, first double-check the credentials entered for the service account as well as the search base configuration. You may also inspect the Rancher logs to help pinpointing the problem cause. Debug logs may contain more detailed information about the error. Please refer to [How can I enable debug logging](/faq/technical-items.md#how-can-i-enable-debug-logging) in this documentation.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-okta-saml.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-okta-saml.md
@@ -83,7 +83,7 @@ You must configure Rancher with a LDAP bind account (aka service account) so tha
 
 > **Using TLS?**
 >
-> If the certificate used by the OpenLDAP server is self-signed or not from a recognized certificate authority, Rancher needs the CA certificate (concatenated with any intermediate certificates) in PEM format. You will have to provide this certificate during the configuration so that Rancher is able to validate the certificate chain.
+> If the certificate used by the OpenLDAP server is self-signed or from an unrecognized certificate authority, Rancher needs the CA certificate (concatenated with any intermediate certificates) in PEM format. Provide this certificate during the configuration so that Rancher can validate the certificate chain.
 
 ### Configure OpenLDAP in Rancher
 

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-okta-saml.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-okta-saml.md
@@ -4,7 +4,7 @@ title: Configure Okta (SAML)
 
 If your organization uses Okta Identity Provider (IdP) for user authentication, you can configure Rancher to allow your users to log in using their IdP credentials.
 
-If you also configure OpenLDAP as the back end to Okta, it will return a SAML assertion to Rancher with user attributes that include groups. Then the authenticated user will be able to access resources in Rancher that their groups have permissions for.
+If you configure Okta with an OpenLAD backend, authenticated users can access Rancher resources through their group permissions.
 
 :::note
 
@@ -62,26 +62,26 @@ Setting | Value
 
 :::note SAML Provider Caveats:
 
-If you configure Okta without OpenLDAP, the following caveats apply due to the fact that SAML Protocol does not support search or lookup for users or groups.
+If you configure Okta without OpenLDAP, you won't be able to search for or directly lookup users or groups. This brings several caveats:
 
-- There is no validation on users or groups when assigning permissions to them in Rancher.
+- Users and groups aren't validated when you assign permissions to them in Rancher.
 - When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
 - When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
 - The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
 
 :::
 
-To enable searching for groups when assigning permissions in Rancher, you will need to configure a back end for the SAML provider that supports groups, such as OpenLDAP.
+To enable group and user lookup when assigning permissions in Rancher, you will need to configure a back end for the SAML provider that supports groups, such as OpenLDAP.
 
 ## Setting up OpenLDAP in Rancher
 
-If you also configure OpenLDAP as the back end to Okta, it will return a SAML assertion to Rancher with user attributes that include groups. Then authenticated users will be able to access resources in Rancher that their groups have permissions for.
+You can set up OpenLDAP within Rancher, so that authenticated users can access Rancher resources through their group permissions. OpenLDAP returns a SAML assertion that lists user attributes, including which groups a user belongs to.
 
 ### OpenLDAP Prerequisites
 
-If you use an Okta Directory as your IdP, you can setup an LDAP Interface for Rancher to use. See the [Okta Documentation](https://help.okta.com/en-us/Content/Topics/Directory/LDAP-interface-main.htm). You can also configure an external OpenLDAP server.
+If you use Okta as your IdP, you can [set up an LDAP interface](https://help.okta.com/en-us/Content/Topics/Directory/LDAP-interface-main.htm) for Rancher to use. You can also configure an external OpenLDAP server.
 
-Rancher must be configured with a LDAP bind account (aka service account) to search and retrieve LDAP entries pertaining to users and groups that should have access. It is recommended to not use an administrator account or personal account for this purpose and instead create a dedicated account in OpenLDAP with read-only access to users and groups under the configured search base (see below).
+You must configure Rancher with a LDAP bind account (aka service account) so that you can search and retrieve LDAP entries for users and groups that should have access. Don't use an administrator account or personal account as an LDAP bind account. Create a dedicated account in OpenLDAP, with read-only access to users and groups under the configured searchbase.
 
 > **Using TLS?**
 >
@@ -89,14 +89,14 @@ Rancher must be configured with a LDAP bind account (aka service account) to sea
 
 ### Configure OpenLDAP in Rancher
 
-Configure the settings for the OpenLDAP server, groups and users. For help filling out each field, refer to the [configuration reference.](/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap/openldap-config-reference.md) Note that nested group membership is not available.
+[Configure the settings](../configure-openldap/openldap-config-reference.md) for the OpenLDAP server, groups and users. Note that nested group membership isn't available.
 
-> Before you proceed with the configuration, please familiarise yourself with the concepts of [External Authentication Configuration and Principal Users](/pages-for-subheaders/authentication-config.md#external-authentication-configuration-and-principal-users).
+> Before you proceed with the configuration, please familiarise yourself with [external authentication configuration and principal users](../../../../pages-for-subheaders/authentication-config.md#external-authentication-configuration-and-principal-users).
 
-1. Log into the Rancher UI using the initial local `admin` account.
+1. Sign into Rancher using a local user assigned the [administrator](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions) role (i.e., the _local principal_).
 1. In the top left corner, click **☰ > Users & Authentication**.
 1. In the left navigation menu, click **Auth Provider**.
 1. Click **Okta** or, if SAML is already configured, **Edit Config**
 1. Under **User and Group Search**, check **Configure an OpenLDAP server**
 
-If you are experiencing issues while testing the connection to the OpenLDAP server, first double-check the credentials entered for the service account as well as the search base configuration. You may also inspect the Rancher logs to help pinpointing the problem cause. Debug logs may contain more detailed information about the error. Please refer to [How can I enable debug logging](/faq/technical-items.md#how-can-i-enable-debug-logging) in this documentation.
+If you experience issues when you test the connection to the OpenLDAP server, ensure that you entered the credentials for the service account and configured the search base correctly. Inspecting the Rancher logs can help pinpoint the root cause. Debug logs may contain more detailed information about the error. Please refer to [How can I enable debug logging](../../../../faq/technical-items.md#how-can-i-enable-debug-logging) for more information.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-okta-saml.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-okta-saml.md
@@ -79,7 +79,7 @@ You can add an OpenLDAP backend to assist with user and group search. Rancher wi
 
 If you use Okta as your IdP, you can [set up an LDAP interface](https://help.okta.com/en-us/Content/Topics/Directory/LDAP-interface-main.htm) for Rancher to use. You can also configure an external OpenLDAP server.
 
-You must configure Rancher with a LDAP bind account (aka service account) so that you can search and retrieve LDAP entries for users and groups that should have access. Don't use an administrator account or personal account as an LDAP bind account. Create a dedicated account in OpenLDAP, with read-only access to users and groups under the configured searchbase.
+You must configure Rancher with a LDAP bind account (aka service account) so that you can search and retrieve LDAP entries for users and groups that should have access. Don't use an administrator account or personal account as an LDAP bind account. [Create](https://help.okta.com/en-us/Content/Topics/users-groups-profiles/usgp-add-users.htm) a dedicated account in OpenLDAP, with read-only access to users and groups under the configured searchbase.
 
 > **Using TLS?**
 >

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-okta-saml.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-okta-saml.md
@@ -81,6 +81,13 @@ If you use Okta as your IdP, you can [set up an LDAP interface](https://help.okt
 
 You must configure Rancher with a LDAP bind account (aka service account) so that you can search and retrieve LDAP entries for users and groups that should have access. Don't use an administrator account or personal account as an LDAP bind account. [Create](https://help.okta.com/en-us/Content/Topics/users-groups-profiles/usgp-add-users.htm) a dedicated account in OpenLDAP, with read-only access to users and groups under the configured searchbase.
 
+:::warning Security Considerations
+
+The OpenLDAP service account is used for all searches. Rancher users will see users and groups that the OpenLDAP service account can view, regardless of their individual SAML permissions.
+
+:::
+
+
 > **Using TLS?**
 >
 > If the certificate used by the OpenLDAP server is self-signed or from an unrecognized certificate authority, Rancher needs the CA certificate (concatenated with any intermediate certificates) in PEM format. Provide this certificate during the configuration so that Rancher can validate the certificate chain.

--- a/docs/pages-for-subheaders/configure-shibboleth-saml.md
+++ b/docs/pages-for-subheaders/configure-shibboleth-saml.md
@@ -94,7 +94,8 @@ Configure the settings for the OpenLDAP server, groups and users. For help filli
 1. Log into the Rancher UI using the initial local `admin` account.
 1. In the top left corner, click **☰ > Users & Authentication**.
 1. In the left navigation menu, click **Auth Provider**.
-1. Click **OpenLDAP**. The **Configure an OpenLDAP server** form will be displayed.
+1. Click **Shibboleth** or, if SAML is already configured, **Edit Config**
+1. Under **User and Group Search**, check **Configure an OpenLDAP server**
 
 ## Troubleshooting
 


### PR DESCRIPTION
This adds documentation for the optional OpenLDAP configuration on Okta providers. Since this feature is nearly identical to the equivalent UI in the Shibboleth provider, I've largely used that text as a base. While I was there, I noticed a tiny problem in the Shibboleth instructions and adjusted it to more closely align with the current UI.

https://github.com/rancher/rancher/issues/41322