### PR TITLE
Update second server node setup description in HA cluster

### DIFF
--- a/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
@@ -45,7 +45,17 @@ When running the command to start the K3s Kubernetes API server, you will pass i
 
   :::
 
-1. Repeat the same command on your second K3s server node.
+1. Get main server node token:
+  ```
+  cat /var/lib/rancher/k3s/server/node-token
+  ```
+
+1. Run command on your second K3s server node:
+  ```
+    curl -sfL https://get.k3s.io |  INSTALL_K3S_VERSION=<VERSION> sh -s - server \
+      --datastore-endpoint="<DATASTORE_ENDPOINT>" \
+      --token "<MAIN_SERVER_NODE_TOKEN>"
+  ```
 
 ### 2. Confirm that K3s is Running
 

--- a/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
@@ -47,7 +47,7 @@ When running the command to start the K3s Kubernetes API server, you will pass i
 
 1. Get main server node token:
   ```
-  cat /var/lib/rancher/k3s/server/node-token
+  cat /var/lib/rancher/k3s/server/token
   ```
 
 1. Run command on your second K3s server node:

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
@@ -45,7 +45,17 @@ When running the command to start the K3s Kubernetes API server, you will pass i
 
   :::
 
-1. Repeat the same command on your second K3s server node.
+1. Get main server node token:
+  ```
+  cat /var/lib/rancher/k3s/server/token
+  ```
+
+1. Run command on your second K3s server node:
+  ```
+    curl -sfL https://get.k3s.io |  INSTALL_K3S_VERSION=<VERSION> sh -s - server \
+      --datastore-endpoint="<DATASTORE_ENDPOINT>" \
+      --token "<MAIN_SERVER_NODE_TOKEN>"
+  ```
 
 ### 2. Confirm that K3s is Running
 

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
@@ -45,7 +45,17 @@ When running the command to start the K3s Kubernetes API server, you will pass i
 
   :::
 
-1. Repeat the same command on your second K3s server node.
+1. Get main server node token:
+  ```
+  cat /var/lib/rancher/k3s/server/token
+  ```
+
+1. Run command on your second K3s server node:
+  ```
+    curl -sfL https://get.k3s.io |  INSTALL_K3S_VERSION=<VERSION> sh -s - server \
+      --datastore-endpoint="<DATASTORE_ENDPOINT>" \
+      --token "<MAIN_SERVER_NODE_TOKEN>"
+  ```
 
 ### 2. Confirm that K3s is Running
 


### PR DESCRIPTION
Current description lacks steps when you have to obtain and apply master node token for second server.