### PR TITLE
#787 - Update reference to outdated UI label

### DIFF
--- a/docs/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/docs/reference-guides/cli-with-rancher/rancher-cli.md
@@ -10,7 +10,7 @@ The Rancher CLI (Command Line Interface) is a unified tool that you can use to i
 The binary can be downloaded directly from the UI.
 
 1. In the upper left corner, click **☰**.
-1. At the bottom, click **v2.6.x**, where **v2.6.x** is a hyperlinked text indicating the installed Rancher version.
+1. At the bottom of the navigation sidebar menu, click **About**.
 1. Under the **CLI Downloads section**, there are links to download the binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
 
 ### Requirements

--- a/versioned_docs/version-2.7/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/versioned_docs/version-2.7/reference-guides/cli-with-rancher/rancher-cli.md
@@ -10,7 +10,7 @@ The Rancher CLI (Command Line Interface) is a unified tool that you can use to i
 The binary can be downloaded directly from the UI.
 
 1. In the upper left corner, click **☰**.
-1. At the bottom, click **v2.6.x**, where **v2.6.x** is a hyperlinked text indicating the installed Rancher version.
+1. At the bottom of the navigation sidebar menu, click **About**.
 1. Under the **CLI Downloads section**, there are links to download the binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
 
 ### Requirements


### PR DESCRIPTION
Fixes #787 

It seems that the UI text for this link was changed at some point but we never updated the docs to account for it. This isn't the kind of thing to get release-noted so I'm not sure if it also affects some earlier minor versions of 2.6.x