### PR TITLE
Don't minify when building

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build website
-        run: yarn build
+        run: yarn build --no-minify
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Check links
         run: yarn run remark --quiet --use remark-validate-links --use remark-lint-no-dead-urls ./docs
       - name: Test build website
-        run: yarn build
+        run: yarn build --no-minify


### PR DESCRIPTION
Related to #665 and #667 

Based on https://github.com/facebook/docusaurus/discussions/3132 and https://github.com/facebook/docusaurus/issues/1782#issuecomment-533227047, not performing minification will use less memory. 

When testing locally, the combination of this and #667 allowed me to build #665 without running into `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`.