### PR TITLE
Add action to apply updates in /docs to /versioned_docs/version-XYZ

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -16,6 +16,24 @@ jobs:
           node-version: 18
           cache: yarn
 
+      - name: Get changed files in /docs directory
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v36
+        with:
+          files: docs
+      - name: Copy changes (if any) to /versioned_docs/
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        run: |
+          cp -r ./docs/* ./versioned_docs/version-2.7/
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          git config --global --add --bool push.autoSetupRemote true
+          gh pr checkout ${{ github.event.pull_request.number }}
+          git add ./versioned_docs/version-2.7/
+          git commit -m "Apply change(s) to versioned_docs/version-2.7"
+          git push
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Check links

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -17,14 +17,35 @@ jobs:
           cache: yarn
 
       - name: Get changed files in /docs directory
-        id: changed-files-specific
+        id: changed-files-docs-dir
         uses: tj-actions/changed-files@v36
         with:
           files: docs
-      - name: Copy changes (if any) to /versioned_docs/
+
+      - name: Get changed files in /versioned_docs/version-2.7/ directory
+        id: changed-files-versioned-docs-dir
+        uses: tj-actions/changed-files@v36
+        with:
+          files: ./versioned_docs/version-2.7/*
+
+      - name: List all changed in /docs
+        run: |
+          for file in ${{ steps.changed-files-docs-dir.outputs.all_changed_files }}; do
+            echo "$file was changed"
+          done
+
+      - name: List all changed in /versioned_docs
+        run: |
+          for file in ${{ steps.changed-files-versioned-docs-dir.outputs.all_changed_files }}; do
+            echo "$file was changed"
+          done
+
+      - name: Copy changes (if any) from /docs to /versioned_docs/version-2.7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        if: |
+          steps.changed-files-docs-dir.outputs.any_changed == 'true' &&
+          steps.changed-files-versioned-docs-dir.outputs.any_changed  == 'false'
         run: |
           cp -r ./docs/* ./versioned_docs/version-2.7/
           git config user.name "GitHub Actions Bot"
@@ -32,8 +53,25 @@ jobs:
           git config --global --add --bool push.autoSetupRemote true
           gh pr checkout ${{ github.event.pull_request.number }}
           git add ./versioned_docs/version-2.7/
-          git commit -m "Apply change(s) to versioned_docs/version-2.7"
+          git commit -m "Apply change(s) from /docs to /versioned_docs/version-2.7"
           git push
+
+      - name: Copy changes (if any) from /versioned_docs/version-2.7 to /docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: |
+          steps.changed-files-docs-dir.outputs.any_changed == 'false' &&
+          steps.changed-files-versioned-docs-dir.outputs.any_changed == 'true'
+        run: |
+          cp -r ./versioned_docs/version-2.7/* ./docs/
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          git config --global --add --bool push.autoSetupRemote true
+          gh pr checkout ${{ github.event.pull_request.number }}
+          git add ./docs/
+          git commit -m "Apply change(s) from /versioned_docs/version-2.7 to /docs"
+          git push
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Check links


### PR DESCRIPTION
Depends on #665.

With the introduction of having a `versioned_docs` entry to represent the latest version, we'll have increased overhead of making sure `/docs` and `versioned_docs/version-<latest>` ( `version-2.7` in this case) are in sync. With this action, when a PR is made against `main`, the corresponding changes will be applied against `versioned_docs/version-<latest>` as well and committed to the same PR.