### PR TITLE
Pin the Node version in the Docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can also use [Docker](https://www.docker.com/) to launch the website.
 The below command can be used to install the dependencies and run the site inside a container:
 
 ```
-docker run --rm -it -v $PWD:$PWD -w $PWD -p 3000:3000 node /bin/sh -c "yarn install && yarn start -h 0.0.0.0"
+docker run --rm -it -v $PWD:$PWD -w $PWD -p 3000:3000 node:18 /bin/sh -c "yarn install && yarn start -h 0.0.0.0"
 ```
 
 Subsequent executions will check for updated dependencies, if there are none, it will skip the updates and quickly start the server.


### PR DESCRIPTION
The `latest` tag doesn't work - tried on my local machine and a cloud VM. There is a problem with either docusaurus startup process or the final stage of building assets.