### PR TITLE
#726 - Getting Started UI instructions added to docs 

### DIFF
--- a/versioned_docs/version-2.5/pages-for-subheaders/access-clusters.md
+++ b/versioned_docs/version-2.5/pages-for-subheaders/access-clusters.md
@@ -13,7 +13,28 @@ For information on how to set up an authentication system, see [this section.](a
 
 ### Rancher UI
 
-Rancher provides an intuitive user interface for interacting with your clusters. All options available in the UI use the Rancher API. Therefore any action possible in the UI is also possible in the Rancher CLI or Rancher API.
+A table listing available clusters is present on the Rancher **Home** page. Click on the name of a cluster from the table to view to that cluster's **Cluster Dashboard**.
+
+The cluster dashboard is also accessible from the **☰** in the top navigation bar:
+
+1. Click **☰**.
+1. Select the name of a cluster from the **Explore Cluster** menu option.
+
+You can view more information about a cluster and perform management tasks by selecting the **Manage** button near the table of clusters on the **Home** page. This will take you to the cluster management page. Select the **Explore** button at the end of each row to view that cluster's **Cluster Dashboard**, or select **⁝** at the end of the row to reveal a submenu featuring the following management options:
+
+* [Kubectl Shell](../how-to-guides/advanced-user-guides/manage-clusters/access-clusters/use-kubectl-and-kubeconfig.md)
+* Download KubeConfig
+* Copy KubeConfig to Clipboard
+* Edit Config
+* View YAML
+* Download YAML 
+
+You can access the cluster management page from the **☰** menu as well:
+
+1. Click **☰**.
+1. Select **Cluster Management**.
+
+All options available in the UI use the Rancher API. Therefore any action possible in the UI is also possible in the Rancher CLI or Rancher API.
 
 ### kubectl
 


### PR DESCRIPTION
https://github.com/rancher/rancher-docs/issues/726#issuecomment-1640393876

We're missing some UI instructions for certain features. This is adding them in.


----
Original Table

> I did an inventory of the items listed in the "Migrating from Cluster Manager" table last night. About half of the listed items have corresponding pages that contain instructions for how to find them in the Rancher UI. Others only seem to have CLI commands included in our docs, or are so frequently navigated to (the clusters list) that there's no particular page to link users to.

Feature | Page | Note
-|-|-
Clusters list | / | /
Cluster drivers | https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-cluster-drivers#docusaurus_skipToContent_fallback | /
RKE (Cluster) Templates | https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/manage-rke1-templates | /
RKE Cloud Credentials | https://ranchermanager.docs.rancher.com/reference-guides/user-settings/manage-cloud-credentials | The instructions on this page aren't RKE1-specific. The original table indicates that this feature can be found under **RKE1 Configuration** but I don't see that the in 2.7 Rancher UI. The 2.6 version of the page also lists the alternate, non-RKE1 path. I think the table might be outdated
RKE Node Templates | https://ranchermanager.docs.rancher.com/reference-guides/user-settings/manage-node-templates | /
RKE1 Snapshots | / | /
Global Setting | / | This is kind of ambiguous. Docs have ["global permissions"](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions#docusaurus_skipToContent_fallback) but not this UI element listed
Catalogs | https://ranchermanager.docs.rancher.com/v2.0-v2.4/how-to-guides/new-user-guides/helm-charts-in-rancher/managing-apps | Only in older versions
Global DNS Entries | / | Older docs have https://ranchermanager.docs.rancher.com/v2.0-v2.4/how-to-guides/new-user-guides/helm-charts-in-rancher/globaldns#global-dns-entries but we need to verify where the newer pages have similar content...
Global DNS Providers | / | Similar to above. We have https://ranchermanager.docs.rancher.com/v2.0-v2.4/how-to-guides/new-user-guides/helm-charts-in-rancher/globaldns#global-dns-providers in oldest versions but not sure where corresponding instructions for newer versions are 
Pod Security Policy | https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/manage-projects/manage-pod-security-policies#docusaurus_skipToContent_fallback | /
Cluster (functionality) | https://ranchermanager.docs.rancher.com/pages-for-subheaders/access-clusters | This page doesn't really describe how to navigate to the feature but it contains a subheading that would be a natural place to correct that
Nodes | / | /
Projects/Namespaces | https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/projects-and-namespaces#docusaurus_skipToContent_fallback | /
Alerts (V1) | | 
Catalogs (for a specific cluster) | https://ranchermanager.docs.rancher.com/v2.0-v2.4/how-to-guides/new-user-guides/helm-charts-in-rancher/managing-apps | Only in older versions
Notifiers (V1) | | 
Monitoring (V1) | |
Cluster Metrics (V1) | | 
Node Metrics (V1) | | 
Workload Metrics (V1) | | 
Pod Metrics (V1) | |  
Namespaces | https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/projects-and-namespaces#docusaurus_skipToContent_fallback | /
Apps | / | /
Alerts | https://ranchermanager.docs.rancher.com/reference-guides/monitoring-v2-configuration/receivers | This isn't along the legacy path suggested by the original table
Catalogs | / | /
Logging | / | / 
Monitoring |  https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring#docusaurus_skipToContent_fallback | /
Kubeconfig Download | / | /
CLI Download | https://ranchermanager.docs.rancher.com/reference-guides/cli-with-rancher/rancher-cli#download-rancher-cli | /
Image Lists Download | / | /
API and Keys | https://ranchermanager.docs.rancher.com/reference-guides/user-settings/api-keys#api-keys-and-user-authentication | /
Preferences | https://ranchermanager.docs.rancher.com/reference-guides/user-settings/user-preferences#docusaurus_skipToContent_fallback | /


