### PR TITLE
Versioned doc + canonical link for #599

### DIFF
--- a/docs/pages-for-subheaders/configure-shibboleth-saml.md
+++ b/docs/pages-for-subheaders/configure-shibboleth-saml.md
@@ -2,6 +2,10 @@
 title: Configuring Shibboleth (SAML)
 ---
 
+<head> 
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configure-shibboleth-saml"/>
+</head>
+
 If your organization uses Shibboleth Identity Provider (IdP) for user authentication, you can configure Rancher to allow your users to log in to Rancher using their Shibboleth credentials.
 
 In this configuration, when Rancher users log in, they will be redirected to the Shibboleth IdP to enter their credentials. After authentication, they will be redirected back to the Rancher UI.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-okta-saml.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-okta-saml.md
@@ -24,10 +24,12 @@ Setting | Value
 
 ## Configuring Okta in Rancher
 
-1.	In the top left corner, click **☰ > Users & Authentication**.
+You can integrate Okta with Rancher, so that authenticated users can access Rancher resources through their group permissions. Okta returns a SAML assertion that authenticates a user, including which groups a user belongs to.
+
+1. In the top left corner, click **☰ > Users & Authentication**.
 1. In the left navigation menu, click **Auth Provider**.
 1. Click **Okta**.
-1.	Complete the **Configure Okta Account** form. The examples below describe how you can map Okta attributes from attribute statements to fields within Rancher.
+1. Complete the **Configure Okta Account** form. The examples below describe how you can map Okta attributes from attribute statements to fields within Rancher.
 
     | Field                     | Description                                                                   |
     | ------------------------- | ----------------------------------------------------------------------------- |
@@ -64,9 +66,46 @@ Setting | Value
 
 :::note SAML Provider Caveats:
 
-- SAML Protocol does not support search or lookup for users or groups. Therefore, there is no validation on users or groups when adding them to Rancher.
+If you configure Okta without OpenLDAP, you won't be able to search for or directly lookup users or groups. This brings several caveats:
+
+- Users and groups aren't validated when you assign permissions to them in Rancher.
 - When adding users, the exact user IDs (i.e. `UID Field`) must be entered correctly. As you type the user ID, there will be no search for other  user IDs that may match.
 - When adding groups, you must select the group from the drop-down that is next to the text box. Rancher assumes that any input from the text box is a user.
 - The group drop-down shows only the groups that you are a member of. You will not be able to add groups that you are not a member of.
 
 :::
+
+## Okta with OpenLDAP search
+
+You can add an OpenLDAP backend to assist with user and group search. Rancher will display additional users and groups from the OpenLDAP service. This allows assigning permissions to groups that the logged-in user is not already a member of.
+
+### OpenLDAP Prerequisites
+
+If you use Okta as your IdP, you can [set up an LDAP interface](https://help.okta.com/en-us/Content/Topics/Directory/LDAP-interface-main.htm) for Rancher to use. You can also configure an external OpenLDAP server.
+
+You must configure Rancher with a LDAP bind account (aka service account) so that you can search and retrieve LDAP entries for users and groups that should have access. Don't use an administrator account or personal account as an LDAP bind account. [Create](https://help.okta.com/en-us/Content/Topics/users-groups-profiles/usgp-add-users.htm) a dedicated account in OpenLDAP, with read-only access to users and groups under the configured searchbase.
+
+:::warning Security Considerations
+
+The OpenLDAP service account is used for all searches. Rancher users will see users and groups that the OpenLDAP service account can view, regardless of their individual SAML permissions.
+
+:::
+
+
+> **Using TLS?**
+>
+> If the certificate used by the OpenLDAP server is self-signed or from an unrecognized certificate authority, Rancher needs the CA certificate (concatenated with any intermediate certificates) in PEM format. Provide this certificate during the configuration so that Rancher can validate the certificate chain.
+
+### Configure OpenLDAP in Rancher
+
+[Configure the settings](../configure-openldap/openldap-config-reference.md) for the OpenLDAP server, groups and users. Note that nested group membership isn't available.
+
+> Before you proceed with the configuration, please familiarise yourself with [external authentication configuration and principal users](../../../../pages-for-subheaders/authentication-config.md#external-authentication-configuration-and-principal-users).
+
+1. Sign into Rancher using a local user assigned the [administrator](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions) role (i.e., the _local principal_).
+1. In the top left corner, click **☰ > Users & Authentication**.
+1. In the left navigation menu, click **Auth Provider**.
+1. Click **Okta** or, if SAML is already configured, **Edit Config**
+1. Under **User and Group Search**, check **Configure an OpenLDAP server**
+
+If you experience issues when you test the connection to the OpenLDAP server, ensure that you entered the credentials for the service account and configured the search base correctly. Inspecting the Rancher logs can help pinpoint the root cause. Debug logs may contain more detailed information about the error. Please refer to [How can I enable debug logging](../../../../faq/technical-items.md#how-can-i-enable-debug-logging) for more information.

--- a/versioned_docs/version-2.7/pages-for-subheaders/configure-shibboleth-saml.md
+++ b/versioned_docs/version-2.7/pages-for-subheaders/configure-shibboleth-saml.md
@@ -2,6 +2,10 @@
 title: Configuring Shibboleth (SAML)
 ---
 
+<head> 
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configure-shibboleth-saml"/>
+</head>
+
 If your organization uses Shibboleth Identity Provider (IdP) for user authentication, you can configure Rancher to allow your users to log in to Rancher using their Shibboleth credentials.
 
 In this configuration, when Rancher users log in, they will be redirected to the Shibboleth IdP to enter their credentials. After authentication, they will be redirected back to the Rancher UI.
@@ -94,7 +98,8 @@ Configure the settings for the OpenLDAP server, groups and users. For help filli
 1. Log into the Rancher UI using the initial local `admin` account.
 1. In the top left corner, click **☰ > Users & Authentication**.
 1. In the left navigation menu, click **Auth Provider**.
-1. Click **OpenLDAP**. The **Configure an OpenLDAP server** form will be displayed.
+1. Click **Shibboleth** or, if SAML is already configured, **Edit Config**
+1. Under **User and Group Search**, check **Configure an OpenLDAP server**
 
 ## Troubleshooting
 


### PR DESCRIPTION
This reflects changes from #599 into the corresponding versioned_docs pages, and adds canonical links to 2 versions of "Configuring Shibboleth (SAML)"