### PR TITLE
Update rke-hardening-guide based on CIS-1.24 and CIS-1.7

### DIFF
--- a/docs/pages-for-subheaders/rke1-hardening-guide.md
+++ b/docs/pages-for-subheaders/rke1-hardening-guide.md
@@ -17,8 +17,8 @@ This hardening guide is intended to be used for RKE clusters and is associated w
 | Rancher v2.7    | Benchmark v1.7        | Kubernetes v1.25 up to v1.26 |
 
 :::note
-- Since Benchmark v1.24, check id `4.1.7 Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Automated)` might fail, as /etc/kubernetes/ssl/kube-ca.pem is provisioned in 644 by default.
-- Since Benchmark v1.7 (latest), `--protect-kernel-defaults` (check id 4.2.6) parameter is not required anymore, and was replaced.
+- In Benchmark v1.24 and later, check id `4.1.7 Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Automated)` might fail, as `/etc/kubernetes/ssl/kube-ca.pem` is set to 644 by default.
+- In Benchmark v1.7, the `--protect-kernel-defaults` (`4.2.6`) parameter isn't required anymore, and was removed by CIS.
 :::
 
 For more details on how to evaluate a hardened RKE cluster against the official CIS benchmark, refer to the RKE self-assessment guides for specific Kubernetes and CIS benchmark versions.

--- a/docs/pages-for-subheaders/rke1-hardening-guide.md
+++ b/docs/pages-for-subheaders/rke1-hardening-guide.md
@@ -295,6 +295,7 @@ services:
   kubelet:
     extra_args:
       feature-gates: RotateKubeletServerCertificate=true
+      protect-kernel-defaults: true
     generate_serving_certificate: true
 addons: |
   # Upstream Kubernetes restricted PSP policy
@@ -441,7 +442,6 @@ rancher_kubernetes_engine_config:
     kubelet:
       extra_args:
         feature-gates: RotateKubeletServerCertificate=true
-        protect-kernel-defaults: true
         tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
       generate_serving_certificate: true
     scheduler:

--- a/docs/pages-for-subheaders/rke1-hardening-guide.md
+++ b/docs/pages-for-subheaders/rke1-hardening-guide.md
@@ -12,7 +12,9 @@ This hardening guide is intended to be used for RKE clusters and is associated w
 
 | Rancher Version | CIS Benchmark Version | Kubernetes Version           |
 |-----------------|-----------------------|------------------------------|
-| Rancher v2.7    | Benchmark v1.7       | Kubernetes v1.24 up to v1.25 |
+| Rancher v2.7    | Benchmark v1.23       | Kubernetes v1.23             |
+| Rancher v2.7    | Benchmark v1.24       | Kubernetes v1.24             |
+| Rancher v2.7    | Benchmark v1.7        | Kubernetes v1.25 up to v1.26 |
 
 :::note
 - Since Benchmark v1.24, check id `4.1.7 Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Automated)` might fail, as /etc/kubernetes/ssl/kube-ca.pem is provisioned in 644 by default.

--- a/docs/pages-for-subheaders/rke1-hardening-guide.md
+++ b/docs/pages-for-subheaders/rke1-hardening-guide.md
@@ -12,10 +12,11 @@ This hardening guide is intended to be used for RKE clusters and is associated w
 
 | Rancher Version | CIS Benchmark Version | Kubernetes Version           |
 |-----------------|-----------------------|------------------------------|
-| Rancher v2.7    | Benchmark v1.23       | Kubernetes v1.23 up to v1.25 |
+| Rancher v2.7    | Benchmark v1.7       | Kubernetes v1.24 up to v1.25 |
 
 :::note
-At the time of writing, the upstream CIS Kubernetes v1.25 benchmark is not yet available in Rancher. At this time Rancher is using the CIS v1.23 benchmark when scanning Kubernetes v1.25 clusters. Due to that, the CIS checks 5.2.3, 5.2.4, 5.2.5 and 5.2.6 might fail.
+- Since Benchmark v1.24, check id `4.1.7 Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Automated)` might fail, as /etc/kubernetes/ssl/kube-ca.pem is provisioned in 644 by default.
+- Since Benchmark v1.7 (latest), `--protect-kernel-defaults` (check id 4.2.6) parameter is not required anymore, and was replaced.
 :::
 
 For more details on how to evaluate a hardened RKE cluster against the official CIS benchmark, refer to the RKE self-assessment guides for specific Kubernetes and CIS benchmark versions.
@@ -243,7 +244,6 @@ services:
   kubelet:
     extra_args:
       feature-gates: RotateKubeletServerCertificate=true
-      protect-kernel-defaults: "true"
     generate_serving_certificate: true
 addons: |
   apiVersion: networking.k8s.io/v1
@@ -293,7 +293,6 @@ services:
   kubelet:
     extra_args:
       feature-gates: RotateKubeletServerCertificate=true
-      protect-kernel-defaults: true
     generate_serving_certificate: true
 addons: |
   # Upstream Kubernetes restricted PSP policy


### PR DESCRIPTION
This PR updates the [RKE hardening guide](https://ranchermanager.docs.rancher.com/pages-for-subheaders/rke1-hardening-guide) with the new requirements added in `cis-1.24` and `cis-1.7`.
Related issue:
- https://github.com/rancher/rancher/issues/42154