### PR TITLE
Fix broken links - Part 12

### DIFF
--- a/docs/integrations-in-rancher/logging/logging-helm-chart-options.md
+++ b/docs/integrations-in-rancher/logging/logging-helm-chart-options.md
@@ -41,7 +41,7 @@ Logging v2 was tested with SELinux on RHEL/CentOS 7 and 8.
 
 [Security-Enhanced Linux (SELinux)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) is a security enhancement to Linux. After being historically used by government agencies, SELinux is now industry standard and is enabled by default on CentOS 7 and 8.
 
-To use Logging v2 with SELinux, we recommend installing the `rancher-selinux` RPM according to the instructions on [this page.](../../pages-for-subheaders/selinux-rpm.md)
+To use Logging v2 with SELinux, we recommend installing the `rancher-selinux` RPM according to these [instructions](../../pages-for-subheaders/selinux-rpm.md).
 
 Then, when installing the logging application, configure the chart to be SELinux aware by changing `global.seLinux.enabled` to `true` in the `values.yaml`.
 

--- a/docs/integrations-in-rancher/logging/logging-helm-chart-options.md
+++ b/docs/integrations-in-rancher/logging/logging-helm-chart-options.md
@@ -41,7 +41,7 @@ Logging v2 was tested with SELinux on RHEL/CentOS 7 and 8.
 
 [Security-Enhanced Linux (SELinux)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) is a security enhancement to Linux. After being historically used by government agencies, SELinux is now industry standard and is enabled by default on CentOS 7 and 8.
 
