### PR TITLE
#755 Update Note for CIS Chart Installation on hardened cluster

### DIFF
--- a/docs/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark.md
+++ b/docs/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark.md
@@ -25,6 +25,3 @@ CIS Benchmark 4.0.0 and above have PSPs disabled by default. To install CIS Benc
 If you have a cluster running Kubernetes v1.25 or later, you can set the Rancher CIS benchmark by [assigning](../../new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md) the `rancher-restricted` [PSA](../../new-user-guides/authentication-permissions-and-global-configuration/pod-security-standards.md) configuration template to the cluster and selecting a CIS profile.  
 </TabItem>
 </Tabs>
-
-[dgf](../open-ports-with-firewalld.md)
-

--- a/docs/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark.md
+++ b/docs/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark.md
@@ -2,6 +2,10 @@
 title: Install Rancher CIS Benchmark
 ---
 
+<Tabs>
+<TabItem value="Kubernetes v1.24 and earlier">
+The following instructions apply to PSP-hardened clusters, which were available in Kubernetes v1.24 and earlier.
+
 1. In the upper left corner, click **☰ > Cluster Management**.
 1. On the **Clusters** page, go to the cluster where you want to install CIS Benchmark and click **Explore**.
 1. In the left navigation bar, click **Apps > Charts**.
@@ -15,3 +19,12 @@ title: Install Rancher CIS Benchmark
 CIS Benchmark 4.0.0 and above have PSPs disabled by default. To install CIS Benchmark on a hardened cluster, set `global.psp.enabled` to `true` in the values before installing the chart.
 
 :::
+
+</TabItem>
+<TabItem value = "Kubernetes v1.25+">
+If you have a cluster running Kubernetes v1.25 or later, you can set the Rancher CIS benchmark by [assigning](../../new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md) the `rancher-restricted` [PSA](../../new-user-guides/authentication-permissions-and-global-configuration/pod-security-standards.md) configuration template to the cluster and selecting a CIS profile.  
+</TabItem>
+</Tabs>
+
+[dgf](../open-ports-with-firewalld.md)
+

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md
@@ -6,10 +6,10 @@ title: Pod Security Admission (PSA) Configuration Templates
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates"/>
 </head>
 
-[Pod Security admission (PSA)](./pod-security-standards.md) configuration templates are a Rancher custom-defined resource (CRD), available in Rancher v2.7.2 and above. The templates provide pre-defined security configurations that you can apply to a cluster:
+[Pod Security Admission (PSA)](./pod-security-standards.md) configuration templates are a Rancher custom-defined resource (CRD), available in Rancher v2.7.2 and above. The templates provide pre-defined security configurations that you can apply to a cluster:
 
 - `rancher-privileged`: The most permissive configuration. It doesn't restrict the behavior of any pods. This allows for known privilege escalations. This policy has no exemptions.
-- `rancher-restricted`: A heavily restricted configuration that follows current best practices for hardening pods. You must make [namespace-level exemptions](./pod-security-standards.md#rancher-on-psa-restricted-clusters) for Rancher components.
+- `rancher-restricted`: A heavily restricted configuration that follows current best practices for hardening pods. You can use this configuration to assign a CIS benchmark profile to the cluster. You must make [namespace-level exemptions](./pod-security-standards.md#rancher-on-psa-restricted-clusters) for Rancher components.
 
 ## Assign a Pod Security Admissions (PSA) Configuration Template
 


### PR DESCRIPTION
Fixes #755 

Rather than update the note, I opted for tabs, since later Kubernetes versions have an alternate path to applying the benchmarks. I made the instructions for the earlier Kubernetes version first since that's what's already listed on the page, but we can switch the order if you think we should emphasize the latest version.

I also updated the PSA config template page to state that assigning a template is how you apply the CIS benchmark