### PR TITLE
Fix broken links - Part 6

### DIFF
--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/troubleshooting.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/troubleshooting.md
@@ -150,7 +150,7 @@ Once the network issue is resolved, the `canal` pods should timeout and restart 
 
 ### nginx-ingress-controller Pods show RESTARTS
 
-The most common cause of this issue is the `canal` pods have failed to establish the overlay network. See [canal Pods show READY `2/3`](#canal-pods-show-ready-2-3) for troubleshooting.
+The most common cause of this issue is the `canal` pods have failed to establish the overlay network. See [canal Pods show READY `2/3`](#canal-pods-show-ready-23) for troubleshooting.
 
 
 ### Failed to dial to /var/run/docker.sock: ssh: rejected: administratively prohibited (open failed)

--- a/docs/how-to-guides/advanced-user-guides/monitoring-alerting-guides/customize-grafana-dashboard.md
+++ b/docs/how-to-guides/advanced-user-guides/monitoring-alerting-guides/customize-grafana-dashboard.md
@@ -35,5 +35,5 @@ You can then modify the query in the Grafana panel or create a new Grafana panel
 
 See also:
 
-- [Grafana docs on editing a panel](https://grafana.com/docs/grafana/latest/panels/panel-editor/)
-- [Grafana docs on adding a panel to a dashboard](https://grafana.com/docs/grafana/latest/panels/add-a-panel/)
+- [Grafana docs on editing a panel](https://grafana.com/docs/grafana/latest/panels-visualizations/configure-panel-options/#edit-a-panel)
+- [Grafana docs on adding a panel to a dashboard](https://grafana.com/docs/grafana/latest/panels-visualizations/panel-editor-overview)

--- a/docs/reference-guides/user-settings/manage-node-templates.md
+++ b/docs/reference-guides/user-settings/manage-node-templates.md
@@ -5,7 +5,7 @@ title: Managing Node Templates
 When you provision a cluster [hosted by an infrastructure provider](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md), [node templates](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md#node-templates) are used to provision the cluster nodes. These templates use Docker Machine configuration options to define an operating system image and settings/parameters for the node. You can create node templates in two contexts:
 
 - While [provisioning a node pool cluster](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md).
-- At any time, from your [user settings](#creating-a-node-template-from-user-settings).
+- At any time, from your [user settings](../../pages-for-subheaders/user-settings.md).
 
 When you create a node template, it is bound to your user profile. Node templates cannot be shared among users. You can delete stale node templates that you no longer user from your user settings.
 
@@ -25,7 +25,7 @@ When you create a node template, it is bound to your user profile. Node template
 1. Choose the node template that you want to edit and click the **⋮ > Edit**.
 
     :::note
-    
+
     The default `active` [node drivers](../../how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md) and any node driver, that has fields marked as `password`, are required to use [cloud credentials](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md#cloud-credentials).
 
     :::

--- a/docs/troubleshooting/other-troubleshooting-tips/dns.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/dns.md
@@ -199,7 +199,7 @@ As the `kubelet` is running inside a container, the path for files located in `/
 
 :::
 
-See [Editing Cluster as YAML](../../pages-for-subheaders/cluster-configuration.md#editing-clusters-with-yaml) how to apply this change. When the provisioning of the cluster has finished, you have to remove the kube-dns pod to activate the new setting in the pod:
+See [Editing Cluster as YAML](../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md#editing-clusters-with-yaml) how to apply this change. When the provisioning of the cluster has finished, you have to remove the kube-dns pod to activate the new setting in the pod:
 
 ```
 kubectl delete pods -n kube-system -l k8s-app=kube-dns

--- a/docs/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs.md
@@ -5,7 +5,7 @@ title: User ID Tracking in Audit Logs
 The following audit logs are used in Rancher to track events occuring on the local and downstream clusters:
 
 * [Kubernetes Audit Logs](https://rancher.com/docs/rke/latest/en/config-options/audit-log/)
-* [Rancher API Audit Logs](../../how-to-guides/advanced-user-guides/enable-api-audit-log)
+* [Rancher API Audit Logs](../../how-to-guides/advanced-user-guides/enable-api-audit-log.md)
 
 Audit logs in Rancher v2.6 have been enhanced to include the external Identity Provider name (common name of the user in the external Auth provider) in both the Rancher and downstream Kubernetes audit logs.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/advanced-user-guides/monitoring-alerting-guides/customize-grafana-dashboard.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/advanced-user-guides/monitoring-alerting-guides/customize-grafana-dashboard.md
@@ -35,5 +35,5 @@ title: 自定义 Grafana 仪表板
 
 参考：
 
-- [编辑面板的 Grafana 文档](https://grafana.com/docs/grafana/latest/panels/panel-editor/)
-- [向仪表板添加面板的 Grafana 文档](https://grafana.com/docs/grafana/latest/panels/add-a-panel/)
+- [编辑面板的 Grafana 文档](https://grafana.com/docs/grafana/latest/panels-visualizations/configure-panel-options/#edit-a-panel)
+- [向仪表板添加面板的 Grafana 文档](https://grafana.com/docs/grafana/latest/panels-visualizations/panel-editor-overview)

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference-guides/user-settings/manage-node-templates.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference-guides/user-settings/manage-node-templates.md
@@ -5,7 +5,7 @@ title: 管理节点模板
 如果要配置[由基础设施提供商托管](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md)的集群，则可以使用[节点模板](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md#节点模板)来配置集群节点。这些模板使用 Docker Machine 配置选项来定义节点的操作系统镜像以及设置/参数。你可以在两种情况下创建节点模板：
 
 - [配置节点池集群](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md)。
-- 在任何时间使用[用户设置](#使用用户设置创建云凭证)。
+- 在任何时间使用[用户设置](../../pages-for-subheaders/user-settings.md)。
 
 创建节点模板时，它会绑定到你的用户配置文件。节点模板不能在用户之间共享。你可以从用户设置中删除不再使用的旧节点模板。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/troubleshooting/other-troubleshooting-tips/dns.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/troubleshooting/other-troubleshooting-tips/dns.md
@@ -199,7 +199,7 @@ services:
 
 :::
 
-请参阅[使用 YAML 编辑集群](../../pages-for-subheaders/cluster-configuration.md#使用-yaml-编辑集群)了解如何应用此修改。集群配置完成后，你必须删除 kube-dns pod 以激活 pod 中的新设置：
+请参阅[使用 YAML 编辑集群](../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md#使用-yaml-编辑集群)了解如何应用此修改。集群配置完成后，你必须删除 kube-dns pod 以激活 pod 中的新设置：
 
 ```
 kubectl delete pods -n kube-system -l k8s-app=kube-dns

--- a/i18n/zh/docusaurus-plugin-content-docs/current/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs.md
@@ -5,7 +5,7 @@ title: 审计日志中的用户 ID 跟踪
 Rancher 使用以下审计日志来跟踪本地和下游集群中发生的事件：
 
 * [Kubernetes 审计日志](https://rancher.com/docs/rke/latest/en/config-options/audit-log/)
-* [Rancher API 审核日志](../../how-to-guides/advanced-user-guides/enable-api-audit-log)
+* [Rancher API 审核日志](../../how-to-guides/advanced-user-guides/enable-api-audit-log.md)
 
 Rancher 2.6 增强了审计日志，在 Rancher 和下游 Kubernetes 审计日志中都包含了外部身份提供程序名称（即外部身份提供程序中用户的通用名称）。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/customize-grafana-dashboard.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/customize-grafana-dashboard.md
@@ -35,5 +35,5 @@ title: 自定义 Grafana 仪表板
 
 参考：
 
-- [编辑面板的 Grafana 文档](https://grafana.com/docs/grafana/latest/panels/panel-editor/)
-- [向仪表板添加面板的 Grafana 文档](https://grafana.com/docs/grafana/latest/panels/add-a-panel/)
+- [编辑面板的 Grafana 文档](https://grafana.com/docs/grafana/latest/panels-visualizations/configure-panel-options/#edit-a-panel)
+- [向仪表板添加面板的 Grafana 文档](https://grafana.com/docs/grafana/latest/panels-visualizations/panel-editor-overview)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/user-settings/manage-node-templates.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/user-settings/manage-node-templates.md
@@ -5,7 +5,7 @@ title: 管理节点模板
 如果要配置[由基础设施提供商托管](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md)的集群，则可以使用[节点模板](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md#节点模板)来配置集群节点。这些模板使用 Docker Machine 配置选项来定义节点的操作系统镜像以及设置/参数。你可以在两种情况下创建节点模板：
 
 - [配置节点池集群](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md)。
-- 在任何时间使用[用户设置](#使用用户设置创建云凭证)。
+- 在任何时间使用[用户设置](../../pages-for-subheaders/user-settings.md)。
 
 创建节点模板时，它会绑定到你的用户配置文件。节点模板不能在用户之间共享。你可以从用户设置中删除不再使用的旧节点模板。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/troubleshooting/other-troubleshooting-tips/dns.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/troubleshooting/other-troubleshooting-tips/dns.md
@@ -199,7 +199,7 @@ services:
 
 :::
 
-请参阅[使用 YAML 编辑集群](../../pages-for-subheaders/cluster-configuration.md#使用-yaml-编辑集群)了解如何应用此修改。集群配置完成后，你必须删除 kube-dns pod 以激活 pod 中的新设置：
+请参阅[使用 YAML 编辑集群](../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md#使用-yaml-编辑集群)了解如何应用此修改。集群配置完成后，你必须删除 kube-dns pod 以激活 pod 中的新设置：
 
 ```
 kubectl delete pods -n kube-system -l k8s-app=kube-dns

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs.md
@@ -5,7 +5,7 @@ title: 审计日志中的用户 ID 跟踪
 Rancher 使用以下审计日志来跟踪本地和下游集群中发生的事件：
 
 * [Kubernetes 审计日志](https://rancher.com/docs/rke/latest/en/config-options/audit-log/)
-* [Rancher API 审核日志](../../how-to-guides/advanced-user-guides/enable-api-audit-log)
+* [Rancher API 审核日志](../../how-to-guides/advanced-user-guides/enable-api-audit-log.md)
 
 Rancher 2.6 增强了审计日志，在 Rancher 和下游 Kubernetes 审计日志中都包含了外部身份提供程序名称（即外部身份提供程序中用户的通用名称）。
 

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/advanced-options/advanced-use-cases/helm2/kubernetes-rke/troubleshooting.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/advanced-options/advanced-use-cases/helm2/kubernetes-rke/troubleshooting.md
@@ -10,7 +10,7 @@ Once the network issue is resolved, the `canal` pods should timeout and restart 
 
 ### nginx-ingress-controller Pods show RESTARTS
 
-The most common cause of this issue is the `canal` pods have failed to establish the overlay network. See [canal Pods show READY `2/3`](#canal-pods-show-ready-2-3) for troubleshooting.
+The most common cause of this issue is the `canal` pods have failed to establish the overlay network. See [canal Pods show READY `2/3`](#canal-pods-show-ready-23) for troubleshooting.
 
 ### Failed to set up SSH tunneling for host [xxx.xxx.xxx.xxx]: Can't retrieve Docker Info
 

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/troubleshooting.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/troubleshooting.md
@@ -146,7 +146,7 @@ Once the network issue is resolved, the `canal` pods should timeout and restart 
 
 ### nginx-ingress-controller Pods show RESTARTS
 
-The most common cause of this issue is the `canal` pods have failed to establish the overlay network. See [canal Pods show READY `2/3`](#canal-pods-show-ready-2-3) for troubleshooting.
+The most common cause of this issue is the `canal` pods have failed to establish the overlay network. See [canal Pods show READY `2/3`](#canal-pods-show-ready-23) for troubleshooting.
 
 
 ### Failed to dial to /var/run/docker.sock: ssh: rejected: administratively prohibited (open failed)

--- a/versioned_docs/version-2.0-2.4/troubleshooting/other-troubleshooting-tips/dns.md
+++ b/versioned_docs/version-2.0-2.4/troubleshooting/other-troubleshooting-tips/dns.md
@@ -195,7 +195,7 @@ services:
 
 > **Note:** As the `kubelet` is running inside a container, the path for files located in `/etc` and `/usr` are in `/host/etc` and `/host/usr` inside the `kubelet` container.
 
-See [Editing Cluster as YAML](../../pages-for-subheaders/cluster-configuration.md#editing-clusters-with-yaml) how to apply this change. When the provisioning of the cluster has finished, you have to remove the kube-dns pod to activate the new setting in the pod:
+See [Editing Cluster as YAML](../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md#editing-clusters-with-yaml) how to apply this change. When the provisioning of the cluster has finished, you have to remove the kube-dns pod to activate the new setting in the pod:
 
 ```
 kubectl delete pods -n kube-system -l k8s-app=kube-dns

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/troubleshooting.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/troubleshooting.md
@@ -146,7 +146,7 @@ Once the network issue is resolved, the `canal` pods should timeout and restart 
 
 ### nginx-ingress-controller Pods show RESTARTS
 
-The most common cause of this issue is the `canal` pods have failed to establish the overlay network. See [canal Pods show READY `2/3`](#canal-pods-show-ready-2-3) for troubleshooting.
+The most common cause of this issue is the `canal` pods have failed to establish the overlay network. See [canal Pods show READY `2/3`](#canal-pods-show-ready-23) for troubleshooting.
 
 
 ### Failed to dial to /var/run/docker.sock: ssh: rejected: administratively prohibited (open failed)

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/monitoring-alerting-guides/customize-grafana-dashboard.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/monitoring-alerting-guides/customize-grafana-dashboard.md
@@ -35,5 +35,5 @@ You can then modify the query in the Grafana panel or create a new Grafana panel
 
 See also:
 
-- [Grafana docs on editing a panel](https://grafana.com/docs/grafana/latest/panels/panel-editor/)
-- [Grafana docs on adding a panel to a dashboard](https://grafana.com/docs/grafana/latest/panels/add-a-panel/)
+- [Grafana docs on editing a panel](https://grafana.com/docs/grafana/latest/panels-visualizations/configure-panel-options/#edit-a-panel)
+- [Grafana docs on adding a panel to a dashboard](https://grafana.com/docs/grafana/latest/panels-visualizations/panel-editor-overview)

--- a/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/dns.md
+++ b/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/dns.md
@@ -195,7 +195,7 @@ services:
 
 > **Note:** As the `kubelet` is running inside a container, the path for files located in `/etc` and `/usr` are in `/host/etc` and `/host/usr` inside the `kubelet` container.
 
-See [Editing Cluster as YAML](../../pages-for-subheaders/cluster-configuration.md#editing-clusters-with-yaml) how to apply this change. When the provisioning of the cluster has finished, you have to remove the kube-dns pod to activate the new setting in the pod:
+See [Editing Cluster as YAML](../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md#editing-clusters-with-yaml) how to apply this change. When the provisioning of the cluster has finished, you have to remove the kube-dns pod to activate the new setting in the pod:
 
 ```
 kubectl delete pods -n kube-system -l k8s-app=kube-dns

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/troubleshooting.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/troubleshooting.md
@@ -150,7 +150,7 @@ Once the network issue is resolved, the `canal` pods should timeout and restart 
 
 ### nginx-ingress-controller Pods show RESTARTS
 
-The most common cause of this issue is the `canal` pods have failed to establish the overlay network. See [canal Pods show READY `2/3`](#canal-pods-show-ready-2-3) for troubleshooting.
+The most common cause of this issue is the `canal` pods have failed to establish the overlay network. See [canal Pods show READY `2/3`](#canal-pods-show-ready-23) for troubleshooting.
 
 
 ### Failed to dial to /var/run/docker.sock: ssh: rejected: administratively prohibited (open failed)

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/customize-grafana-dashboard.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/customize-grafana-dashboard.md
@@ -35,5 +35,5 @@ You can then modify the query in the Grafana panel or create a new Grafana panel
 
 See also:
 
-- [Grafana docs on editing a panel](https://grafana.com/docs/grafana/latest/panels/panel-editor/)
-- [Grafana docs on adding a panel to a dashboard](https://grafana.com/docs/grafana/latest/panels/add-a-panel/)
+- [Grafana docs on editing a panel](https://grafana.com/docs/grafana/latest/panels-visualizations/configure-panel-options/#edit-a-panel)
+- [Grafana docs on adding a panel to a dashboard](https://grafana.com/docs/grafana/latest/panels-visualizations/panel-editor-overview)

--- a/versioned_docs/version-2.6/reference-guides/user-settings/manage-node-templates.md
+++ b/versioned_docs/version-2.6/reference-guides/user-settings/manage-node-templates.md
@@ -5,7 +5,7 @@ title: Managing Node Templates
 When you provision a cluster [hosted by an infrastructure provider](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md), [node templates](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md#node-templates) are used to provision the cluster nodes. These templates use Docker Machine configuration options to define an operating system image and settings/parameters for the node. You can create node templates in two contexts:
 
 - While [provisioning a node pool cluster](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md).
-- At any time, from your [user settings](#creating-a-node-template-from-user-settings).
+- At any time, from your [user settings](../../pages-for-subheaders/user-settings.md).
 
 When you create a node template, it is bound to your user profile. Node templates cannot be shared among users. You can delete stale node templates that you no longer user from your user settings.
 
@@ -25,7 +25,7 @@ When you create a node template, it is bound to your user profile. Node template
 1. Choose the node template that you want to edit and click the **⋮ > Edit**.
 
     :::note
-    
+
     The default `active` [node drivers](../../how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md) and any node driver, that has fields marked as `password`, are required to use [cloud credentials](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md#cloud-credentials).
 
     :::

--- a/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/dns.md
+++ b/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/dns.md
@@ -199,7 +199,7 @@ As the `kubelet` is running inside a container, the path for files located in `/
 
 :::
 
-See [Editing Cluster as YAML](../../pages-for-subheaders/cluster-configuration.md#editing-clusters-with-yaml) how to apply this change. When the provisioning of the cluster has finished, you have to remove the kube-dns pod to activate the new setting in the pod:
+See [Editing Cluster as YAML](../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md#editing-clusters-with-yaml) how to apply this change. When the provisioning of the cluster has finished, you have to remove the kube-dns pod to activate the new setting in the pod:
 
 ```
 kubectl delete pods -n kube-system -l k8s-app=kube-dns

--- a/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs.md
+++ b/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs.md
@@ -5,7 +5,7 @@ title: User ID Tracking in Audit Logs
 The following audit logs are used in Rancher to track events occuring on the local and downstream clusters:
 
 * [Kubernetes Audit Logs](https://rancher.com/docs/rke/latest/en/config-options/audit-log/)
-* [Rancher API Audit Logs](../../how-to-guides/advanced-user-guides/enable-api-audit-log)
+* [Rancher API Audit Logs](../../how-to-guides/advanced-user-guides/enable-api-audit-log.md)
 
 Audit logs in Rancher v2.6 have been enhanced to include the external Identity Provider name (common name of the user in the external Auth provider) in both the Rancher and downstream Kubernetes audit logs.
 


### PR DESCRIPTION
This part of a series of PRs to fixe the broken links discovered after adding a link checker in #208.

Note that a small fraction (~15) of the 180 warnings still remain:
- Alternative/new links could not be found for some external links. E.g. https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers
- Docusaurus supports setting [custom heading IDs](https://docusaurus.io/docs/markdown-features/toc#heading-ids), which get flagged as broken by the checker.
- We've manually added anchors directly with HTML to some areas that normally don't have them. These get flagged as broken by the checker.