### PR TITLE
Use HTTPS for site url

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,7 +3,7 @@
 module.exports = {
   title: 'Rancher',
   tagline: '',
-  url: 'http://ranchermanager.docs.rancher.com/',
+  url: 'https://ranchermanager.docs.rancher.com/',
   baseUrl: '/',
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
This value is affecting the URLs in generated content like the sitemap and canonical links. [At one point](https://github.com/rancherlabs/eio/issues/1297), we weren't enforcing HTTPS so the HTTP variant was used.