### PR TITLE
Revert "Update .gitignore to include files_without_canonical.txt"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,3 @@ yarn-error.log*
 
 /dev-resources/algolia-search/.env
 /dev-resources/algolia-search/algolia-index.sh
-
-files_without_canonical.txt


### PR DESCRIPTION
Reverts rancher/rancher-docs#781

The script we use that generates `files_without_canonical.txt` isn't part of this project/repo so we shouldn't include it in the repo's gitignore file. Instead, the file should be ignored at the local level using `.git/info/exclude`.