### PR TITLE
Remove/update scale down verbiage

### DIFF
--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/rke1-vs-rke2-differences.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/rke1-vs-rke2-differences.md
@@ -20,8 +20,6 @@ The following are some specific example configuration changes that may cause the
 
 - When editing the cluster and enabling `drain before delete`, the existing control plane nodes and worker are deleted and new nodes are created.
 
-- When nodes are being provisioned and a scale down operation is performed, rather than scaling down the desired number of nodes, it is possible that the currently provisioning nodes get deleted and new nodes are provisioned to reach the desired node count. Please note that this is a bug in Cluster API, and it will be fixed in an upcoming release. Once fixed, Rancher will update the documentation.
-
 Users who are used to RKE1 provisioning should take note of this new RKE2 behavior which may be unexpected.
 
 ### Terminology

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/rke1-vs-rke2-differences.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/rke1-vs-rke2-differences.md
@@ -20,7 +20,7 @@ The following are some specific example configuration changes that may cause the
 
 - When editing the cluster and enabling `drain before delete`, the existing control plane nodes and worker are deleted and new nodes are created.
 
-- For Rancher v2.6.6 and earlier, when nodes are being provisioned and a scale down operation is performed, rather than scaling down the desired number of nodes, it is possible that the currently provisioning nodes get deleted and new nodes are provisioned to reach the desired node count. Please note that this is a bug in the Cluster API, and that it will be fixed in an upcoming release. Once fixed, Rancher will update the documentation.
+- For Rancher v2.6.6 and earlier, when nodes are being provisioned and a scale down operation is performed, rather than scaling down the desired number of nodes, it is possible that the currently provisioning nodes get deleted and new nodes are provisioned to reach the desired node count. Please note that this is a bug in the Cluster API that is fixed in newer Rancher versions.
 
 Users who are used to RKE1 provisioning should take note of this new RKE2 behavior which may be unexpected.
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/rke1-vs-rke2-differences.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/rke1-vs-rke2-differences.md
@@ -20,7 +20,7 @@ The following are some specific example configuration changes that may cause the
 
 - When editing the cluster and enabling `drain before delete`, the existing control plane nodes and worker are deleted and new nodes are created.
 
-- When nodes are being provisioned and a scale down operation is performed, rather than scaling down the desired number of nodes, it is possible that the currently provisioning nodes get deleted and new nodes are provisioned to reach the desired node count. Please note that this is a bug in Cluster API, and it will be fixed in an upcoming release. Once fixed, Rancher will update the documentation.
+- For Rancher v2.6.6 and earlier, when nodes are being provisioned and a scale down operation is performed, rather than scaling down the desired number of nodes, it is possible that the currently provisioning nodes get deleted and new nodes are provisioned to reach the desired node count. Please note that this is a bug in Cluster API, and it will be fixed in an upcoming release. Once fixed, Rancher will update the documentation.
 
 Users who are used to RKE1 provisioning should take note of this new RKE2 behavior which may be unexpected.
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/rke1-vs-rke2-differences.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/rke1-vs-rke2-differences.md
@@ -20,7 +20,7 @@ The following are some specific example configuration changes that may cause the
 
 - When editing the cluster and enabling `drain before delete`, the existing control plane nodes and worker are deleted and new nodes are created.
 
-- For Rancher v2.6.6 and earlier, when nodes are being provisioned and a scale down operation is performed, rather than scaling down the desired number of nodes, it is possible that the currently provisioning nodes get deleted and new nodes are provisioned to reach the desired node count. Please note that this is a bug in Cluster API, and it will be fixed in an upcoming release. Once fixed, Rancher will update the documentation.
+- For Rancher v2.6.6 and earlier, when nodes are being provisioned and a scale down operation is performed, rather than scaling down the desired number of nodes, it is possible that the currently provisioning nodes get deleted and new nodes are provisioned to reach the desired node count. Please note that this is a bug in the Cluster API, and that it will be fixed in an upcoming release. Once fixed, Rancher will update the documentation.
 
 Users who are used to RKE1 provisioning should take note of this new RKE2 behavior which may be unexpected.
 


### PR DESCRIPTION
2.7: removed
2.6: updated to indicate applicable to 2.6.6 and earlier (fixed in 2.6.7)

Fixes https://github.com/rancher/rancher-docs/issues/65.