### PR TITLE
#420 Test Docusaurus head metadata override of autogenerated canonical annotations

### DIFF
--- a/docs/getting-started/installation-and-upgrade/installation-references/helm-chart-options.md
+++ b/docs/getting-started/installation-and-upgrade/installation-references/helm-chart-options.md
@@ -3,7 +3,7 @@ title: Rancher Helm Chart Options
 ---
 
 <head>
-    <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references/helm-chart-options"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references/helm-chart-options"/>
 </head>
 
 This page is a configuration reference for the Rancher Helm chart.

--- a/docs/getting-started/installation-and-upgrade/installation-references/helm-chart-options.md
+++ b/docs/getting-started/installation-and-upgrade/installation-references/helm-chart-options.md
@@ -2,6 +2,10 @@
 title: Rancher Helm Chart Options
 ---
 
+<head>
+    <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references/helm-chart-options"/>
+</head>
+
 This page is a configuration reference for the Rancher Helm chart.
 
 For help choosing a Helm chart version, refer to [this page.](../../../getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md)

--- a/versioned_docs/version-2.0-2.4/reference-guides/installation-references/helm-chart-options.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/installation-references/helm-chart-options.md
@@ -2,6 +2,10 @@
 title: Rancher Helm Chart Options
 ---
 
+<head>
+    <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references/helm-chart-options"/>
+</head>
+
 This page is a configuration reference for the Rancher Helm chart.
 
 For help choosing a Helm chart version, refer to [this page.](../../getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md)

--- a/versioned_docs/version-2.0-2.4/reference-guides/installation-references/helm-chart-options.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/installation-references/helm-chart-options.md
@@ -3,7 +3,7 @@ title: Rancher Helm Chart Options
 ---
 
 <head>
-    <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references/helm-chart-options"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references/helm-chart-options"/>
 </head>
 
 This page is a configuration reference for the Rancher Helm chart.

--- a/versioned_docs/version-2.5/reference-guides/installation-references/helm-chart-options.md
+++ b/versioned_docs/version-2.5/reference-guides/installation-references/helm-chart-options.md
@@ -2,6 +2,10 @@
 title: Rancher Helm Chart Options
 ---
 
+<head>
+    <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references/helm-chart-options"/>
+</head>
+
 This page is a configuration reference for the Rancher Helm chart.
 
 For help choosing a Helm chart version, refer to [this page.](../../getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md)

--- a/versioned_docs/version-2.5/reference-guides/installation-references/helm-chart-options.md
+++ b/versioned_docs/version-2.5/reference-guides/installation-references/helm-chart-options.md
@@ -3,7 +3,7 @@ title: Rancher Helm Chart Options
 ---
 
 <head>
-    <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references/helm-chart-options"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references/helm-chart-options"/>
 </head>
 
 This page is a configuration reference for the Rancher Helm chart.

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/installation-references/helm-chart-options.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/installation-references/helm-chart-options.md
@@ -3,7 +3,7 @@ title: Rancher Helm Chart Options
 ---
 
 <head>
-    <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references/helm-chart-options"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references/helm-chart-options"/>
 </head>
 
 This page is a configuration reference for the Rancher Helm chart.

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/installation-references/helm-chart-options.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/installation-references/helm-chart-options.md
@@ -2,6 +2,10 @@
 title: Rancher Helm Chart Options
 ---
 
+<head>
+    <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references/helm-chart-options"/>
+</head>
+
 This page is a configuration reference for the Rancher Helm chart.
 
 For help choosing a Helm chart version, refer to [this page.](../../../getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md)


### PR DESCRIPTION
When sites have multiple versions of the same/similar pages, Google uses the `canonical` annotation in the page's `head` to determine which URL to elevate in search rankings. The annotation is accompanied by an URL, which indicates which page to rank higher. For example, if we have two pages, A and B, and we want A to have the higher search ranking, we would set 
`<link rel="canonical" href="httpts://A.com"/>` on A and `<link rel="canonical" href="httpts://A.com"/>` on B as well.

By default, Docusaurus automatically adds the annotation to every page in a docset, but the URL always points to the address of the page it's set on. To go back to our example, this results in Docusaurus setting `<link rel="canonical" href="httpts://A.com"/>` on A and `<link rel="canonical" href="httpts://B.com"/>` on B.

If you have multiple versions of the same page, Docusaurus will create competing canonical pages, impairing search results. 

In our case, this means that `/versioned_docs` pages erroneously point to themselves as canonical, and search results will often give users older pages instead of pages pertaining to the latest version of Rancher.

Thankfully, Docusaurus allows us to [override ](https://docusaurus.io/docs/2.3.1/markdown-features/head-metadata) this behavior by editing each page's `head`. This is distinct from the front matter we can add to our Markdown files, as this metadata is contained within standard HTML tags.

Here's a screenshot of the page source on a preview build of the v2.5 page we edited for the PR:

![image](https://github.com/rancher/rancher-docs/assets/19174201/4de32808-c7df-4882-a5a7-b8ea6f311347)

As you can see, it points to the URL for the v2.7 page in `/docs`.

Hopefully, this will help address problems with users finding older pages within search results.
 