### PR TITLE
Fix broken links - Part 3

### DIFF
--- a/docs/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
+++ b/docs/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
@@ -2,7 +2,7 @@
 title: Continuous Delivery with Fleet
 ---
 
-Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It's also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/single-cluster-install/) too, but it really shines when you get to a [large scale.](https://fleet.rancher.io/multi-cluster-install/) By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
+Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It's also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/single-cluster-install) too, but it really shines when you get to a [large scale.](https://fleet.rancher.io/multi-cluster-install) By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
 
 Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.
 
@@ -13,7 +13,7 @@ For information about how Fleet works, see [this page.](../../../integrations-in
 
 ## Accessing Fleet in the Rancher UI
 
-Fleet comes preinstalled in Rancher and is managed by the **Continous Delivery** option in the Rancher UI. For additional information on Continuous Delivery and other Fleet troubleshooting tips, refer [here](https://fleet.rancher.io/troubleshooting/).
+Fleet comes preinstalled in Rancher and is managed by the **Continous Delivery** option in the Rancher UI. For additional information on Continuous Delivery and other Fleet troubleshooting tips, refer [here](https://fleet.rancher.io/troubleshooting).
 
 Users can leverage continuous delivery to deploy their applications to the Kubernetes clusters in the git repository without any manual operation by following **gitops** practice.
 
@@ -28,7 +28,7 @@ Follow the steps below to access Continuous Delivery in the Rancher UI:
 
 1. Click on **Gitrepos** on the left navigation bar to deploy the gitrepo into your clusters in the current workspace.
 
-1. Select your [git repository](https://fleet.rancher.io/gitrepo-add/) and [target clusters/cluster group](https://fleet.rancher.io/gitrepo-targets). You can also create the cluster group in the UI by clicking on **Cluster Groups** from the left navigation bar.
+1. Select your [git repository](https://fleet.rancher.io/gitrepo-add) and [target clusters/cluster group](https://fleet.rancher.io/gitrepo-targets). You can also create the cluster group in the UI by clicking on **Cluster Groups** from the left navigation bar.
 
 1. Once the gitrepo is deployed, you can monitor the application through the Rancher UI.
 

--- a/docs/how-to-guides/new-user-guides/manage-clusters/manage-cluster-templates.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/manage-cluster-templates.md
@@ -84,7 +84,7 @@ You can update any clusters using a template from the **Apps > Installed Apps** 
 - In order to show in the form for creating new clusters, the cluster template's Helm chart must have the `catalog.cattle.io/type:cluster-template` annotation.
 - In order to use a template as part of continuous delivery/GitOps, the cluster template needs to be deployed in the `fleet-local` namespace of the `local` cluster.
 - All values must be set in the `values.yaml` of the template.
-- Fleet repositories must follow the guidelines on [this page.](http://fleet.rancher.io/gitrepo-structure/) For RKE2 cluster templates, that means a `fleet.yaml` file must be added to the repository.
+- Fleet repositories must follow the guidelines on [this page.](http://fleet.rancher.io/gitrepo-structure) For RKE2 cluster templates, that means a `fleet.yaml` file must be added to the repository.
 
 :::
 

--- a/docs/pages-for-subheaders/fleet-gitops-at-scale.md
+++ b/docs/pages-for-subheaders/fleet-gitops-at-scale.md
@@ -2,7 +2,7 @@
 title: Continuous Delivery with Fleet
 ---
 
-Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/single-cluster-install/) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/multi-cluster-install/). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
+Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/single-cluster-install) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/multi-cluster-install). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
 
 Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.
 
@@ -13,7 +13,7 @@ For information about how Fleet works, see [this page](../integrations-in-ranche
 
 ## Accessing Fleet in the Rancher UI
 
-Fleet comes preinstalled in Rancher and is managed by the **Continuous Delivery** option in the Rancher UI. For additional information on Continuous Delivery and other Fleet troubleshooting tips, refer [here](https://fleet.rancher.io/troubleshooting/).
+Fleet comes preinstalled in Rancher and is managed by the **Continuous Delivery** option in the Rancher UI. For additional information on Continuous Delivery and other Fleet troubleshooting tips, refer [here](https://fleet.rancher.io/troubleshooting).
 
 Users can leverage continuous delivery to deploy their applications to the Kubernetes clusters in the git repository without any manual operation by following **gitops** practice.
 
@@ -31,7 +31,7 @@ Follow the steps below to access Continuous Delivery in the Rancher UI:
 
 1. Click on **Gitrepos** on the left navigation bar to deploy the gitrepo into your clusters in the current workspace.
 
-1. Select your [git repository](https://fleet.rancher.io/gitrepo-add/) and [target clusters/cluster group](https://fleet.rancher.io/gitrepo-targets/). You can also create the cluster group in the UI by clicking on **Cluster Groups** from the left navigation bar.
+1. Select your [git repository](https://fleet.rancher.io/gitrepo-add) and [target clusters/cluster group](https://fleet.rancher.io/gitrepo-targets). You can also create the cluster group in the UI by clicking on **Cluster Groups** from the left navigation bar.
 
 1. Once the gitrepo is deployed, you can monitor the application through the Rancher UI.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
@@ -2,7 +2,7 @@
 title: 使用 Feet 进行持续交付
 ---
 
-使用 Fleet 的持续交付是大规模的 GitOps。你可以使用 Fleet 管理多达一百万个集群。Fleet 非常轻量，可以很好地用于[单个集群](https://fleet.rancher.io/single-cluster-install/)，但是在你达到[大规模](https://fleet.rancher.io/multi-cluster-install/)时，它能发挥更强的实力。此处的大规模指的是大量集群、大量部署、或组织中存在大量团队的情况。
+使用 Fleet 的持续交付是大规模的 GitOps。你可以使用 Fleet 管理多达一百万个集群。Fleet 非常轻量，可以很好地用于[单个集群](https://fleet.rancher.io/single-cluster-install)，但是在你达到[大规模](https://fleet.rancher.io/multi-cluster-install)时，它能发挥更强的实力。此处的大规模指的是大量集群、大量部署、或组织中存在大量团队的情况。
 
 Fleet 是一个独立于 Rancher 的项目，你可以使用 Helm 将它安装在任何 Kubernetes 集群上。
 
@@ -13,7 +13,7 @@ Fleet 是一个独立于 Rancher 的项目，你可以使用 Helm 将它安装�
 
 ## 在 Rancher UI 中访问 Fleet
 
-Fleet 预装在 Rancher 中，通过 Rancher UI 中的**持续交付**选项管理。有关持续交付和 Fleet 故障排除技巧的更多信息，请参阅[此处](https://fleet.rancher.io/troubleshooting/)。
+Fleet 预装在 Rancher 中，通过 Rancher UI 中的**持续交付**选项管理。有关持续交付和 Fleet 故障排除技巧的更多信息，请参阅[此处](https://fleet.rancher.io/troubleshooting)。
 
 用户可以通过遵循 **gitops** 的实践，利用持续交付将应用部署到 git 仓库中的 Kubernetes 集群，而无需任何手动操作。
 
@@ -28,7 +28,7 @@ Fleet 预装在 Rancher 中，通过 Rancher UI 中的**持续交付**选项管�
 
 1. 单击左侧导航栏上的 **Git 仓库**将 git 仓库部署到当前工作空间中的集群中。
 
-1. 选择你的 [git 仓库](https://fleet.rancher.io/gitrepo-add/)和[目标集群/集群组](https://fleet.rancher.io/gitrepo-targets)。你还可以单击左侧导航栏中的**集群组**在 UI 中创建集群组。
+1. 选择你的 [git 仓库](https://fleet.rancher.io/gitrepo-add)和[目标集群/集群组](https://fleet.rancher.io/gitrepo-targets)。你还可以单击左侧导航栏中的**集群组**在 UI 中创建集群组。
 
 1. 部署 git 仓库后，你可以通过 Rancher UI 监控应用。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/manage-clusters/manage-cluster-templates.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/manage-clusters/manage-cluster-templates.md
@@ -84,7 +84,7 @@ RKE2 集群模板的示例仓库在[这里](https://github.com/rancher/cluster-t
 - 为了以创建新集群的形式显示，集群模板的 Helm Chart 必须具有 `catalog.cattle.io/type:cluster-template` 注释。
 - 为了将模板用作持续交付/GitOps 的一部分，集群模板需要部署在`本地`集群的 `fleet-local` 命名空间中。
 - 所有值都必须在模板的 `values.yaml` 中设置。
-- Fleet 仓库必须遵循此处的[准则](http://fleet.rancher.io/gitrepo-structure/)。对于 RKE2 集群模板，则必须把 `fleet.yaml` 文件添加到仓库。
+- Fleet 仓库必须遵循此处的[准则](http://fleet.rancher.io/gitrepo-structure)。对于 RKE2 集群模板，则必须把 `fleet.yaml` 文件添加到仓库。
 
 :::
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/pages-for-subheaders/fleet-gitops-at-scale.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/pages-for-subheaders/fleet-gitops-at-scale.md
@@ -2,7 +2,7 @@
 title: 使用 Feet 进行持续交付
 ---
 
-使用 Fleet 的持续交付是大规模的 GitOps。你可以使用 Fleet 管理多达一百万个集群。此外，它非常轻量，因此也非常适用于[单个集群](https://fleet.rancher.io/single-cluster-install/)。但是，它在[大规模](https://fleet.rancher.io/multi-cluster-install/)场景下的功能更加强大。大规模指的是大量集群、大量部署或大量团队。
+使用 Fleet 的持续交付是大规模的 GitOps。你可以使用 Fleet 管理多达一百万个集群。此外，它非常轻量，因此也非常适用于[单个集群](https://fleet.rancher.io/single-cluster-install)。但是，它在[大规模](https://fleet.rancher.io/multi-cluster-install)场景下的功能更加强大。大规模指的是大量集群、大量部署或大量团队。
 
 Fleet 是一个独立于 Rancher 的项目，你可以使用 Helm 将它安装在任何 Kubernetes 集群上。
 
@@ -13,7 +13,7 @@ Fleet 是一个独立于 Rancher 的项目，你可以使用 Helm 将它安装�
 
 ## 在 Rancher UI 中访问 Fleet
 
-Fleet 预装在 Rancher 中，可以通过 Rancher UI 中的**持续交付**选项进行管理。有关持续交付和 Fleet 故障排除技巧的更多信息，请参阅[此处](https://fleet.rancher.io/troubleshooting/)。
+Fleet 预装在 Rancher 中，可以通过 Rancher UI 中的**持续交付**选项进行管理。有关持续交付和 Fleet 故障排除技巧的更多信息，请参阅[此处](https://fleet.rancher.io/troubleshooting)。
 
 用户可以通过遵循 **gitops** 的实践，利用持续交付将应用部署到 git 仓库中的 Kubernetes 集群，而无需任何手动操作。
 
@@ -31,7 +31,7 @@ Fleet 预装在 Rancher 中，可以通过 Rancher UI 中的**持续交付**选�
 
 1. 单击左侧导航栏上的 **Git 仓库**将 git 仓库部署到当前工作空间中的集群中。
 
-1. 选择你的 [git 仓库](https://fleet.rancher.io/gitrepo-add/)和[目标集群/集群组](https://fleet.rancher.io/gitrepo-targets/)。你还可以单击左侧导航栏中的**集群组**在 UI 中创建集群组。
+1. 选择你的 [git 仓库](https://fleet.rancher.io/gitrepo-add)和[目标集群/集群组](https://fleet.rancher.io/gitrepo-targets)。你还可以单击左侧导航栏中的**集群组**在 UI 中创建集群组。
 
 1. 部署 git 仓库后，你可以通过 Rancher UI 监控应用。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
@@ -2,7 +2,7 @@
 title: 使用 Feet 进行持续交付
 ---
 
-使用 Fleet 的持续交付是大规模的 GitOps。你可以使用 Fleet 管理多达一百万个集群。Fleet 非常轻量，可以很好地用于[单个集群](https://fleet.rancher.io/single-cluster-install/)，但是在你达到[大规模](https://fleet.rancher.io/multi-cluster-install/)时，它能发挥更强的实力。此处的大规模指的是大量集群、大量部署、或组织中存在大量团队的情况。
+使用 Fleet 的持续交付是大规模的 GitOps。你可以使用 Fleet 管理多达一百万个集群。Fleet 非常轻量，可以很好地用于[单个集群](https://fleet.rancher.io/single-cluster-install)，但是在你达到[大规模](https://fleet.rancher.io/multi-cluster-install)时，它能发挥更强的实力。此处的大规模指的是大量集群、大量部署、或组织中存在大量团队的情况。
 
 Fleet 是一个独立于 Rancher 的项目，你可以使用 Helm 将它安装在任何 Kubernetes 集群上。
 
@@ -13,7 +13,7 @@ Fleet 是一个独立于 Rancher 的项目，你可以使用 Helm 将它安装�
 
 ## 在 Rancher UI 中访问 Fleet
 
-Fleet 预装在 Rancher 中，通过 Rancher UI 中的**持续交付**选项管理。有关持续交付和 Fleet 故障排除技巧的更多信息，请参阅[此处](https://fleet.rancher.io/troubleshooting/)。
+Fleet 预装在 Rancher 中，通过 Rancher UI 中的**持续交付**选项管理。有关持续交付和 Fleet 故障排除技巧的更多信息，请参阅[此处](https://fleet.rancher.io/troubleshooting)。
 
 用户可以通过遵循 **gitops** 的实践，利用持续交付将应用部署到 git 仓库中的 Kubernetes 集群，而无需任何手动操作。
 
@@ -28,7 +28,7 @@ Fleet 预装在 Rancher 中，通过 Rancher UI 中的**持续交付**选项管�
 
 1. 单击左侧导航栏上的 **Git 仓库**将 git 仓库部署到当前工作空间中的集群中。
 
-1. 选择你的 [git 仓库](https://fleet.rancher.io/gitrepo-add/)和[目标集群/集群组](https://fleet.rancher.io/gitrepo-targets)。你还可以单击左侧导航栏中的**集群组**在 UI 中创建集群组。
+1. 选择你的 [git 仓库](https://fleet.rancher.io/gitrepo-add)和[目标集群/集群组](https://fleet.rancher.io/gitrepo-targets)。你还可以单击左侧导航栏中的**集群组**在 UI 中创建集群组。
 
 1. 部署 git 仓库后，你可以通过 Rancher UI 监控应用。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/manage-cluster-templates.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/manage-cluster-templates.md
@@ -108,7 +108,7 @@ RKE2 集群模板的示例仓库在[这里](https://github.com/rancher/cluster-t
 - 为了以创建新集群的形式显示，集群模板的 Helm Chart 必须具有 `catalog.cattle.io/type:cluster-template` 注释。
 - 为了将模板用作持续交付/GitOps 的一部分，集群模板需要部署在`本地`集群的 `fleet-local` 命名空间中。
 - 所有值都必须在模板的 `values.yaml` 中设置。
-- Fleet 仓库必须遵循此处的[准则](http://fleet.rancher.io/gitrepo-structure/)。对于 RKE2 集群模板，则必须把 `fleet.yaml` 文件添加到仓库。
+- Fleet 仓库必须遵循此处的[准则](http://fleet.rancher.io/gitrepo-structure)。对于 RKE2 集群模板，则必须把 `fleet.yaml` 文件添加到仓库。
 
 :::
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/pages-for-subheaders/fleet-gitops-at-scale.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/pages-for-subheaders/fleet-gitops-at-scale.md
@@ -2,7 +2,7 @@
 title: 使用 Feet 进行持续交付
 ---
 
-使用 Fleet 的持续交付是大规模的 GitOps。你可以使用 Fleet 管理多达一百万个集群。此外，它非常轻量，因此也非常适用于[单个集群](https://fleet.rancher.io/single-cluster-install/)。但是，它在[大规模](https://fleet.rancher.io/multi-cluster-install/)场景下的功能更加强大。大规模指的是大量集群、大量部署或大量团队。
+使用 Fleet 的持续交付是大规模的 GitOps。你可以使用 Fleet 管理多达一百万个集群。此外，它非常轻量，因此也非常适用于[单个集群](https://fleet.rancher.io/single-cluster-install)。但是，它在[大规模](https://fleet.rancher.io/multi-cluster-install)场景下的功能更加强大。大规模指的是大量集群、大量部署或大量团队。
 
 Fleet 是一个独立于 Rancher 的项目，你可以使用 Helm 将它安装在任何 Kubernetes 集群上。
 
@@ -13,7 +13,7 @@ Fleet 是一个独立于 Rancher 的项目，你可以使用 Helm 将它安装�
 
 ## 在 Rancher UI 中访问 Fleet
 
-Fleet 预装在 Rancher 中，可以通过 Rancher UI 中的**持续交付**选项进行管理。有关持续交付和 Fleet 故障排除技巧的更多信息，请参阅[此处](https://fleet.rancher.io/troubleshooting/)。
+Fleet 预装在 Rancher 中，可以通过 Rancher UI 中的**持续交付**选项进行管理。有关持续交付和 Fleet 故障排除技巧的更多信息，请参阅[此处](https://fleet.rancher.io/troubleshooting)。
 
 用户可以通过遵循 **gitops** 的实践，利用持续交付将应用部署到 git 仓库中的 Kubernetes 集群，而无需任何手动操作。
 
@@ -31,7 +31,7 @@ Fleet 预装在 Rancher 中，可以通过 Rancher UI 中的**持续交付**选�
 
 1. 单击左侧导航栏上的 **Git 仓库**将 git 仓库部署到当前工作空间中的集群中。
 
-1. 选择你的 [git 仓库](https://fleet.rancher.io/gitrepo-add/)和[目标集群/集群组](https://fleet.rancher.io/gitrepo-targets)。你还可以单击左侧导航栏中的**集群组**在 UI 中创建集群组。
+1. 选择你的 [git 仓库](https://fleet.rancher.io/gitrepo-add)和[目标集群/集群组](https://fleet.rancher.io/gitrepo-targets)。你还可以单击左侧导航栏中的**集群组**在 UI 中创建集群组。
 
 1. 部署 git 仓库后，你可以通过 Rancher UI 监控应用。
 

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
@@ -4,7 +4,7 @@ title: Fleet - GitOps at Scale
 
 _Available as of Rancher v2.5_
 
-Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It's also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/single-cluster-install/) too, but it really shines when you get to a [large scale.](https://fleet.rancher.io/multi-cluster-install/) By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
+Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It's also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/single-cluster-install) too, but it really shines when you get to a [large scale.](https://fleet.rancher.io/multi-cluster-install) By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
 
 Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.
 
@@ -15,7 +15,7 @@ For information about how Fleet works, see [this page.](../../../explanations/in
 
 ## Accessing Fleet in the Rancher UI
 
-Fleet comes preinstalled in Rancher v2.5. Users can leverage continuous delivery to deploy their applications to the Kubernetes clusters in the git repository without any manual operation by following **gitops** practice. For additional information on Continuous Delivery and other Fleet troubleshooting tips, refer [here](https://fleet.rancher.io/troubleshooting/).
+Fleet comes preinstalled in Rancher v2.5. Users can leverage continuous delivery to deploy their applications to the Kubernetes clusters in the git repository without any manual operation by following **gitops** practice. For additional information on Continuous Delivery and other Fleet troubleshooting tips, refer [here](https://fleet.rancher.io/troubleshooting).
 
 Follow the steps below to access Continuous Delivery in the Rancher UI:
 
@@ -30,7 +30,7 @@ Follow the steps below to access Continuous Delivery in the Rancher UI:
 
 1. Click on **Gitrepos** on the left navigation bar to deploy the gitrepo into your clusters in the current workspace.
 
-1. Select your [git repository](https://fleet.rancher.io/gitrepo-add/) and [target clusters/cluster group](https://fleet.rancher.io/gitrepo-targets). You can also create the cluster group in the UI by clicking on **Cluster Groups** from the left navigation bar.
+1. Select your [git repository](https://fleet.rancher.io/gitrepo-add) and [target clusters/cluster group](https://fleet.rancher.io/gitrepo-targets). You can also create the cluster group in the UI by clicking on **Cluster Groups** from the left navigation bar.
 
 1. Once the gitrepo is deployed, you can monitor the application through the Rancher UI.
 

--- a/versioned_docs/version-2.5/pages-for-subheaders/fleet-gitops-at-scale.md
+++ b/versioned_docs/version-2.5/pages-for-subheaders/fleet-gitops-at-scale.md
@@ -4,7 +4,7 @@ title: Continuous Delivery with Fleet
 
 _Available as of Rancher v2.5_
 
-Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/single-cluster-install/) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/multi-cluster-install/). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
+Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/single-cluster-install) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/multi-cluster-install). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
 
 Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.
 
@@ -15,7 +15,7 @@ For information about how Fleet works, see [this page](../explanations/integrati
 
 ## Accessing Fleet in the Rancher UI
 
-Fleet comes preinstalled in Rancher v2.5. Users can leverage continuous delivery to deploy their applications to the Kubernetes clusters in the git repository without any manual operation by following **gitops** practice. For additional information on Continuous Delivery and other Fleet troubleshooting tips, refer [here](https://fleet.rancher.io/troubleshooting/).
+Fleet comes preinstalled in Rancher v2.5. Users can leverage continuous delivery to deploy their applications to the Kubernetes clusters in the git repository without any manual operation by following **gitops** practice. For additional information on Continuous Delivery and other Fleet troubleshooting tips, refer [here](https://fleet.rancher.io/troubleshooting).
 
 Follow the steps below to access Continuous Delivery in the Rancher UI:
 
@@ -33,7 +33,7 @@ Follow the steps below to access Continuous Delivery in the Rancher UI:
 
 1. Click on **Gitrepos** on the left navigation bar to deploy the gitrepo into your clusters in the current workspace.
 
-1. Select your [git repository](https://fleet.rancher.io/gitrepo-add/) and [target clusters/cluster group](https://fleet.rancher.io/gitrepo-targets). You can also create the cluster group in the UI by clicking on **Cluster Groups** from the left navigation bar.
+1. Select your [git repository](https://fleet.rancher.io/gitrepo-add) and [target clusters/cluster group](https://fleet.rancher.io/gitrepo-targets). You can also create the cluster group in the UI by clicking on **Cluster Groups** from the left navigation bar.
 
 1. Once the gitrepo is deployed, you can monitor the application through the Rancher UI.
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
@@ -2,7 +2,7 @@
 title: Continuous Delivery with Fleet
 ---
 
-Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It's also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/single-cluster-install/) too, but it really shines when you get to a [large scale.](https://fleet.rancher.io/multi-cluster-install/) By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
+Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It's also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/single-cluster-install) too, but it really shines when you get to a [large scale.](https://fleet.rancher.io/multi-cluster-install) By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
 
 Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.
 
@@ -13,7 +13,7 @@ For information about how Fleet works, see [this page.](../../../integrations-in
 
 ## Accessing Fleet in the Rancher UI
 
-Fleet comes preinstalled in Rancher and is managed by the **Continous Delivery** option in the Rancher UI. For additional information on Continuous Delivery and other Fleet troubleshooting tips, refer [here](https://fleet.rancher.io/troubleshooting/).
+Fleet comes preinstalled in Rancher and is managed by the **Continous Delivery** option in the Rancher UI. For additional information on Continuous Delivery and other Fleet troubleshooting tips, refer [here](https://fleet.rancher.io/troubleshooting).
 
 Users can leverage continuous delivery to deploy their applications to the Kubernetes clusters in the git repository without any manual operation by following **gitops** practice.
 
@@ -28,7 +28,7 @@ Follow the steps below to access Continuous Delivery in the Rancher UI:
 
 1. Click on **Gitrepos** on the left navigation bar to deploy the gitrepo into your clusters in the current workspace.
 
-1. Select your [git repository](https://fleet.rancher.io/gitrepo-add/) and [target clusters/cluster group](https://fleet.rancher.io/gitrepo-targets). You can also create the cluster group in the UI by clicking on **Cluster Groups** from the left navigation bar.
+1. Select your [git repository](https://fleet.rancher.io/gitrepo-add) and [target clusters/cluster group](https://fleet.rancher.io/gitrepo-targets). You can also create the cluster group in the UI by clicking on **Cluster Groups** from the left navigation bar.
 
 1. Once the gitrepo is deployed, you can monitor the application through the Rancher UI.
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/manage-cluster-templates.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/manage-cluster-templates.md
@@ -108,7 +108,7 @@ You can update any clusters using a template from the **Apps & Marketplace > Ins
 - In order to show in the form for creating new clusters, the cluster template's Helm chart must have the `catalog.cattle.io/type:cluster-template` annotation.
 - In order to use a template as part of continuous delivery/GitOps, the cluster template needs to be deployed in the `fleet-local` namespace of the `local` cluster.
 - All values must be set in the `values.yaml` of the template.
-- Fleet repositories must follow the guidelines on [this page.](http://fleet.rancher.io/gitrepo-structure/) For RKE2 cluster templates, that means a `fleet.yaml` file must be added to the repository.
+- Fleet repositories must follow the guidelines on [this page.](http://fleet.rancher.io/gitrepo-structure) For RKE2 cluster templates, that means a `fleet.yaml` file must be added to the repository.
 
 :::
 

--- a/versioned_docs/version-2.6/pages-for-subheaders/fleet-gitops-at-scale.md
+++ b/versioned_docs/version-2.6/pages-for-subheaders/fleet-gitops-at-scale.md
@@ -2,7 +2,7 @@
 title: Continuous Delivery with Fleet
 ---
 
-Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/single-cluster-install/) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/multi-cluster-install/). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
+Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/single-cluster-install) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/multi-cluster-install). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
 
 Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.
 
@@ -13,7 +13,7 @@ For information about how Fleet works, see [this page](../integrations-in-ranche
 
 ## Accessing Fleet in the Rancher UI
 
-Fleet comes preinstalled in Rancher and is managed by the **Continuous Delivery** option in the Rancher UI. For additional information on Continuous Delivery and other Fleet troubleshooting tips, refer [here](https://fleet.rancher.io/troubleshooting/).
+Fleet comes preinstalled in Rancher and is managed by the **Continuous Delivery** option in the Rancher UI. For additional information on Continuous Delivery and other Fleet troubleshooting tips, refer [here](https://fleet.rancher.io/troubleshooting).
 
 Users can leverage continuous delivery to deploy their applications to the Kubernetes clusters in the git repository without any manual operation by following **gitops** practice.
 
@@ -31,7 +31,7 @@ Follow the steps below to access Continuous Delivery in the Rancher UI:
 
 1. Click on **Gitrepos** on the left navigation bar to deploy the gitrepo into your clusters in the current workspace.
 
-1. Select your [git repository](https://fleet.rancher.io/gitrepo-add/) and [target clusters/cluster group](https://fleet.rancher.io/gitrepo-targets). You can also create the cluster group in the UI by clicking on **Cluster Groups** from the left navigation bar.
+1. Select your [git repository](https://fleet.rancher.io/gitrepo-add) and [target clusters/cluster group](https://fleet.rancher.io/gitrepo-targets). You can also create the cluster group in the UI by clicking on **Cluster Groups** from the left navigation bar.
 
 1. Once the gitrepo is deployed, you can monitor the application through the Rancher UI.
 


### PR DESCRIPTION
This part of a series of PRs to fixe the broken links discovered after adding a link checker in #208.

Note that a small fraction (~15) of the 180 warnings still remain:
- Alternative/new links could not be found for some external links. E.g. https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers
- Docusaurus supports setting [custom heading IDs](https://docusaurus.io/docs/markdown-features/toc#heading-ids), which get flagged as broken by the checker.
- We've manually added anchors directly with HTML to some areas that normally don't have them. These get flagged as broken by the checker.