### PR TITLE
#420 SEO Improvements: Canonical links for deploy apps across clusters directory. Part 1/1

### DIFF
--- a/docs/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
+++ b/docs/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
@@ -2,6 +2,10 @@
 title: Continuous Delivery with Fleet
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet"/>
+</head>
+
 Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It's also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale.](https://fleet.rancher.io/installation#configuration-for-multi-cluster) By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
 
 Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.

--- a/docs/how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md
+++ b/docs/how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md
@@ -2,7 +2,9 @@
 title: Multi-cluster Apps
 ---
 
-> As of Rancher v2.5, multi-cluster apps are deprecated. We now recommend using [Fleet](fleet.md) for deploying apps across clusters.
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps"/>
+</head>
 
 Typically, most applications are deployed on a single Kubernetes cluster, but there will be times you might want to deploy multiple copies of the same application across different clusters and/or projects. In Rancher, a _multi-cluster application_,  is an application deployed using a Helm chart across multiple clusters. With the ability to deploy the same application across multiple clusters, it avoids the repetition of the same action on each cluster, which could introduce user error during application configuration. With multi-cluster applications, you can customize to have the same configuration across all projects/clusters as well as have the ability to change the configuration based on your target project. Since multi-cluster application is considered a single application, it's easy to manage and maintain this application.
 

--- a/docs/pages-for-subheaders/fleet-gitops-at-scale.md
+++ b/docs/pages-for-subheaders/fleet-gitops-at-scale.md
@@ -2,6 +2,10 @@
 title: Continuous Delivery with Fleet
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet"/>
+</head>
+
 Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/installation#configuration-for-multi-cluster). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
 
 Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/deploy-apps-across-clusters.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/deploy-apps-across-clusters.md
@@ -2,6 +2,10 @@
 title: Deploying Applications across Clusters
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps"/>
+</head>
+
 _Available as of v2.2.0_
 
 Typically, most applications are deployed on a single Kubernetes cluster, but there will be times you might want to deploy multiple copies of the same application across different clusters and/or projects. In Rancher, a _multi-cluster application_,  is an application deployed using a Helm chart across multiple clusters. With the ability to deploy the same application across multiple clusters, it avoids the repetition of the same action on each cluster, which could introduce user error during application configuration. With multi-cluster applications, you can customize to have the same configuration across all projects/clusters as well as have the ability to change the configuration based on your target project. Since multi-cluster application is considered a single application, it's easy to manage and maintain this application.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/helm-charts-in-rancher/multi-cluster-apps.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/helm-charts-in-rancher/multi-cluster-apps.md
@@ -1,6 +1,11 @@
 ---
 title: Multi-Cluster Apps
 ---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps"/>
+</head>
+
 _Available as of v2.2.0_
 
 The documentation about multi-cluster apps has moved [here.](../deploy-apps-across-clusters.md)

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md
@@ -2,6 +2,10 @@
 title: Multi-cluster Apps
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps"/>
+</head>
+
 > As of Rancher v2.5, we now recommend using [Fleet](fleet.md) for deploying apps across clusters.
 
 Typically, most applications are deployed on a single Kubernetes cluster, but there will be times you might want to deploy multiple copies of the same application across different clusters and/or projects. In Rancher, a _multi-cluster application_,  is an application deployed using a Helm chart across multiple clusters. With the ability to deploy the same application across multiple clusters, it avoids the repetition of the same action on each cluster, which could introduce user error during application configuration. With multi-cluster applications, you can customize to have the same configuration across all projects/clusters as well as have the ability to change the configuration based on your target project. Since multi-cluster application is considered a single application, it's easy to manage and maintain this application.

--- a/versioned_docs/version-2.5/pages-for-subheaders/fleet-gitops-at-scale.md
+++ b/versioned_docs/version-2.5/pages-for-subheaders/fleet-gitops-at-scale.md
@@ -2,6 +2,10 @@
 title: Continuous Delivery with Fleet
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet"/>
+</head>
+
 _Available as of Rancher v2.5_
 
 Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/installation#configuration-for-multi-cluster). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
@@ -2,6 +2,10 @@
 title: Continuous Delivery with Fleet
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet"/>
+</head>
+
 Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It's also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale.](https://fleet.rancher.io/installation#configuration-for-multi-cluster) By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
 
 Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md
@@ -2,7 +2,9 @@
 title: Multi-cluster Apps
 ---
 
-> As of Rancher v2.5, multi-cluster apps are deprecated. We now recommend using [Fleet](fleet.md) for deploying apps across clusters.
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps"/>
+</head>
 
 Typically, most applications are deployed on a single Kubernetes cluster, but there will be times you might want to deploy multiple copies of the same application across different clusters and/or projects. In Rancher, a _multi-cluster application_,  is an application deployed using a Helm chart across multiple clusters. With the ability to deploy the same application across multiple clusters, it avoids the repetition of the same action on each cluster, which could introduce user error during application configuration. With multi-cluster applications, you can customize to have the same configuration across all projects/clusters as well as have the ability to change the configuration based on your target project. Since multi-cluster application is considered a single application, it's easy to manage and maintain this application.
 

--- a/versioned_docs/version-2.6/pages-for-subheaders/fleet-gitops-at-scale.md
+++ b/versioned_docs/version-2.6/pages-for-subheaders/fleet-gitops-at-scale.md
@@ -2,6 +2,10 @@
 title: Continuous Delivery with Fleet
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet"/>
+</head>
+
 Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/installation#configuration-for-multi-cluster). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
 
 Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
@@ -2,6 +2,10 @@
 title: Continuous Delivery with Fleet
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet"/>
+</head>
+
 Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It's also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale.](https://fleet.rancher.io/installation#configuration-for-multi-cluster) By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
 
 Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md
@@ -2,7 +2,9 @@
 title: Multi-cluster Apps
 ---
 
-> As of Rancher v2.5, multi-cluster apps are deprecated. We now recommend using [Fleet](fleet.md) for deploying apps across clusters.
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps"/>
+</head>
 
 Typically, most applications are deployed on a single Kubernetes cluster, but there will be times you might want to deploy multiple copies of the same application across different clusters and/or projects. In Rancher, a _multi-cluster application_,  is an application deployed using a Helm chart across multiple clusters. With the ability to deploy the same application across multiple clusters, it avoids the repetition of the same action on each cluster, which could introduce user error during application configuration. With multi-cluster applications, you can customize to have the same configuration across all projects/clusters as well as have the ability to change the configuration based on your target project. Since multi-cluster application is considered a single application, it's easy to manage and maintain this application.
 

--- a/versioned_docs/version-2.7/pages-for-subheaders/fleet-gitops-at-scale.md
+++ b/versioned_docs/version-2.7/pages-for-subheaders/fleet-gitops-at-scale.md
@@ -2,6 +2,10 @@
 title: Continuous Delivery with Fleet
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet"/>
+</head>
+
 Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/installation#configuration-for-multi-cluster). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
 
 Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.


### PR DESCRIPTION
This is a very small directory, with a little weirdness. The fleet.md and fleet-gitops-at-scale.md pages seem to be identical. Since we're thinking of moving files out of /pages-for-subheaders anyway, is it really necessary to have copies of fleet.md hosted under another filename in that directory?