### PR TITLE
formatting typo

### DIFF
--- a/versioned_docs/version-2.5/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli.md
+++ b/versioned_docs/version-2.5/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli.md
@@ -10,7 +10,6 @@ Howdy Partner! This tutorial walks you through:
 
 >**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation](../../../pages-for-subheaders/installation-and-upgrade.md).
 
-<br/>
 ### 1. Provision a Linux Host
 
  Begin creation of a custom cluster by provisioning a Linux host. Your host can be:


### PR DESCRIPTION
The ### Markdown syntax was visible due to a HTML spacing tag being placed right above the header line