-To use Logging v2 with SELinux, we recommend installing the `rancher-selinux` RPM according to the instructions on [this page.](../../pages-for-subheaders/selinux-rpm.md#installing-the-rancher-selinux-rpm)
+To use Logging v2 with SELinux, we recommend installing the `rancher-selinux` RPM according to the instructions on [this page.](../../pages-for-subheaders/selinux-rpm.md)
 
 Then, when installing the logging application, configure the chart to be SELinux aware by changing `global.seLinux.enabled` to `true` in the `values.yaml`.
 

--- a/docs/integrations-in-rancher/logging/taints-and-tolerations.md
+++ b/docs/integrations-in-rancher/logging/taints-and-tolerations.md
@@ -12,7 +12,7 @@ Using `nodeSelector` gives pods an affinity towards certain nodes.
 
 Both provide choice for the what node(s) the pod will run on.
 
-- [Default Implementation in Rancher's Logging Stack](#default-implementation-in-rancher-s-logging-stack)
+- [Default Implementation in Rancher's Logging Stack](#default-implementation-in-ranchers-logging-stack)
 - [Adding NodeSelector Settings and Tolerations for Custom Taints](#adding-nodeselector-settings-and-tolerations-for-custom-taints)
 
 

--- a/docs/integrations-in-rancher/monitoring-and-alerting/built-in-dashboards.md
+++ b/docs/integrations-in-rancher/monitoring-and-alerting/built-in-dashboards.md
@@ -27,7 +27,7 @@ When `rancher-monitoring` is installed, the Prometheus Alertmanager UI is deploy
 
 :::note
 
-This section assumes familiarity with how monitoring components work together. For more information about Alertmanager, see [this section.](how-monitoring-works.md#how-alertmanager-works)
+This section assumes familiarity with how monitoring components work together. For more information about Alertmanager, see [this section.](how-monitoring-works.md#3-how-alertmanager-works)
 
 :::
 

--- a/docs/integrations-in-rancher/monitoring-and-alerting/built-in-dashboards.md
+++ b/docs/integrations-in-rancher/monitoring-and-alerting/built-in-dashboards.md
@@ -27,7 +27,7 @@ When `rancher-monitoring` is installed, the Prometheus Alertmanager UI is deploy
 
 :::note
 
-This section assumes familiarity with how monitoring components work together. For more information about Alertmanager, see [this section.](how-monitoring-works.md#3-how-alertmanager-works)
+This section assumes familiarity with how monitoring components work together. For more information about Alertmanager, see [How Alertmanager Works.](how-monitoring-works.md#3-how-alertmanager-works)
 
 :::
 

--- a/docs/pages-for-subheaders/backup-restore-and-disaster-recovery.md
+++ b/docs/pages-for-subheaders/backup-restore-and-disaster-recovery.md
@@ -93,4 +93,4 @@ For information on configuring these options, refer to [this page.](../reference
 
 ### Example values.yaml for the rancher-backup Helm Chart
 
-The example [values.yaml file](../reference-guides/backup-restore-configuration/storage-configuration.md#example-values-yaml-for-the-rancher-backup-helm-chart) can be used to configure the `rancher-backup` operator when the Helm CLI is used to install it.
+The example [values.yaml file](../reference-guides/backup-restore-configuration/storage-configuration.md#example-valuesyaml-for-the-rancher-backup-helm-chart) can be used to configure the `rancher-backup` operator when the Helm CLI is used to install it.

--- a/docs/pages-for-subheaders/cli-with-rancher.md
+++ b/docs/pages-for-subheaders/cli-with-rancher.md
@@ -2,4 +2,4 @@
 title: CLI with Rancher
 ---
 
-Interact with Rancher using command line interface (CLI) tools from your workstation. The following docs will describe the [Rancher CLI](../reference-guides/cli-with-rancher/rancher-cli.md) and [kubectl Utility](../reference-guides/cli-with-rancher/kubectl-utility).
+Interact with Rancher using command line interface (CLI) tools from your workstation. The following docs will describe the [Rancher CLI](../reference-guides/cli-with-rancher/rancher-cli.md) and [kubectl Utility](../reference-guides/cli-with-rancher/kubectl-utility.md).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/integrations-in-rancher/logging/logging-helm-chart-options.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/integrations-in-rancher/logging/logging-helm-chart-options.md
@@ -41,7 +41,7 @@ Logging v2 已在 RHEL/CentOS 7 和 8 上使用 SELinux 进行了测试。
 
 [安全增强型 Linux (SELinux)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) 是对 Linux 的安全增强。被政府机构使用之后，SELinux 已成为行业标准，并在 CentOS 7 和 8 上默认启用。
 
-要配合使用 Logging V2 与 SELinux，我们建议你根据[此页面](../../pages-for-subheaders/selinux-rpm.md#安装-rancher-selinux-rpm)的安装说明安装 `rancher-selinux` RPM。
+要配合使用 Logging V2 与 SELinux，我们建议你根据[此页面](../../pages-for-subheaders/selinux-rpm.md)的安装说明安装 `rancher-selinux` RPM。
 
 然后，在安装 Logging 应用程序时，在 `values.yaml` 中将 `global.seLinux.enabled` 更改为 `true`，使 Chart 支持 SELinux。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/integrations-in-rancher/monitoring-and-alerting/built-in-dashboards.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/integrations-in-rancher/monitoring-and-alerting/built-in-dashboards.md
@@ -27,7 +27,7 @@ title: 内置仪表板
 
 :::note
 
-本节参考假设你已经熟悉 Monitoring 组件的协同工作方式。有关 Alertmanager 的详细信息，请参阅[本节](how-monitoring-works.md#alertmanager-工作原理)。
+本节参考假设你已经熟悉 Monitoring 组件的协同工作方式。有关 Alertmanager 的详细信息，请参阅[本节](how-monitoring-works.md#3-alertmanager-的工作原理)。
 
 :::
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/integrations-in-rancher/logging/logging-helm-chart-options.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/integrations-in-rancher/logging/logging-helm-chart-options.md
@@ -41,7 +41,7 @@ Logging v2 已在 RHEL/CentOS 7 和 8 上使用 SELinux 进行了测试。
 
 [安全增强型 Linux (SELinux)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) 是对 Linux 的安全增强。被政府机构使用之后，SELinux 已成为行业标准，并在 CentOS 7 和 8 上默认启用。
 
-要配合使用 Logging V2 与 SELinux，我们建议你根据[此页面](../../pages-for-subheaders/selinux-rpm.md#安装-rancher-selinux-rpm)的安装说明安装 `rancher-selinux` RPM。
+要配合使用 Logging V2 与 SELinux，我们建议你根据[此页面](../../pages-for-subheaders/selinux-rpm.md)的安装说明安装 `rancher-selinux` RPM。
 
 然后，在安装 Logging 应用程序时，在 `values.yaml` 中将 `global.seLinux.enabled` 更改为 `true`，使 Chart 支持 SELinux。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/integrations-in-rancher/monitoring-and-alerting/built-in-dashboards.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/integrations-in-rancher/monitoring-and-alerting/built-in-dashboards.md
@@ -27,7 +27,7 @@ title: 内置仪表板
 
 :::note
 
-本节参考假设你已经熟悉 Monitoring 组件的协同工作方式。有关 Alertmanager 的详细信息，请参阅[本节](how-monitoring-works.md#alertmanager-工作原理)。
+本节参考假设你已经熟悉 Monitoring 组件的协同工作方式。有关 Alertmanager 的详细信息，请参阅[本节](how-monitoring-works.md#3-alertmanager-的工作原理)。
 
 :::
 

--- a/versioned_docs/version-2.0-2.4/pages-for-subheaders/cli-with-rancher.md
+++ b/versioned_docs/version-2.0-2.4/pages-for-subheaders/cli-with-rancher.md
@@ -2,4 +2,4 @@
 title: CLI with Rancher
 ---
 
-Interact with Rancher using command line interface (CLI) tools from your workstation. The following docs will describe the [Rancher CLI](../reference-guides/cli-with-rancher/rancher-cli.md) and [kubectl Utility](../reference-guides/cli-with-rancher/kubectl-utility).
+Interact with Rancher using command line interface (CLI) tools from your workstation. The following docs will describe the [Rancher CLI](../reference-guides/cli-with-rancher/rancher-cli.md) and [kubectl Utility](../reference-guides/cli-with-rancher/kubectl-utility.md).

--- a/versioned_docs/version-2.5/explanations/integrations-in-rancher/logging/logging-helm-chart-options.md
+++ b/versioned_docs/version-2.5/explanations/integrations-in-rancher/logging/logging-helm-chart-options.md
@@ -39,7 +39,7 @@ _Available as of v2.5.8_
 
 [Security-Enhanced Linux (SELinux)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) is a security enhancement to Linux. After being historically used by government agencies, SELinux is now industry standard and is enabled by default on CentOS 7 and 8.
 
-To use Logging v2 with SELinux, we recommend installing the `rancher-selinux` RPM according to the instructions on [this page.](../../../pages-for-subheaders/selinux-rpm.md#installing-the-rancher-selinux-rpm)
+To use Logging v2 with SELinux, we recommend installing the `rancher-selinux` RPM according to the instructions on [this page.](../../../pages-for-subheaders/selinux-rpm.md)
 
 Then, when installing the logging application, configure the chart to be SELinux aware by changing `global.seLinux.enabled` to `true` in the `values.yaml`.
 

--- a/versioned_docs/version-2.5/explanations/integrations-in-rancher/logging/logging-helm-chart-options.md
+++ b/versioned_docs/version-2.5/explanations/integrations-in-rancher/logging/logging-helm-chart-options.md
@@ -39,7 +39,7 @@ _Available as of v2.5.8_
 
 [Security-Enhanced Linux (SELinux)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) is a security enhancement to Linux. After being historically used by government agencies, SELinux is now industry standard and is enabled by default on CentOS 7 and 8.
 
-To use Logging v2 with SELinux, we recommend installing the `rancher-selinux` RPM according to the instructions on [this page.](../../../pages-for-subheaders/selinux-rpm.md)
+To use Logging v2 with SELinux, we recommend installing the `rancher-selinux` RPM according to these [instructions.](../../../pages-for-subheaders/selinux-rpm.md)
 
 Then, when installing the logging application, configure the chart to be SELinux aware by changing `global.seLinux.enabled` to `true` in the `values.yaml`.
 

--- a/versioned_docs/version-2.5/explanations/integrations-in-rancher/logging/taints-and-tolerations.md
+++ b/versioned_docs/version-2.5/explanations/integrations-in-rancher/logging/taints-and-tolerations.md
@@ -12,7 +12,7 @@ Using `nodeSelector` gives pods an affinity towards certain nodes.
 
 Both provide choice for the what node(s) the pod will run on.
 
-- [Default Implementation in Rancher's Logging Stack](#default-implementation-in-rancher-s-logging-stack)
+- [Default Implementation in Rancher's Logging Stack](#default-implementation-in-ranchers-logging-stack)
 - [Adding NodeSelector Settings and Tolerations for Custom Taints](#adding-nodeselector-settings-and-tolerations-for-custom-taints)
 
 

--- a/versioned_docs/version-2.5/explanations/integrations-in-rancher/monitoring-and-alerting/built-in-dashboards.md
+++ b/versioned_docs/version-2.5/explanations/integrations-in-rancher/monitoring-and-alerting/built-in-dashboards.md
@@ -25,7 +25,7 @@ For information about role-based access control for Grafana, see [this section.]
 
 When `rancher-monitoring` is installed, the Prometheus Alertmanager UI is deployed, allowing you to view your alerts and the current Alertmanager configuration.
 
-> This section assumes familiarity with how monitoring components work together. For more information about Alertmanager, see [this section.](how-monitoring-works.md#how-alertmanager-works)
+> This section assumes familiarity with how monitoring components work together. For more information about Alertmanager, see [this section.](how-monitoring-works.md#3-how-alertmanager-works)
 
 
 ### Accessing the Alertmanager UI

--- a/versioned_docs/version-2.5/explanations/integrations-in-rancher/monitoring-and-alerting/built-in-dashboards.md
+++ b/versioned_docs/version-2.5/explanations/integrations-in-rancher/monitoring-and-alerting/built-in-dashboards.md
@@ -25,7 +25,7 @@ For information about role-based access control for Grafana, see [this section.]
 
 When `rancher-monitoring` is installed, the Prometheus Alertmanager UI is deployed, allowing you to view your alerts and the current Alertmanager configuration.
 
-> This section assumes familiarity with how monitoring components work together. For more information about Alertmanager, see [this section.](how-monitoring-works.md#3-how-alertmanager-works)
+> This section assumes familiarity with how monitoring components work together. For more information about Alertmanager, see [How Alertmanager Works.](how-monitoring-works.md#3-how-alertmanager-works)
 
 
 ### Accessing the Alertmanager UI

--- a/versioned_docs/version-2.5/pages-for-subheaders/backup-restore-and-disaster-recovery.md
+++ b/versioned_docs/version-2.5/pages-for-subheaders/backup-restore-and-disaster-recovery.md
@@ -103,4 +103,4 @@ For information on configuring these options, refer to [this page.](../reference
 
 ### Example values.yaml for the rancher-backup Helm Chart
 
-The example [values.yaml file](../reference-guides/backup-restore-configuration/storage-configuration.md#example-values-yaml-for-the-rancher-backup-helm-chart) can be used to configure the `rancher-backup` operator when the Helm CLI is used to install it.
+The example [values.yaml file](../reference-guides/backup-restore-configuration/storage-configuration.md#example-valuesyaml-for-the-rancher-backup-helm-chart) can be used to configure the `rancher-backup` operator when the Helm CLI is used to install it.

--- a/versioned_docs/version-2.5/pages-for-subheaders/cli-with-rancher.md
+++ b/versioned_docs/version-2.5/pages-for-subheaders/cli-with-rancher.md
@@ -2,4 +2,4 @@
 title: CLI with Rancher
 ---
 
-Interact with Rancher using command line interface (CLI) tools from your workstation. The following docs will describe the [Rancher CLI](../reference-guides/cli-with-rancher/rancher-cli.md) and [kubectl Utility](../reference-guides/cli-with-rancher/kubectl-utility).
+Interact with Rancher using command line interface (CLI) tools from your workstation. The following docs will describe the [Rancher CLI](../reference-guides/cli-with-rancher/rancher-cli.md) and [kubectl Utility](../reference-guides/cli-with-rancher/kubectl-utility.md).

--- a/versioned_docs/version-2.6/integrations-in-rancher/logging/logging-helm-chart-options.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/logging/logging-helm-chart-options.md
@@ -41,7 +41,7 @@ Logging v2 was tested with SELinux on RHEL/CentOS 7 and 8.
 
 [Security-Enhanced Linux (SELinux)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) is a security enhancement to Linux. After being historically used by government agencies, SELinux is now industry standard and is enabled by default on CentOS 7 and 8.
 
-To use Logging v2 with SELinux, we recommend installing the `rancher-selinux` RPM according to the instructions on [this page.](../../pages-for-subheaders/selinux-rpm.md)
+To use Logging v2 with SELinux, we recommend installing the `rancher-selinux` RPM according to these [instructions.](../../pages-for-subheaders/selinux-rpm.md)
 
 Then, when installing the logging application, configure the chart to be SELinux aware by changing `global.seLinux.enabled` to `true` in the `values.yaml`.
 

--- a/versioned_docs/version-2.6/integrations-in-rancher/logging/logging-helm-chart-options.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/logging/logging-helm-chart-options.md
@@ -41,7 +41,7 @@ Logging v2 was tested with SELinux on RHEL/CentOS 7 and 8.
 
 [Security-Enhanced Linux (SELinux)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) is a security enhancement to Linux. After being historically used by government agencies, SELinux is now industry standard and is enabled by default on CentOS 7 and 8.
 
-To use Logging v2 with SELinux, we recommend installing the `rancher-selinux` RPM according to the instructions on [this page.](../../pages-for-subheaders/selinux-rpm.md#installing-the-rancher-selinux-rpm)
+To use Logging v2 with SELinux, we recommend installing the `rancher-selinux` RPM according to the instructions on [this page.](../../pages-for-subheaders/selinux-rpm.md)
 
 Then, when installing the logging application, configure the chart to be SELinux aware by changing `global.seLinux.enabled` to `true` in the `values.yaml`.
 

--- a/versioned_docs/version-2.6/integrations-in-rancher/logging/taints-and-tolerations.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/logging/taints-and-tolerations.md
@@ -12,7 +12,7 @@ Using `nodeSelector` gives pods an affinity towards certain nodes.
 
 Both provide choice for the what node(s) the pod will run on.
 
-- [Default Implementation in Rancher's Logging Stack](#default-implementation-in-rancher-s-logging-stack)
+- [Default Implementation in Rancher's Logging Stack](#default-implementation-in-ranchers-logging-stack)
 - [Adding NodeSelector Settings and Tolerations for Custom Taints](#adding-nodeselector-settings-and-tolerations-for-custom-taints)
 
 

--- a/versioned_docs/version-2.6/integrations-in-rancher/monitoring-and-alerting/built-in-dashboards.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/monitoring-and-alerting/built-in-dashboards.md
@@ -27,7 +27,7 @@ When `rancher-monitoring` is installed, the Prometheus Alertmanager UI is deploy
 
 :::note
 
-This section assumes familiarity with how monitoring components work together. For more information about Alertmanager, see [this section.](how-monitoring-works.md#how-alertmanager-works)
+This section assumes familiarity with how monitoring components work together. For more information about Alertmanager, see [this section.](how-monitoring-works.md#3-how-alertmanager-works)
 
 :::
 

--- a/versioned_docs/version-2.6/integrations-in-rancher/monitoring-and-alerting/built-in-dashboards.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/monitoring-and-alerting/built-in-dashboards.md
@@ -27,7 +27,7 @@ When `rancher-monitoring` is installed, the Prometheus Alertmanager UI is deploy
 
 :::note
 
-This section assumes familiarity with how monitoring components work together. For more information about Alertmanager, see [this section.](how-monitoring-works.md#3-how-alertmanager-works)
+This section assumes familiarity with how monitoring components work together. For more information about Alertmanager,  see [How Alertmanager Works.](how-monitoring-works.md#3-how-alertmanager-works)
 
 :::
 

--- a/versioned_docs/version-2.6/pages-for-subheaders/backup-restore-and-disaster-recovery.md
+++ b/versioned_docs/version-2.6/pages-for-subheaders/backup-restore-and-disaster-recovery.md
@@ -110,4 +110,4 @@ For information on configuring these options, refer to [this page.](../reference
 
 ### Example values.yaml for the rancher-backup Helm Chart
 
-The example [values.yaml file](../reference-guides/backup-restore-configuration/storage-configuration.md#example-values-yaml-for-the-rancher-backup-helm-chart) can be used to configure the `rancher-backup` operator when the Helm CLI is used to install it.
+The example [values.yaml file](../reference-guides/backup-restore-configuration/storage-configuration.md#example-valuesyaml-for-the-rancher-backup-helm-chart) can be used to configure the `rancher-backup` operator when the Helm CLI is used to install it.

--- a/versioned_docs/version-2.6/pages-for-subheaders/cli-with-rancher.md
+++ b/versioned_docs/version-2.6/pages-for-subheaders/cli-with-rancher.md
@@ -2,4 +2,4 @@
 title: CLI with Rancher
 ---
 
-Interact with Rancher using command line interface (CLI) tools from your workstation. The following docs will describe the [Rancher CLI](../reference-guides/cli-with-rancher/rancher-cli.md) and [kubectl Utility](../reference-guides/cli-with-rancher/kubectl-utility).
+Interact with Rancher using command line interface (CLI) tools from your workstation. The following docs will describe the [Rancher CLI](../reference-guides/cli-with-rancher/rancher-cli.md) and [kubectl Utility](../reference-guides/cli-with-rancher/kubectl-utility.md).


### PR DESCRIPTION
This part of a series of PRs to fixe the broken links discovered after adding a link checker in #208.

Note that a small fraction (~15) of the 180 warnings still remain:
- Alternative/new links could not be found for some external links. E.g. https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers
- Docusaurus supports setting [custom heading IDs](https://docusaurus.io/docs/markdown-features/toc#heading-ids), which get flagged as broken by the checker.
- We've manually added anchors directly with HTML to some areas that normally don't have them. These get flagged as broken by the checker.