### PR TITLE
#636 Add pages missing from sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -49,6 +49,7 @@ const sidebars = {
                 "getting-started/quick-start-guides/deploy-rancher-manager/hetzner-cloud",
                 "getting-started/quick-start-guides/deploy-rancher-manager/vagrant",
                 "getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal",
+                "getting-started/quick-start-guides/deploy-rancher-manager/outscale-qs",
                 "getting-started/quick-start-guides/deploy-rancher-manager/helm-cli",
 
               ]

--- a/versioned_sidebars/version-2.6-sidebars.json
+++ b/versioned_sidebars/version-2.6-sidebars.json
@@ -30,6 +30,7 @@
                 "getting-started/quick-start-guides/deploy-rancher-manager/hetzner-cloud",
                 "getting-started/quick-start-guides/deploy-rancher-manager/vagrant",
                 "getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal",
+                "getting-started/quick-start-guides/deploy-rancher-manager/outscale-qs",
                 "getting-started/quick-start-guides/deploy-rancher-manager/helm-cli"
               ]
             },


### PR DESCRIPTION
Fixes #636 

Two quickstart pages for Outscale were missing from the sidebar, but were still accessible via site search. Looking into the problem, it seems like it was a simple oversight during the site migration.