### PR TITLE
#420 SEO Improvements: Canonical links for Kubernetes cluster setup

### DIFF
--- a/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -2,6 +2,10 @@
 title: About High-availability Installations
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs"/>
+</head>
+
 We recommend using Helm, a Kubernetes package manager, to install Rancher on a dedicated Kubernetes cluster. This is called a high-availability Kubernetes installation because increased availability is achieved by running Rancher on multiple nodes.
 
 In a standard installation, Kubernetes is first installed on three nodes that are hosted in an infrastructure provider such as Amazon's EC2 or Google Compute Engine.

--- a/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
@@ -2,6 +2,10 @@
 title: Setting up a High-availability K3s Kubernetes Cluster for Rancher
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher"/>
+</head>
+
 This section describes how to install a Kubernetes cluster according to the [best practices for the Rancher server environment.](../../../reference-guides/rancher-manager-architecture/architecture-recommendations.md#environment-for-kubernetes-installations)
 
 For systems without direct internet access, refer to the air gap installation instructions.

--- a/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher.md
@@ -2,6 +2,10 @@
 title: Setting up a High-availability RKE Kubernetes Cluster
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher"/>
+</head>
+
 This section describes how to install a Kubernetes cluster. This cluster should be dedicated to run only the Rancher server.
 
 :::note

--- a/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke2-for-rancher.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke2-for-rancher.md
@@ -2,6 +2,10 @@
 title: Setting up a High-availability RKE2 Kubernetes Cluster for Rancher
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke2-for-rancher"/>
+</head>
+
 This section describes how to install a Kubernetes cluster according to the [best practices for the Rancher server environment.](../../../reference-guides/rancher-manager-architecture/architecture-recommendations.md#environment-for-kubernetes-installations)
 
 ## Prerequisites

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -2,6 +2,10 @@
 title: About High-availability Installations
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs"/>
+</head>
+
 We recommend using Helm, a Kubernetes package manager, to install Rancher on a dedicated Kubernetes cluster. This is called a high-availability Kubernetes installation because increased availability is achieved by running Rancher on multiple nodes.
 
 In a standard installation, Kubernetes is first installed on three nodes that are hosted in an infrastructure provider such as Amazon's EC2 or Google Compute Engine.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
@@ -2,6 +2,10 @@
 title: Setting up a High-availability K3s Kubernetes Cluster for Rancher
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher"/>
+</head>
+
 This section describes how to install a Kubernetes cluster according to the [best practices for the Rancher server environment.](../../../reference-guides/rancher-manager-architecture/architecture-recommendations.md#environment-for-kubernetes-installations)
 
 For systems without direct internet access, refer to the air gap installation instructions.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher.md
@@ -2,6 +2,10 @@
 title: Setting up a High-availability RKE Kubernetes Cluster
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher"/>
+</head>
+
 This section describes how to install a Kubernetes cluster. This cluster should be dedicated to run only the Rancher server.
 
 For Rancher before v2.4, Rancher should be installed on an RKE Kubernetes cluster. RKE is a CNCF-certified Kubernetes distribution that runs entirely within Docker containers.

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -2,6 +2,10 @@
 title: About High-availability Installations
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs"/>
+</head>
+
 We recommend using Helm, a Kubernetes package manager, to install Rancher on a dedicated Kubernetes cluster. This is called a high-availability Kubernetes installation because increased availability is achieved by running Rancher on multiple nodes.
 
 In a standard installation, Kubernetes is first installed on three nodes that are hosted in an infrastructure provider such as Amazon's EC2 or Google Compute Engine.

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
@@ -2,6 +2,10 @@
 title: Setting up a High-availability K3s Kubernetes Cluster for Rancher
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher"/>
+</head>
+
 This section describes how to install a Kubernetes cluster according to the [best practices for the Rancher server environment.](../../../reference-guides/rancher-manager-architecture/architecture-recommendations.md#environment-for-kubernetes-installations)
 
 For systems without direct internet access, refer to the air gap installation instructions.

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher.md
@@ -2,6 +2,10 @@
 title: Setting up a High-availability RKE Kubernetes Cluster
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher"/>
+</head>
+
 This section describes how to install a Kubernetes cluster. This cluster should be dedicated to run only the Rancher server.
 
 > As of Rancher v2.5, Rancher can run on any Kubernetes cluster, included hosted Kubernetes solutions such as Amazon EKS. The below instructions represent only one possible way to install Kubernetes.

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke2-for-rancher.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke2-for-rancher.md
@@ -2,6 +2,10 @@
 title: Setting up a High-availability RKE2 Kubernetes Cluster for Rancher
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke2-for-rancher"/>
+</head>
+
 _Tested on v2.5.6_
 
 This section describes how to install a Kubernetes cluster according to the [best practices for the Rancher server environment.](../../../reference-guides/rancher-manager-architecture/architecture-recommendations.md#environment-for-kubernetes-installations)

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -2,6 +2,10 @@
 title: About High-availability Installations
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs"/>
+</head>
+
 We recommend using Helm, a Kubernetes package manager, to install Rancher on a dedicated Kubernetes cluster. This is called a high-availability Kubernetes installation because increased availability is achieved by running Rancher on multiple nodes.
 
 In a standard installation, Kubernetes is first installed on three nodes that are hosted in an infrastructure provider such as Amazon's EC2 or Google Compute Engine.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
@@ -2,6 +2,10 @@
 title: Setting up a High-availability K3s Kubernetes Cluster for Rancher
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher"/>
+</head>
+
 This section describes how to install a Kubernetes cluster according to the [best practices for the Rancher server environment.](../../../reference-guides/rancher-manager-architecture/architecture-recommendations.md#environment-for-kubernetes-installations)
 
 For systems without direct internet access, refer to the air gap installation instructions.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher.md
@@ -2,6 +2,10 @@
 title: Setting up a High-availability RKE Kubernetes Cluster
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher"/>
+</head>
+
 This section describes how to install a Kubernetes cluster. This cluster should be dedicated to run only the Rancher server.
 
 :::note

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke2-for-rancher.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke2-for-rancher.md
@@ -2,6 +2,10 @@
 title: Setting up a High-availability RKE2 Kubernetes Cluster for Rancher
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke2-for-rancher"/>
+</head>
+
 This section describes how to install a Kubernetes cluster according to the [best practices for the Rancher server environment.](../../../reference-guides/rancher-manager-architecture/architecture-recommendations.md#environment-for-kubernetes-installations)
 
 ## Prerequisites

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -2,6 +2,10 @@
 title: About High-availability Installations
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs"/>
+</head>
+
 We recommend using Helm, a Kubernetes package manager, to install Rancher on a dedicated Kubernetes cluster. This is called a high-availability Kubernetes installation because increased availability is achieved by running Rancher on multiple nodes.
 
 In a standard installation, Kubernetes is first installed on three nodes that are hosted in an infrastructure provider such as Amazon's EC2 or Google Compute Engine.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher.md
@@ -2,6 +2,10 @@
 title: Setting up a High-availability K3s Kubernetes Cluster for Rancher
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/k3s-for-rancher"/>
+</head>
+
 This section describes how to install a Kubernetes cluster according to the [best practices for the Rancher server environment.](../../../reference-guides/rancher-manager-architecture/architecture-recommendations.md#environment-for-kubernetes-installations)
 
 For systems without direct internet access, refer to the air gap installation instructions.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher.md
@@ -2,6 +2,10 @@
 title: Setting up a High-availability RKE Kubernetes Cluster
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke1-for-rancher"/>
+</head>
+
 This section describes how to install a Kubernetes cluster. This cluster should be dedicated to run only the Rancher server.
 
 :::note

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke2-for-rancher.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke2-for-rancher.md
@@ -2,6 +2,10 @@
 title: Setting up a High-availability RKE2 Kubernetes Cluster for Rancher
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup/rke2-for-rancher"/>
+</head>
+
 This section describes how to install a Kubernetes cluster according to the [best practices for the Rancher server environment.](../../../reference-guides/rancher-manager-architecture/architecture-recommendations.md#environment-for-kubernetes-installations)
 
 ## Prerequisites


### PR DESCRIPTION
This uses the https://github.com/btat/rm-seo-helpers linking tool to streamline adding canonical links.