### PR TITLE
[SEO] Use www in link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -96,7 +96,7 @@ module.exports = {
           className: 'navbar__github',
         },
         {
-          href: 'https://rancher.com',
+          href: 'https://www.rancher.com',
           label: 'Rancher Home',
           position: 'right',
         },


### PR DESCRIPTION
Linking to rancher.com without the www negatively impacts our SEO score (per ContentKing) as it's a redirect. 