### PR TITLE
Removing sentence with typo in provision-kubernetes-clusters-in-vsphere.md

### DIFF
--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere.md
@@ -48,8 +48,6 @@ If you have a cluster with DRS enabled, setting up [VM-VM Affinity Rules](https:
 
 ## Creating a vSphere Cluster
 
-The a vSphere cluster is created in Rancher depends on the Rancher version.
-
 1. [Create your cloud credentials](#1-create-your-cloud-credentials)
 2. [Create a node template with your cloud credentials](#2-create-a-node-template-with-your-cloud-credentials)
 3. [Create a cluster with node pools using the node template](#3-create-a-cluster-with-node-pools-using-the-node-template)


### PR DESCRIPTION
There was a typo as if words were removed at some point (maybe "The way a cluster is created depends on the Rancher version?"), but the sentence as a whole doesn't make much sense in context and we don't seem to lose anything by removing.