### PR TITLE
Update .gitignore to include files_without_canonical.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ yarn-error.log*
 
 /dev-resources/algolia-search/.env
 /dev-resources/algolia-search/algolia-index.sh
+
+files_without_canonical.txt


### PR DESCRIPTION
`files_without_canonical.txt` is autogenerated by the canonical links script we've started using. This makes it so we don't have to remove it every time we run the script and commit.