### PR TITLE
Fix broken links - Part 13

### DIFF
--- a/docs/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/manage-persistent-storage/set-up-existing-storage.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/manage-persistent-storage/set-up-existing-storage.md
@@ -14,7 +14,7 @@ To set up storage, follow these steps:
 
 1. [Set up persistent storage.](#1-set-up-persistent-storage)
 2. [Add a PersistentVolume that refers to the persistent storage.](#2-add-a-persistentvolume-that-refers-to-the-persistent-storage)
-3. [Use the PersistentVolume for Pods Deployed with a StatefulSet.](#3-use-the-persistentvolume-for-pods-deployed-with-a-statefulset)
+3. [Use the PersistentVolume for Pods Deployed with a StatefulSet.](#3-use-the-storage-class-for-pods-deployed-with-a-statefulset)
 
 ### Prerequisites
 
@@ -25,7 +25,7 @@ To set up storage, follow these steps:
 
 Creating a persistent volume in Rancher will not create a storage volume. It only creates a Kubernetes resource that maps to an existing volume. Therefore, before you can create a persistent volume as a Kubernetes resource, you must have storage provisioned.
 
-The steps to set up a persistent storage device will differ based on your infrastructure. We provide examples of how to set up storage using [vSphere,](../../provisioning-storage-examples/vsphere-storage.md) [NFS,](../../provisioning-storage-examples/nfs-storage.md) or Amazon's [EBS.](../../provisioning-storage-examples/persistent-storage-in-amazon-ebs.md) 
+The steps to set up a persistent storage device will differ based on your infrastructure. We provide examples of how to set up storage using [vSphere,](../../provisioning-storage-examples/vsphere-storage.md) [NFS,](../../provisioning-storage-examples/nfs-storage.md) or Amazon's [EBS.](../../provisioning-storage-examples/persistent-storage-in-amazon-ebs.md)
 
 If you have a pool of block storage, and you don't want to use a cloud provider, Longhorn could help you provide persistent storage to your Kubernetes cluster. For more information, see [this page.](../../../../../integrations-in-rancher/longhorn.md)
 

--- a/docs/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/manage-persistent-storage/set-up-existing-storage.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/manage-persistent-storage/set-up-existing-storage.md
@@ -14,7 +14,7 @@ To set up storage, follow these steps:
 
 1. [Set up persistent storage.](#1-set-up-persistent-storage)
 2. [Add a PersistentVolume that refers to the persistent storage.](#2-add-a-persistentvolume-that-refers-to-the-persistent-storage)
-3. [Use the PersistentVolume for Pods Deployed with a StatefulSet.](#3-use-the-storage-class-for-pods-deployed-with-a-statefulset)
+3. [Use the Storage Class for Pods Deployed with a StatefulSet.](#3-use-the-storage-class-for-pods-deployed-with-a-statefulset)
 
 ### Prerequisites
 

--- a/docs/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.md
@@ -321,7 +321,7 @@ cloud-provider|-|Cloud provider type|
 
 #### Deployment
 
-Based on [cluster-autoscaler-run-on-control-plane.yaml](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml) example, we've created our own `cluster-autoscaler-deployment.yaml` to use preferred [auto-discovery setup](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#auto-discovery-setup), updating tolerations, nodeSelector, image version and command config:
+Based on the [cluster-autoscaler-run-on-control-plane.yaml](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml) example, we've created our own `cluster-autoscaler-deployment.yaml` to use preferred [auto-discovery setup](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#auto-discovery-setup), updating tolerations, nodeSelector, image version and command config:
 
 
 ```yml

--- a/docs/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.md
@@ -321,7 +321,7 @@ cloud-provider|-|Cloud provider type|
 
 #### Deployment
 
-Based on [cluster-autoscaler-run-on-master.yaml](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-master.yaml) example, we've created our own `cluster-autoscaler-deployment.yaml` to use preferred [auto-discovery setup](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#auto-discovery-setup), updating tolerations, nodeSelector, image version and command config:
+Based on [cluster-autoscaler-run-on-control-plane.yaml](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml) example, we've created our own `cluster-autoscaler-deployment.yaml` to use preferred [auto-discovery setup](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#auto-discovery-setup), updating tolerations, nodeSelector, image version and command config:
 
 
 ```yml

--- a/docs/how-to-guides/new-user-guides/manage-clusters/nodes-and-node-pools.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/nodes-and-node-pools.md
@@ -149,7 +149,7 @@ If the drain continues without error, the node enters a `draining` state. You'll
 
 Once drain successfully completes, the node will be in a state of `drained`. You can then power off or delete the node.
 
-**Want to know more about cordon and drain?** See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/cluster-management/#maintenance-on-a-node).
+**Want to know more about cordon and drain?** See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/).
 
 ## Labeling a Node to be Ignored by Rancher
 

--- a/docs/how-to-guides/new-user-guides/manage-clusters/projects-and-namespaces.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/projects-and-namespaces.md
@@ -77,7 +77,7 @@ You can use projects to perform actions such as:
 
 When you create a cluster, two projects are automatically created within it:
 
-- [Default Project](#the-cluster-s-default-project)
+- [Default Project](#the-clusters-default-project)
 - [System Project](#the-system-project)
 
 ### The Cluster's Default Project

--- a/docs/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/vsphere-storage.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/vsphere-storage.md
@@ -4,7 +4,7 @@ title: vSphere Storage
 
 To provide stateful workloads with vSphere storage, we recommend creating a vSphereVolume StorageClass. This practice dynamically provisions vSphere storage when workloads request volumes through a PersistentVolumeClaim.
 
-In order to dynamically provision storage in vSphere, the vSphere provider must be enabled. See the following pages for more: [Out-of-tree vSphere](../../../new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-out-of-tree-vsphere) and [in-tree vSphere](../../../new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-in-tree-vsphere).
+In order to dynamically provision storage in vSphere, the vSphere provider must be enabled. See the following pages for more: [Out-of-tree vSphere](../../../new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-out-of-tree-vsphere.md) and [in-tree vSphere](../../../new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-in-tree-vsphere.md).
 
 
 ### Prerequisites
@@ -20,7 +20,7 @@ The following steps can also be performed using the `kubectl` command line tool.
 :::
 
 1. Click **☰ > Cluster Management**.
-1. Choose the cluster you want to provide vSphere storage to and click **Exlpore**. 
+1. Choose the cluster you want to provide vSphere storage to and click **Exlpore**.
 1. In the left navigation bar, select **Storage > StorageClasses**.
 1. Click **Create**.
 3. Enter a **Name** for the StorageClass.
@@ -28,7 +28,7 @@ The following steps can also be performed using the `kubectl` command line tool.
 
     ![](/img/vsphere-storage-class.png)
 
-5. Optionally, specify additional properties for this storage class under **Parameters**. Refer to the [vSphere storage documentation](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/storageclass.html) for details.
+5. Optionally, specify additional properties for this storage class under **Parameters**. Refer to the [vSphere storage documentation](https://github.com/vmware-archive/vsphere-storage-for-kubernetes/blob/master/documentation/storageclass.md) for details.
 5. Click **Create**.
 
 ### Creating a Workload with a vSphere Volume
@@ -68,5 +68,5 @@ Even using a deployment resource with just a single replica may result in a dead
 
 ### Related Links
 
-- [vSphere Storage for Kubernetes](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/)
+- [vSphere Storage for Kubernetes](https://github.com/vmware-archive/vsphere-storage-for-kubernetes/tree/master/documentation)
 - [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)

--- a/docs/integrations-in-rancher/harvester.md
+++ b/docs/integrations-in-rancher/harvester.md
@@ -26,7 +26,7 @@ To navigate to the Harvester cluster, click **☰ > Virtualization Management**.
 
 ### Harvester Node Driver
 
-As of Rancher v2.6.3, the [Harvester node driver](https://docs.harvesterhci.io/v0.3/rancher/node-driver/) is GA for RKE and RKE2 options in Rancher. The node driver is available whether or not the Harvester feature flag is enabled. Note that the node driver is off by default. Users may create RKE or RKE2 clusters on Harvester only from the Cluster Management page.
+As of Rancher v2.6.3, the [Harvester node driver](https://docs.harvesterhci.io/v1.1/rancher/node/node-driver/) is GA for RKE and RKE2 options in Rancher. The node driver is available whether or not the Harvester feature flag is enabled. Note that the node driver is off by default. Users may create RKE or RKE2 clusters on Harvester only from the Cluster Management page.
 
 Harvester allows `.ISO` images to be uploaded and displayed through the Harvester UI, but this is not supported in the Rancher UI. This is because `.ISO` images usually require additional setup that interferes with a clean deployment (without requiring user intervention), and they are not typically used in cloud environments.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/manage-persistent-storage/set-up-existing-storage.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/manage-persistent-storage/set-up-existing-storage.md
@@ -14,7 +14,7 @@ title: 设置现有存储
 
 1. [设置持久存储](#1-设置持久存储)。
 2. [添加一个引用持久存储的 PersistentVolume](#2-添加一个引用持久存储的-persistentvolume)。
-3. [为使用 StatefulSet 部署的 Pod 使用 PersistentVolume](#3-为使用-statefulset-部署的-pod-使用-persistentvolume)。
+3. [为使用 StatefulSet 部署的 Pod 使用 PersistentVolume](#3-为使用-statefulset-部署的-pod-使用存储类)。
 
 ### 先决条件
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/manage-clusters/nodes-and-node-pools.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/manage-clusters/nodes-and-node-pools.md
@@ -149,7 +149,7 @@ Kubernetes 1.12 之前的版本中，在清空节点时不会强制执行[超时
 
 清空成功完成后，节点将处于 `drained` 状态。然后你可以关闭或删除节点。
 
-有关**封锁和清空**的更多信息，请参阅 [Kubernetes 文档](https://kubernetes.io/docs/tasks/administer-cluster/cluster-management/#maintenance-on-a-node)。
+有关**封锁和清空**的更多信息，请参阅 [Kubernetes 文档](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/)。
 
 ## 标记 Rancher 忽略的节点
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/vsphere-storage.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/vsphere-storage.md
@@ -4,7 +4,7 @@ title: vSphere 存储
 
 要为有状态的工作负载提供 vSphere 存储，我们建议创建一个 vSphereVolume StorageClass。当工作负载通过 PersistentVolumeClaim 请求卷时，这种做法会动态调配 vSphere 存储。
 
-为了在 vSphere 中动态调配存储，必须启用 vSphere 提供商。有关更多信息，请参阅[树外 vSphere](../../../new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-out-of-tree-vsphere) 和[树内 vSphere](../../../new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-in-tree-vsphere)。
+为了在 vSphere 中动态调配存储，必须启用 vSphere 提供商。有关更多信息，请参阅[树外 vSphere](../../../new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-out-of-tree-vsphere.md) 和[树内 vSphere](../../../new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-in-tree-vsphere.md)。
 
 
 ### 先决条件
@@ -28,7 +28,7 @@ title: vSphere 存储
 
    ![](/img/vsphere-storage-class.png)
 
-5. 可选地，你可以在**参数**下指定存储类的其他属性。有关详细信息，请参阅 [vSphere 存储文档](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/storageclass.html)。
+5. 可选地，你可以在**参数**下指定存储类的其他属性。有关详细信息，请参阅 [vSphere 存储文档](https://github.com/vmware-archive/vsphere-storage-for-kubernetes/blob/master/documentation/storageclass.md)。
 5. 单击**创建**。
 
 ### 创建使用 vSphere 卷的工作负载
@@ -68,5 +68,5 @@ title: vSphere 存储
 
 ### 相关链接
 
-- [用于 Kubernetes 的 vSphere 存储](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/)
+- [用于 Kubernetes 的 vSphere 存储](https://github.com/vmware-archive/vsphere-storage-for-kubernetes/tree/master/documentation)
 - [Kubernetes 持久卷](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)

--- a/i18n/zh/docusaurus-plugin-content-docs/current/integrations-in-rancher/harvester.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/integrations-in-rancher/harvester.md
@@ -26,7 +26,7 @@ Harvester 已 GA。有关所有更新，请参阅 [Harvester 发行说明](https
 
 ### Harvester 主机驱动
 
-从 Rancher v2.6.3 开始，[Harvester 主机驱动](https://docs.harvesterhci.io/v0.3/rancher/node-driver/) 已在 Rancher 的 RKE 和 RKE2 选项中 GA。无论 Harvester 功能开关是否启用，主机驱动都是可用的。请注意，默认情况下主机驱动是关闭的。用户只能通过**集群管理**页面在 Harvester 上创建 RKE 或 RKE2 集群。
+从 Rancher v2.6.3 开始，[Harvester 主机驱动](https://docs.harvesterhci.io/v1.1/rancher/node/node-driver/) 已在 Rancher 的 RKE 和 RKE2 选项中 GA。无论 Harvester 功能开关是否启用，主机驱动都是可用的。请注意，默认情况下主机驱动是关闭的。用户只能通过**集群管理**页面在 Harvester 上创建 RKE 或 RKE2 集群。
 
 Harvester 允许通过 Harvester UI 上传和显示 `.ISO` 镜像，但 Rancher UI 不支持。这是因为 `.ISO` 镜像通常需要额外的设置，这会干扰干净的部署（即无需用户干预），并且它们通常不用于云环境。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/manage-persistent-storage/set-up-existing-storage.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/manage-persistent-storage/set-up-existing-storage.md
@@ -14,7 +14,7 @@ title: 设置现有存储
 
 1. [设置持久存储](#1-设置持久存储)。
 2. [添加一个引用持久存储的 PersistentVolume](#2-添加一个引用持久存储的-persistentvolume)。
-3. [为使用 StatefulSet 部署的 Pod 使用 PersistentVolume](#3-为使用-statefulset-部署的-pod-使用-persistentvolume)。
+3. [为使用 StatefulSet 部署的 Pod 使用 PersistentVolume](#3-为使用-statefulset-部署的-pod-使用存储类)。
 
 ### 先决条件
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/nodes-and-node-pools.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/nodes-and-node-pools.md
@@ -149,7 +149,7 @@ Kubernetes 1.12 之前的版本中，在清空节点时不会强制执行[超时
 
 清空成功完成后，节点将处于 `drained` 状态。然后你可以关闭或删除节点。
 
-有关**封锁和清空**的更多信息，请参阅 [Kubernetes 文档](https://kubernetes.io/docs/tasks/administer-cluster/cluster-management/#maintenance-on-a-node)。
+有关**封锁和清空**的更多信息，请参阅 [Kubernetes 文档](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/)。
 
 ## 标记 Rancher 忽略的节点
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/vsphere-storage.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/vsphere-storage.md
@@ -4,7 +4,7 @@ title: vSphere 存储
 
 要为有状态的工作负载提供 vSphere 存储，我们建议创建一个 vSphereVolume StorageClass。当工作负载通过 PersistentVolumeClaim 请求卷时，这种做法会动态调配 vSphere 存储。
 
-为了在 vSphere 中动态调配存储，必须启用 vSphere 提供商。有关更多信息，请参阅[树外 vSphere](../../../new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-out-of-tree-vsphere) 和[树内 vSphere](../../../new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-in-tree-vsphere)。
+为了在 vSphere 中动态调配存储，必须启用 vSphere 提供商。有关更多信息，请参阅[树外 vSphere](../../../new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-out-of-tree-vsphere.md) 和[树内 vSphere](../../../new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-in-tree-vsphere.md)。
 
 
 ### 先决条件
@@ -28,7 +28,7 @@ title: vSphere 存储
 
    ![](/img/vsphere-storage-class.png)
 
-5. 可选地，你可以在**参数**下指定存储类的其他属性。有关详细信息，请参阅 [vSphere 存储文档](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/storageclass.html)。
+5. 可选地，你可以在**参数**下指定存储类的其他属性。有关详细信息，请参阅 [vSphere 存储文档](https://github.com/vmware-archive/vsphere-storage-for-kubernetes/blob/master/documentation/storageclass.md)。
 5. 单击**创建**。
 
 ### 创建使用 vSphere 卷的工作负载
@@ -68,5 +68,5 @@ title: vSphere 存储
 
 ### 相关链接
 
-- [用于 Kubernetes 的 vSphere 存储](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/)
+- [用于 Kubernetes 的 vSphere 存储](https://github.com/vmware-archive/vsphere-storage-for-kubernetes/tree/master/documentation)
 - [Kubernetes 持久卷](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/integrations-in-rancher/harvester.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/integrations-in-rancher/harvester.md
@@ -26,7 +26,7 @@ Harvester 已 GA。有关所有更新，请参阅 [Harvester 发行说明](https
 
 ### Harvester 主机驱动
 
-从 Rancher v2.6.3 开始，[Harvester 主机驱动](https://docs.harvesterhci.io/v0.3/rancher/node-driver/) 已在 Rancher 的 RKE 和 RKE2 选项中 GA。无论 Harvester 功能开关是否启用，主机驱动都是可用的。请注意，默认情况下主机驱动是关闭的。用户只能通过**集群管理**页面在 Harvester 上创建 RKE 或 RKE2 集群。
+从 Rancher v2.6.3 开始，[Harvester 主机驱动](https://docs.harvesterhci.io/v1.1/rancher/node/node-driver/) 已在 Rancher 的 RKE 和 RKE2 选项中 GA。无论 Harvester 功能开关是否启用，主机驱动都是可用的。请注意，默认情况下主机驱动是关闭的。用户只能通过**集群管理**页面在 Harvester 上创建 RKE 或 RKE2 集群。
 
 Harvester 允许通过 Harvester UI 上传和显示 `.ISO` 镜像，但 Rancher UI 不支持。这是因为 `.ISO` 镜像通常需要额外的设置，这会干扰干净的部署（即无需用户干预），并且它们通常不用于云环境。
 

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/manage-clusters/create-kubernetes-persistent-storage/provisioning-storage-examples/vsphere-storage.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/manage-clusters/create-kubernetes-persistent-storage/provisioning-storage-examples/vsphere-storage.md
@@ -24,7 +24,7 @@ In order to provision vSphere volumes in a cluster created with the [Rancher Kub
 
     ![](/img/vsphere-storage-class.png)
 
-5. Optionally, specify additional properties for this storage class under **Parameters**. Refer to the [vSphere storage documentation](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/storageclass.html) for details.
+5. Optionally, specify additional properties for this storage class under **Parameters**. Refer to the [vSphere storage documentation](https://github.com/vmware-archive/vsphere-storage-for-kubernetes/blob/master/documentation/storageclass.md) for details.
 5. Click **Save**.
 
 ### Creating a Workload with a vSphere Volume
@@ -66,5 +66,5 @@ Even using a deployment resource with just a single replica may result in a dead
 
 ### Related Links
 
-- [vSphere Storage for Kubernetes](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/)
+- [vSphere Storage for Kubernetes](https://github.com/vmware-archive/vsphere-storage-for-kubernetes/tree/master/documentation)
 - [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.md
@@ -319,7 +319,7 @@ cloud-provider|-|Cloud provider type|
 
 #### Deployment
 
-Based on [cluster-autoscaler-run-on-master.yaml](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-master.yaml) example, we've created our own `cluster-autoscaler-deployment.yaml` to use preferred [auto-discovery setup](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#auto-discovery-setup), updating tolerations, nodeSelector, image version and command config:
+Based on [cluster-autoscaler-run-on-control-plane.yaml](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml) example, we've created our own `cluster-autoscaler-deployment.yaml` to use preferred [auto-discovery setup](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#auto-discovery-setup), updating tolerations, nodeSelector, image version and command config:
 
 
 ```yml

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.md
@@ -319,7 +319,7 @@ cloud-provider|-|Cloud provider type|
 
 #### Deployment
 
-Based on [cluster-autoscaler-run-on-control-plane.yaml](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml) example, we've created our own `cluster-autoscaler-deployment.yaml` to use preferred [auto-discovery setup](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#auto-discovery-setup), updating tolerations, nodeSelector, image version and command config:
+Based on the [cluster-autoscaler-run-on-control-plane.yaml](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml) example, we've created our own `cluster-autoscaler-deployment.yaml` to use preferred [auto-discovery setup](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#auto-discovery-setup), updating tolerations, nodeSelector, image version and command config:
 
 
 ```yml

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/manage-clusters/nodes-and-node-pools.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/manage-clusters/nodes-and-node-pools.md
@@ -163,7 +163,7 @@ If the drain continues without error, the node enters a `draining` state. You'll
 
 Once drain successfully completes, the node will be in a state of `drained`. You can then power off or delete the node.
 
->**Want to know more about cordon and drain?** See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/cluster-management/#maintenance-on-a-node).
+>**Want to know more about cordon and drain?** See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/).
 
 ## Labeling a Node to be Ignored by Rancher
 

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/manage-clusters/projects-and-namespaces.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/manage-clusters/projects-and-namespaces.md
@@ -68,7 +68,7 @@ You can use projects to perform actions such as:
 
 When you create a cluster, two projects are automatically created within it:
 
-- [Default Project](#the-cluster-s-default-project)
+- [Default Project](#the-clusters-default-project)
 - [System Project](#the-system-project)
 
 ### The Cluster's Default Project

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/manage-clusters/create-kubernetes-persistent-storage/provisioning-storage-examples/vsphere-storage.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/manage-clusters/create-kubernetes-persistent-storage/provisioning-storage-examples/vsphere-storage.md
@@ -24,7 +24,7 @@ In order to provision vSphere volumes in a cluster created with the [Rancher Kub
 
     ![](/img/vsphere-storage-class.png)
 
-5. Optionally, specify additional properties for this storage class under **Parameters**. Refer to the [vSphere storage documentation](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/storageclass.html) for details.
+5. Optionally, specify additional properties for this storage class under **Parameters**. Refer to the [vSphere storage documentation](https://github.com/vmware-archive/vsphere-storage-for-kubernetes/blob/master/documentation/storageclass.md) for details.
 5. Click **Save**.
 
 ### Creating a Workload with a vSphere Volume
@@ -66,5 +66,5 @@ Even using a deployment resource with just a single replica may result in a dead
 
 ### Related Links
 
-- [vSphere Storage for Kubernetes](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/)
+- [vSphere Storage for Kubernetes](https://github.com/vmware-archive/vsphere-storage-for-kubernetes/tree/master/documentation)
 - [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.md
@@ -321,7 +321,7 @@ cloud-provider|-|Cloud provider type|
 
 #### Deployment
 
-Based on [cluster-autoscaler-run-on-control-plane.yaml](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml) example, we've created our own `cluster-autoscaler-deployment.yaml` to use preferred [auto-discovery setup](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#auto-discovery-setup), updating tolerations, nodeSelector, image version and command config:
+Based on the [cluster-autoscaler-run-on-control-plane.yaml](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml) example, we've created our own `cluster-autoscaler-deployment.yaml` to use preferred [auto-discovery setup](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#auto-discovery-setup), updating tolerations, nodeSelector, image version and command config:
 
 
 ```yml

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.md
@@ -321,7 +321,7 @@ cloud-provider|-|Cloud provider type|
 
 #### Deployment
 
-Based on [cluster-autoscaler-run-on-master.yaml](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-master.yaml) example, we've created our own `cluster-autoscaler-deployment.yaml` to use preferred [auto-discovery setup](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#auto-discovery-setup), updating tolerations, nodeSelector, image version and command config:
+Based on [cluster-autoscaler-run-on-control-plane.yaml](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml) example, we've created our own `cluster-autoscaler-deployment.yaml` to use preferred [auto-discovery setup](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#auto-discovery-setup), updating tolerations, nodeSelector, image version and command config:
 
 
 ```yml

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/manage-clusters/nodes-and-node-pools.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/manage-clusters/nodes-and-node-pools.md
@@ -142,7 +142,7 @@ If the drain continues without error, the node enters a `draining` state. You'll
 
 Once drain successfully completes, the node will be in a state of `drained`. You can then power off or delete the node.
 
->**Want to know more about cordon and drain?** See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/cluster-management/#maintenance-on-a-node).
+>**Want to know more about cordon and drain?** See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/).
 
 ## Labeling a Node to be Ignored by Rancher
 

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/manage-clusters/projects-and-namespaces.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/manage-clusters/projects-and-namespaces.md
@@ -67,7 +67,7 @@ You can use projects to perform actions such as:
 
 When you create a cluster, two projects are automatically created within it:
 
-- [Default Project](#the-cluster-s-default-project)
+- [Default Project](#the-clusters-default-project)
 - [System Project](#the-system-project)
 
 ### The Cluster's Default Project

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/manage-persistent-storage/set-up-existing-storage.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/manage-persistent-storage/set-up-existing-storage.md
@@ -14,7 +14,7 @@ To set up storage, follow these steps:
 
 1. [Set up persistent storage.](#1-set-up-persistent-storage)
 2. [Add a PersistentVolume that refers to the persistent storage.](#2-add-a-persistentvolume-that-refers-to-the-persistent-storage)
-3. [Use the PersistentVolume for Pods Deployed with a StatefulSet.](#3-use-the-persistentvolume-for-pods-deployed-with-a-statefulset)
+3. [Use the PersistentVolume for Pods Deployed with a StatefulSet.](#3-use-the-storage-class-for-pods-deployed-with-a-statefulset)
 
 ### Prerequisites
 
@@ -25,7 +25,7 @@ To set up storage, follow these steps:
 
 Creating a persistent volume in Rancher will not create a storage volume. It only creates a Kubernetes resource that maps to an existing volume. Therefore, before you can create a persistent volume as a Kubernetes resource, you must have storage provisioned.
 
-The steps to set up a persistent storage device will differ based on your infrastructure. We provide examples of how to set up storage using [vSphere,](../../provisioning-storage-examples/vsphere-storage.md) [NFS,](../../provisioning-storage-examples/nfs-storage.md) or Amazon's [EBS.](../../provisioning-storage-examples/persistent-storage-in-amazon-ebs.md) 
+The steps to set up a persistent storage device will differ based on your infrastructure. We provide examples of how to set up storage using [vSphere,](../../provisioning-storage-examples/vsphere-storage.md) [NFS,](../../provisioning-storage-examples/nfs-storage.md) or Amazon's [EBS.](../../provisioning-storage-examples/persistent-storage-in-amazon-ebs.md)
 
 If you have a pool of block storage, and you don't want to use a cloud provider, Longhorn could help you provide persistent storage to your Kubernetes cluster. For more information, see [this page.](../../../../../integrations-in-rancher/longhorn.md)
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/manage-persistent-storage/set-up-existing-storage.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/manage-persistent-storage/set-up-existing-storage.md
@@ -14,7 +14,7 @@ To set up storage, follow these steps:
 
 1. [Set up persistent storage.](#1-set-up-persistent-storage)
 2. [Add a PersistentVolume that refers to the persistent storage.](#2-add-a-persistentvolume-that-refers-to-the-persistent-storage)
-3. [Use the PersistentVolume for Pods Deployed with a StatefulSet.](#3-use-the-storage-class-for-pods-deployed-with-a-statefulset)
+3. [Use the Storage Class for Pods Deployed with a StatefulSet.](#3-use-the-storage-class-for-pods-deployed-with-a-statefulset)
 
 ### Prerequisites
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.md
@@ -321,7 +321,7 @@ cloud-provider|-|Cloud provider type|
 
 #### Deployment
 
-Based on [cluster-autoscaler-run-on-control-plane.yaml](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml) example, we've created our own `cluster-autoscaler-deployment.yaml` to use preferred [auto-discovery setup](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#auto-discovery-setup), updating tolerations, nodeSelector, image version and command config:
+Based on the [cluster-autoscaler-run-on-control-plane.yaml](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml) example, we've created our own `cluster-autoscaler-deployment.yaml` to use preferred [auto-discovery setup](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#auto-discovery-setup), updating tolerations, nodeSelector, image version and command config:
 
 
 ```yml

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.md
@@ -321,7 +321,7 @@ cloud-provider|-|Cloud provider type|
 
 #### Deployment
 
-Based on [cluster-autoscaler-run-on-master.yaml](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-master.yaml) example, we've created our own `cluster-autoscaler-deployment.yaml` to use preferred [auto-discovery setup](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#auto-discovery-setup), updating tolerations, nodeSelector, image version and command config:
+Based on [cluster-autoscaler-run-on-control-plane.yaml](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-run-on-control-plane.yaml) example, we've created our own `cluster-autoscaler-deployment.yaml` to use preferred [auto-discovery setup](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#auto-discovery-setup), updating tolerations, nodeSelector, image version and command config:
 
 
 ```yml

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/nodes-and-node-pools.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/nodes-and-node-pools.md
@@ -149,7 +149,7 @@ If the drain continues without error, the node enters a `draining` state. You'll
 
 Once drain successfully completes, the node will be in a state of `drained`. You can then power off or delete the node.
 
-**Want to know more about cordon and drain?** See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/cluster-management/#maintenance-on-a-node).
+**Want to know more about cordon and drain?** See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/).
 
 ## Labeling a Node to be Ignored by Rancher
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/projects-and-namespaces.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/projects-and-namespaces.md
@@ -77,7 +77,7 @@ You can use projects to perform actions such as:
 
 When you create a cluster, two projects are automatically created within it:
 
-- [Default Project](#the-cluster-s-default-project)
+- [Default Project](#the-clusters-default-project)
 - [System Project](#the-system-project)
 
 ### The Cluster's Default Project
@@ -191,7 +191,7 @@ To add a resource quota,
 1. In the upper left corner, click **☰ > Cluster Management**.
 1. On the **Clusters** page, go to the cluster the project is attached to, and click **Explore**.
 1. Click **Cluster > Projects/Namespaces**.
-1. Find the project you want to delete, and click **⋮**. 
+1. Find the project you want to delete, and click **⋮**.
 1. Select **Delete**.
 
 When you delete a project, any namespaces that were formerly associated with the project will remain on the cluster. You can find these namespaces in the Rancher UI, in the **Not in a Project** tab of the **Projects/Namespaces** page. You can reassign these namespaces to a project by [moving](../manage-namespaces.md#moving-namespaces-to-another-project) them.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/vsphere-storage.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/vsphere-storage.md
@@ -4,7 +4,7 @@ title: vSphere Storage
 
 To provide stateful workloads with vSphere storage, we recommend creating a vSphereVolume StorageClass. This practice dynamically provisions vSphere storage when workloads request volumes through a PersistentVolumeClaim.
 
-In order to dynamically provision storage in vSphere, the vSphere provider must be enabled. See the following pages for more: [Out-of-tree vSphere](../../../new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-out-of-tree-vsphere) and [in-tree vSphere](../../../new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-in-tree-vsphere).
+In order to dynamically provision storage in vSphere, the vSphere provider must be enabled. See the following pages for more: [Out-of-tree vSphere](../../../new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-out-of-tree-vsphere.md) and [in-tree vSphere](../../../new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-in-tree-vsphere.md).
 
 
 ### Prerequisites
@@ -20,7 +20,7 @@ The following steps can also be performed using the `kubectl` command line tool.
 :::
 
 1. Click **☰ > Cluster Management**.
-1. Choose the cluster you want to provide vSphere storage to and click **Exlpore**. 
+1. Choose the cluster you want to provide vSphere storage to and click **Exlpore**.
 1. In the left navigation bar, select **Storage > StorageClasses**.
 1. Click **Create**.
 3. Enter a **Name** for the StorageClass.
@@ -28,7 +28,7 @@ The following steps can also be performed using the `kubectl` command line tool.
 
     ![](/img/vsphere-storage-class.png)
 
-5. Optionally, specify additional properties for this storage class under **Parameters**. Refer to the [vSphere storage documentation](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/storageclass.html) for details.
+5. Optionally, specify additional properties for this storage class under **Parameters**. Refer to the [vSphere storage documentation](https://github.com/vmware-archive/vsphere-storage-for-kubernetes/blob/master/documentation/storageclass.md) for details.
 5. Click **Create**.
 
 ### Creating a Workload with a vSphere Volume
@@ -68,5 +68,5 @@ Even using a deployment resource with just a single replica may result in a dead
 
 ### Related Links
 
-- [vSphere Storage for Kubernetes](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/)
+- [vSphere Storage for Kubernetes](https://github.com/vmware-archive/vsphere-storage-for-kubernetes/tree/master/documentation)
 - [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)

--- a/versioned_docs/version-2.6/integrations-in-rancher/harvester.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/harvester.md
@@ -26,7 +26,7 @@ To navigate to the Harvester cluster, click **☰ > Virtualization Management**.
 
 ### Harvester Node Driver
 
-As of Rancher v2.6.3, the [Harvester node driver](https://docs.harvesterhci.io/v0.3/rancher/node-driver/) is GA for RKE and RKE2 options in Rancher. The node driver is available whether or not the Harvester feature flag is enabled. Note that the node driver is off by default. Users may create RKE or RKE2 clusters on Harvester only from the Cluster Management page.
+As of Rancher v2.6.3, the [Harvester node driver](https://docs.harvesterhci.io/v1.1/rancher/node/node-driver/) is GA for RKE and RKE2 options in Rancher. The node driver is available whether or not the Harvester feature flag is enabled. Note that the node driver is off by default. Users may create RKE or RKE2 clusters on Harvester only from the Cluster Management page.
 
 Harvester allows `.ISO` images to be uploaded and displayed through the Harvester UI, but this is not supported in the Rancher UI. This is because `.ISO` images usually require additional setup that interferes with a clean deployment (without requiring user intervention), and they are not typically used in cloud environments.
 


### PR DESCRIPTION
This part of a series of PRs to fixe the broken links discovered after adding a link checker in #208.

Note that a small fraction (~15) of the 180 warnings still remain:
- Alternative/new links could not be found for some external links. E.g. https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers
- Docusaurus supports setting [custom heading IDs](https://docusaurus.io/docs/markdown-features/toc#heading-ids), which get flagged as broken by the checker.
- We've manually added anchors directly with HTML to some areas that normally don't have them. These get flagged as broken by the checker.