### PR TITLE
Fix broken links - Part 18

### DIFF
--- a/docs/faq/technical-items.md
+++ b/docs/faq/technical-items.md
@@ -91,7 +91,7 @@ When the node is removed from the cluster, and the node is cleaned, you can read
 
 ### How can I add additional arguments/binds/environment variables to Kubernetes components in a Rancher Launched Kubernetes cluster?
 
-You can add additional arguments/binds/environment variables via the [Config File](../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md#cluster-config-file) option in Cluster Options. For more information, see the [Extra Args, Extra Binds, and Extra Environment Variables](https://rancher.com/docs/rke/latest/en/config-options/services/services-extras/) in the RKE documentation or browse the [Example Cluster.ymls](https://rancher.com/docs/rke/latest/en/example-yamls/).
+You can add additional arguments/binds/environment variables via the [Config File](../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md#rke-cluster-config-file-reference) option in Cluster Options. For more information, see the [Extra Args, Extra Binds, and Extra Environment Variables](https://rancher.com/docs/rke/latest/en/config-options/services/services-extras/) in the RKE documentation or browse the [Example Cluster.ymls](https://rancher.com/docs/rke/latest/en/example-yamls/).
 
 ### How do I check if my certificate chain is valid?
 

--- a/docs/how-to-guides/advanced-user-guides/enable-experimental-features/rancher-on-arm64.md
+++ b/docs/how-to-guides/advanced-user-guides/enable-experimental-features/rancher-on-arm64.md
@@ -37,7 +37,7 @@ version's release notes in the following two ways:
 - Importing clusters that contain ARM64 based nodes
   - Kubernetes cluster version must be 1.12 or higher
 
-Please see [Cluster Options](cluster-provisioning/rke-clusters/options/) how to configure the cluster options.
+Please see [Cluster Options](../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md) how to configure the cluster options.
 
 The following features are not tested:
 

--- a/docs/how-to-guides/advanced-user-guides/monitoring-alerting-guides/create-persistent-grafana-dashboard.md
+++ b/docs/how-to-guides/advanced-user-guides/monitoring-alerting-guides/create-persistent-grafana-dashboard.md
@@ -16,7 +16,7 @@ To allow the Grafana dashboard to persist after the Grafana instance restarts, a
 
 - The monitoring application needs to be installed.
 - To create the persistent dashboard, you must have at least the **Manage Config Maps** Rancher RBAC permissions assigned to you in the project or namespace that contains the Grafana Dashboards. This correlates to the `monitoring-dashboard-edit` or `monitoring-dashboard-admin` Kubernetes native RBAC Roles exposed by the Monitoring chart.
-- To see the links to the external monitoring UIs, including Grafana dashboards, you will need at least a [project-member role.](../../../integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.md#users-with-rancher-cluster-manager-based-permissions)
+- To see the links to the external monitoring UIs, including Grafana dashboards, you will need at least a [project-member role.](../../../integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.md#users-with-rancher-based-permissions)
 
 :::
 

--- a/docs/how-to-guides/advanced-user-guides/monitoring-alerting-guides/customize-grafana-dashboard.md
+++ b/docs/how-to-guides/advanced-user-guides/monitoring-alerting-guides/customize-grafana-dashboard.md
@@ -8,7 +8,7 @@ In this section, you'll learn how to customize the Grafana dashboard to show met
 
 Before you can customize a Grafana dashboard, the `rancher-monitoring` application must be installed.
 
-To see the links to the external monitoring UIs, including Grafana dashboards, you will need at least a [project-member role.](../../../integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.md#users-with-rancher-cluster-manager-based-permissions)
+To see the links to the external monitoring UIs, including Grafana dashboards, you will need at least a [project-member role.](../../../integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.md#users-with-rancher-based-permissions)
 
 ### Signing in to Grafana
 

--- a/docs/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.md
+++ b/docs/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.md
@@ -62,7 +62,7 @@ For more information about the default limits, see [this page.](../../../referen
 
 **Result:** The monitoring app is deployed in the `cattle-monitoring-system` namespace.
 
-When [creating a receiver,](../monitoring-v2-configuration-guides/advanced-configuration/alertmanager.md#creating-receivers-in-the-rancher-ui) SSL-enabled receivers such as email or webhook will have a **SSL** section with fields for **CA File Path**, **Cert File Path**, and **Key File Path**. Fill in these fields with the paths to each of `ca`, `cert`, and `key`. The path will be of the form `/etc/alertmanager/secrets/name-of-file-in-secret`.
+When [creating a receiver,](../../../reference-guides/monitoring-v2-configuration/receivers.md#creating-receivers-in-the-rancher-ui) SSL-enabled receivers such as email or webhook will have a **SSL** section with fields for **CA File Path**, **Cert File Path**, and **Key File Path**. Fill in these fields with the paths to each of `ca`, `cert`, and `key`. The path will be of the form `/etc/alertmanager/secrets/name-of-file-in-secret`.
 
 For example, if you created a secret with these key-value pairs:
 

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-active-directory.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-active-directory.md
@@ -146,7 +146,7 @@ You will still be able to login using the locally configured `admin` account and
 
 In order to successfully configure AD authentication it is crucial that you provide the correct configuration pertaining to the hierarchy and schema of your AD server.
 
-The [`ldapsearch`](http://manpages.ubuntu.com/manpages/artful/man1/ldapsearch.1.html) tool allows you to query your AD server to learn about the schema used for user and group objects.
+The [`ldapsearch`](https://manpages.ubuntu.com/manpages/kinetic/en/man1/ldapsearch.1.html) tool allows you to query your AD server to learn about the schema used for user and group objects.
 
 For the purpose of the example commands provided below we will assume:
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/faq/technical-items.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/faq/technical-items.md
@@ -91,7 +91,7 @@ UI 由静态文件组成，并根据 API 的响应工作。换言之，UI 中可
 
 ### 如何将其他参数/绑定/环境变量添加到 Rancher 启动的 Kubernetes 集群的 Kubernetes 组件中？
 
-你可以使用集群选项中的[配置文件](../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md#集群配置文件)选项来添加其他参数/​​绑定/环境变量。有关详细信息，请参阅 RKE 文档中的[其他参数、绑定和环境变量](https://rancher.com/docs/rke/latest/en/config-options/services/services-extras/)，或浏览 [Cluster.ymls 示例](https://rancher.com/docs/rke/latest/en/example-yamls/)。
+你可以使用集群选项中的[配置文件](../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md#rke-集群配置文件参考)选项来添加其他参数/​​绑定/环境变量。有关详细信息，请参阅 RKE 文档中的[其他参数、绑定和环境变量](https://rancher.com/docs/rke/latest/en/config-options/services/services-extras/)，或浏览 [Cluster.ymls 示例](https://rancher.com/docs/rke/latest/en/example-yamls/)。
 
 ### 如何检查证书链是否有效？
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/advanced-user-guides/enable-experimental-features/rancher-on-arm64.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/advanced-user-guides/enable-experimental-features/rancher-on-arm64.md
@@ -36,7 +36,7 @@ title: "在 ARM64 上运行 Rancher（实验性）"
 - 导入包含使用 ARM64 架构的节点的集群
    - Kubernetes 集群必须为 1.12 或更高版本
 
-如需了解如何配置集群选项，请参见[集群选项](cluster-provisioning/rke-clusters/options/)。
+如需了解如何配置集群选项，请参见[集群选项](../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md)。
 
 以下是未经测试的功能：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.md
@@ -62,7 +62,7 @@ rkeEtcd:
 
 **结果**：Monitoring 应用已部署到 `cattle-monitoring-system` 命名空间中。
 
-[创建接收器](../monitoring-v2-configuration-guides/advanced-configuration/alertmanager.md#在-rancher-ui-中创建接收器)时，启用 SSL 的接收器（例如电子邮件或 webhook）将具有 **SSL**，其中包含 **CA 文件路径**、**证书文件路径**和**密钥文件路径**字段。使用 `ca`、`cert` 和 `key` 的路径填写这些字段。路径的格式为 `/etc/alertmanager/secrets/name-of-file-in-secret`。
+[创建接收器](../../../reference-guides/monitoring-v2-configuration/receivers.md#在-rancher-ui-中创建接收器)时，启用 SSL 的接收器（例如电子邮件或 webhook）将具有 **SSL**，其中包含 **CA 文件路径**、**证书文件路径**和**密钥文件路径**字段。使用 `ca`、`cert` 和 `key` 的路径填写这些字段。路径的格式为 `/etc/alertmanager/secrets/name-of-file-in-secret`。
 
 例如，如果你使用以下键值对创建了一个密文：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-active-directory.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-active-directory.md
@@ -146,7 +146,7 @@ Rancher 使用 LDAP 查询来搜索和检索关于 Active Directory 中的用户
 
 为了成功配置 AD 身份验证，你必须提供 AD 服务器的层次结构和 Schema 的正确配置。
 
-[`ldapsearch`](http://manpages.ubuntu.com/manpages/artful/man1/ldapsearch.1.html) 工具允许你查询你的 AD 服务器，从而了解用于用户和组对象的 Schema。
+[`ldapsearch`](https://manpages.ubuntu.com/manpages/kinetic/en/man1/ldapsearch.1.html) 工具允许你查询你的 AD 服务器，从而了解用于用户和组对象的 Schema。
 
 在下面的示例命令中，我们假设：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/faq/technical-items.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/faq/technical-items.md
@@ -91,7 +91,7 @@ UI 由静态文件组成，并根据 API 的响应工作。换言之，UI 中可
 
 ### 如何将其他参数/绑定/环境变量添加到 Rancher 启动的 Kubernetes 集群的 Kubernetes 组件中？
 
-你可以使用集群选项中的[配置文件](../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md#集群配置文件)选项来添加其他参数/​​绑定/环境变量。有关详细信息，请参阅 RKE 文档中的[其他参数、绑定和环境变量](https://rancher.com/docs/rke/latest/en/config-options/services/services-extras/)，或浏览 [Cluster.ymls 示例](https://rancher.com/docs/rke/latest/en/example-yamls/)。
+你可以使用集群选项中的[配置文件](../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md#rke-集群配置文件参考)选项来添加其他参数/​​绑定/环境变量。有关详细信息，请参阅 RKE 文档中的[其他参数、绑定和环境变量](https://rancher.com/docs/rke/latest/en/config-options/services/services-extras/)，或浏览 [Cluster.ymls 示例](https://rancher.com/docs/rke/latest/en/example-yamls/)。
 
 ### 如何检查证书链是否有效？
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/advanced-user-guides/enable-experimental-features/rancher-on-arm64.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/advanced-user-guides/enable-experimental-features/rancher-on-arm64.md
@@ -36,7 +36,7 @@ title: "在 ARM64 上运行 Rancher（实验性）"
 - 导入包含使用 ARM64 架构的节点的集群
    - Kubernetes 集群必须为 1.12 或更高版本
 
-如需了解如何配置集群选项，请参见[集群选项](cluster-provisioning/rke-clusters/options/)。
+如需了解如何配置集群选项，请参见[集群选项](../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md)。
 
 以下是未经测试的功能：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.md
@@ -82,7 +82,7 @@ rkeEtcd:
 
 **结果**：Monitoring 应用已部署到 `cattle-monitoring-system` 命名空间中。
 
-[创建接收器](../monitoring-v2-configuration-guides/advanced-configuration/alertmanager.md#在-rancher-ui-中创建接收器)时，启用 SSL 的接收器（例如电子邮件或 webhook）将具有 **SSL**，其中包含 **CA 文件路径**、**证书文件路径**和**密钥文件路径**字段。使用 `ca`、`cert` 和 `key` 的路径填写这些字段。路径的格式为 `/etc/alertmanager/secrets/name-of-file-in-secret`。
+[创建接收器](../../../reference-guides/monitoring-v2-configuration/receivers.md#在-rancher-ui-中创建接收器)时，启用 SSL 的接收器（例如电子邮件或 webhook）将具有 **SSL**，其中包含 **CA 文件路径**、**证书文件路径**和**密钥文件路径**字段。使用 `ca`、`cert` 和 `key` 的路径填写这些字段。路径的格式为 `/etc/alertmanager/secrets/name-of-file-in-secret`。
 
 例如，如果你使用以下键值对创建了一个密文：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-active-directory.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-active-directory.md
@@ -146,7 +146,7 @@ Rancher 使用 LDAP 查询来搜索和检索关于 Active Directory 中的用户
 
 为了成功配置 AD 身份验证，你必须提供 AD 服务器的层次结构和 Schema 的正确配置。
 
-[`ldapsearch`](http://manpages.ubuntu.com/manpages/artful/man1/ldapsearch.1.html) 工具允许你查询你的 AD 服务器，从而了解用于用户和组对象的 Schema。
+[`ldapsearch`](https://manpages.ubuntu.com/manpages/focal/en/man1/ldapsearch.1.html) 工具允许你查询你的 AD 服务器，从而了解用于用户和组对象的 Schema。
 
 在下面的示例命令中，我们假设：
 

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-active-directory.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-active-directory.md
@@ -125,7 +125,7 @@ Once you have completed the configuration, proceed by testing the connection to 
 
 In order to successfully configure AD authentication it is crucial that you provide the correct configuration pertaining to the hierarchy and schema of your AD server.
 
-The [`ldapsearch`](http://manpages.ubuntu.com/manpages/artful/man1/ldapsearch.1.html) tool allows you to query your AD server to learn about the schema used for user and group objects.
+The [`ldapsearch`](https://manpages.ubuntu.com/manpages/focal/en/man1/ldapsearch.1.html) tool allows you to query your AD server to learn about the schema used for user and group objects.
 
 For the purpose of the example commands provided below we will assume:
 

--- a/versioned_docs/version-2.5/faq/technical-items.md
+++ b/versioned_docs/version-2.5/faq/technical-items.md
@@ -91,7 +91,7 @@ When the node is removed from the cluster, and the node is cleaned, you can read
 
 ### How can I add additional arguments/binds/environment variables to Kubernetes components in a Rancher Launched Kubernetes cluster?
 
-You can add additional arguments/binds/environment variables via the [Config File](cluster-provisioning/rke-clusters/options/#cluster-config-file) option in Cluster Options. For more information, see the [Extra Args, Extra Binds, and Extra Environment Variables](https://rancher.com/docs/rke/latest/en/config-options/services/services-extras/) in the RKE documentation or browse the [Example Cluster.ymls](https://rancher.com/docs/rke/latest/en/example-yamls/).
+You can add additional arguments/binds/environment variables via the [Config File](../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md#editing-clusters-with-yaml) option in Cluster Options. For more information, see the [Extra Args, Extra Binds, and Extra Environment Variables](https://rancher.com/docs/rke/latest/en/config-options/services/services-extras/) in the RKE documentation or browse the [Example Cluster.ymls](https://rancher.com/docs/rke/latest/en/example-yamls/).
 
 ### How do I check if my certificate chain is valid?
 

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-active-directory.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/configure-active-directory.md
@@ -125,7 +125,7 @@ Once you have completed the configuration, proceed by testing the connection to 
 
 In order to successfully configure AD authentication it is crucial that you provide the correct configuration pertaining to the hierarchy and schema of your AD server.
 
-The [`ldapsearch`](http://manpages.ubuntu.com/manpages/artful/man1/ldapsearch.1.html) tool allows you to query your AD server to learn about the schema used for user and group objects.
+The [`ldapsearch`](https://manpages.ubuntu.com/manpages/focal/en/man1/ldapsearch.1.html) tool allows you to query your AD server to learn about the schema used for user and group objects.
 
 For the purpose of the example commands provided below we will assume:
 

--- a/versioned_docs/version-2.6/faq/technical-items.md
+++ b/versioned_docs/version-2.6/faq/technical-items.md
@@ -91,7 +91,7 @@ When the node is removed from the cluster, and the node is cleaned, you can read
 
 ### How can I add additional arguments/binds/environment variables to Kubernetes components in a Rancher Launched Kubernetes cluster?
 
-You can add additional arguments/binds/environment variables via the [Config File](../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md#cluster-config-file) option in Cluster Options. For more information, see the [Extra Args, Extra Binds, and Extra Environment Variables](https://rancher.com/docs/rke/latest/en/config-options/services/services-extras/) in the RKE documentation or browse the [Example Cluster.ymls](https://rancher.com/docs/rke/latest/en/example-yamls/).
+You can add additional arguments/binds/environment variables via the [Config File](../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md#rke-cluster-config-file-reference) option in Cluster Options. For more information, see the [Extra Args, Extra Binds, and Extra Environment Variables](https://rancher.com/docs/rke/latest/en/config-options/services/services-extras/) in the RKE documentation or browse the [Example Cluster.ymls](https://rancher.com/docs/rke/latest/en/example-yamls/).
 
 ### How do I check if my certificate chain is valid?
 

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/enable-experimental-features/rancher-on-arm64.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/enable-experimental-features/rancher-on-arm64.md
@@ -37,7 +37,7 @@ version's release notes in the following two ways:
 - Importing clusters that contain ARM64 based nodes
   - Kubernetes cluster version must be 1.12 or higher
 
-Please see [Cluster Options](cluster-provisioning/rke-clusters/options/) how to configure the cluster options.
+Please see [Cluster Options](../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md) how to configure the cluster options.
 
 The following features are not tested:
 

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/create-persistent-grafana-dashboard.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/create-persistent-grafana-dashboard.md
@@ -16,7 +16,7 @@ To allow the Grafana dashboard to persist after the Grafana instance restarts, a
 
 - The monitoring application needs to be installed.
 - To create the persistent dashboard, you must have at least the **Manage Config Maps** Rancher RBAC permissions assigned to you in the project or namespace that contains the Grafana Dashboards. This correlates to the `monitoring-dashboard-edit` or `monitoring-dashboard-admin` Kubernetes native RBAC Roles exposed by the Monitoring chart.
-- To see the links to the external monitoring UIs, including Grafana dashboards, you will need at least a [project-member role.](../../../integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.md#users-with-rancher-cluster-manager-based-permissions)
+- To see the links to the external monitoring UIs, including Grafana dashboards, you will need at least a [project-member role.](../../../integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.md#users-with-rancher-based-permissions)
 
 :::
 

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/customize-grafana-dashboard.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/customize-grafana-dashboard.md
@@ -8,7 +8,7 @@ In this section, you'll learn how to customize the Grafana dashboard to show met
 
 Before you can customize a Grafana dashboard, the `rancher-monitoring` application must be installed.
 
-To see the links to the external monitoring UIs, including Grafana dashboards, you will need at least a [project-member role.](../../../integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.md#users-with-rancher-cluster-manager-based-permissions)
+To see the links to the external monitoring UIs, including Grafana dashboards, you will need at least a [project-member role.](../../../integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.md#users-with-rancher-based-permissions)
 
 ### Signing in to Grafana
 

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.md
@@ -82,7 +82,7 @@ For more information about the default limits, see [this page.](../../../referen
 
 **Result:** The monitoring app is deployed in the `cattle-monitoring-system` namespace.
 
-When [creating a receiver,](../monitoring-v2-configuration-guides/advanced-configuration/alertmanager.md#creating-receivers-in-the-rancher-ui) SSL-enabled receivers such as email or webhook will have a **SSL** section with fields for **CA File Path**, **Cert File Path**, and **Key File Path**. Fill in these fields with the paths to each of `ca`, `cert`, and `key`. The path will be of the form `/etc/alertmanager/secrets/name-of-file-in-secret`.
+When [creating a receiver,](../../../reference-guides/monitoring-v2-configuration/receivers.md#creating-receivers-in-the-rancher-ui) SSL-enabled receivers such as email or webhook will have a **SSL** section with fields for **CA File Path**, **Cert File Path**, and **Key File Path**. Fill in these fields with the paths to each of `ca`, `cert`, and `key`. The path will be of the form `/etc/alertmanager/secrets/name-of-file-in-secret`.
 
 For example, if you created a secret with these key-value pairs:
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-active-directory.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-active-directory.md
@@ -146,7 +146,7 @@ You will still be able to login using the locally configured `admin` account and
 
 In order to successfully configure AD authentication it is crucial that you provide the correct configuration pertaining to the hierarchy and schema of your AD server.
 
-The [`ldapsearch`](http://manpages.ubuntu.com/manpages/artful/man1/ldapsearch.1.html) tool allows you to query your AD server to learn about the schema used for user and group objects.
+The [`ldapsearch`](https://manpages.ubuntu.com/manpages/focal/en/man1/ldapsearch.1.html) tool allows you to query your AD server to learn about the schema used for user and group objects.
 
 For the purpose of the example commands provided below we will assume:
 


### PR DESCRIPTION
This part of a series of PRs to fixe the broken links discovered after adding a link checker in #208.

Note that a small fraction (~15) of the 180 warnings still remain:
- Alternative/new links could not be found for some external links. E.g. https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers
- Docusaurus supports setting [custom heading IDs](https://docusaurus.io/docs/markdown-features/toc#heading-ids), which get flagged as broken by the checker.
- We've manually added anchors directly with HTML to some areas that normally don't have them. These get flagged as broken by the checker.