### PR TITLE
#801 - Correcting no-space between closing head tag and next line in file

### DIFF
--- a/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
@@ -6,6 +6,7 @@ description: Learn about the container image registry and Kubernetes registry, t
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries"/>
 </head>
+
 Registries are Kubernetes secrets containing credentials used to authenticate with [private container registries](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 
 The word "registry" can mean two things, depending on whether it is used to refer to a container or Kubernetes registry:

--- a/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/layer-4-and-layer-7-load-balancing.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/layer-4-and-layer-7-load-balancing.md
@@ -6,6 +6,7 @@ description: "Kubernetes supports load balancing in two ways: Layer-4 Load Balan
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/layer-4-and-layer-7-load-balancing"/>
 </head>
+
 Kubernetes supports load balancing in two ways: Layer-4 Load Balancing and Layer-7 Load Balancing.
 
 ## Layer-4 Load Balancer

--- a/docs/pages-for-subheaders/create-kubernetes-persistent-storage.md
+++ b/docs/pages-for-subheaders/create-kubernetes-persistent-storage.md
@@ -6,6 +6,7 @@ description: "Learn about the two ways with which you can create persistent stor
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/create-kubernetes-persistent-storage"/>
 </head>
+
 When deploying an application that needs to retain data, you'll need to create persistent storage. Persistent storage allows you to store application data external from the pod running your application. This storage practice allows you to maintain application data, even if the application's pod fails.
 
 The documents in this section assume that you understand the Kubernetes concepts of persistent volumes, persistent volume claims, and storage classes. For more information, refer to the section on [how storage works.](../how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/manage-persistent-storage/about-persistent-storage.md)

--- a/docs/pages-for-subheaders/enable-experimental-features.md
+++ b/docs/pages-for-subheaders/enable-experimental-features.md
@@ -5,6 +5,7 @@ title: Enabling Experimental Features
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/enable-experimental-features"/>
 </head>
+
 Rancher includes some features that are experimental and disabled by default. You might want to enable these features, for example, if you decide that the benefits of using an [unsupported storage type](../how-to-guides/advanced-user-guides/enable-experimental-features/unsupported-storage-drivers.md) outweighs the risk of using an untested feature. Feature flags were introduced to allow you to try these features that are not enabled by default.
 
 The features can be enabled in three ways:

--- a/docs/pages-for-subheaders/vsphere.md
+++ b/docs/pages-for-subheaders/vsphere.md
@@ -6,6 +6,7 @@ description: Use Rancher to create a vSphere cluster. It may consist of groups o
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/vsphere"/>
 </head>
+
 import YouTube from '@site/src/components/YouTube'
 
 By using Rancher with vSphere, you can bring cloud operations on-premises.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/layer-4-and-layer-7-load-balancing.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/layer-4-and-layer-7-load-balancing.md
@@ -6,6 +6,7 @@ description: "Kubernetes supports load balancing in two ways: Layer-4 Load Balan
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/layer-4-and-layer-7-load-balancing"/>
 </head>
+
 Kubernetes supports load balancing in two ways: Layer-4 Load Balancing and Layer-7 Load Balancing.
 
 ## Layer-4 Load Balancer

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
@@ -6,6 +6,7 @@ description: Learn about the Docker registry and Kubernetes registry, their use 
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries"/>
 </head>
+
 Registries are Kubernetes secrets containing credentials used to authenticate with [private Docker registries](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 
 The word "registry" can mean two things, depending on whether it is used to refer to a Docker or Kubernetes registry:

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/layer-4-and-layer-7-load-balancing.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/layer-4-and-layer-7-load-balancing.md
@@ -6,6 +6,7 @@ description: "Kubernetes supports load balancing in two ways: Layer-4 Load Balan
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/layer-4-and-layer-7-load-balancing"/>
 </head>
+
 Kubernetes supports load balancing in two ways: Layer-4 Load Balancing and Layer-7 Load Balancing.
 
 ## Layer-4 Load Balancer

--- a/versioned_docs/version-2.6/pages-for-subheaders/create-kubernetes-persistent-storage.md
+++ b/versioned_docs/version-2.6/pages-for-subheaders/create-kubernetes-persistent-storage.md
@@ -6,6 +6,7 @@ description: "Learn about the two ways with which you can create persistent stor
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/create-kubernetes-persistent-storage"/>
 </head>
+
 When deploying an application that needs to retain data, you'll need to create persistent storage. Persistent storage allows you to store application data external from the pod running your application. This storage practice allows you to maintain application data, even if the application's pod fails.
 
 The documents in this section assume that you understand the Kubernetes concepts of persistent volumes, persistent volume claims, and storage classes. For more information, refer to the section on [how storage works.](../how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/manage-persistent-storage/about-persistent-storage.md)

--- a/versioned_docs/version-2.6/pages-for-subheaders/enable-experimental-features.md
+++ b/versioned_docs/version-2.6/pages-for-subheaders/enable-experimental-features.md
@@ -5,6 +5,7 @@ title: Enabling Experimental Features
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/enable-experimental-features"/>
 </head>
+
 Rancher includes some features that are experimental and disabled by default. You might want to enable these features, for example, if you decide that the benefits of using an [unsupported storage type](../how-to-guides/advanced-user-guides/enable-experimental-features/unsupported-storage-drivers.md) outweighs the risk of using an untested feature. Feature flags were introduced to allow you to try these features that are not enabled by default.
 
 The features can be enabled in three ways:

--- a/versioned_docs/version-2.6/pages-for-subheaders/vsphere.md
+++ b/versioned_docs/version-2.6/pages-for-subheaders/vsphere.md
@@ -6,6 +6,7 @@ description: Use Rancher to create a vSphere cluster. It may consist of groups o
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/vsphere"/>
 </head>
+
 import YouTube from '@site/src/components/YouTube'
 
 By using Rancher with vSphere, you can bring cloud operations on-premises.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
@@ -6,6 +6,7 @@ description: Learn about the container image registry and Kubernetes registry, t
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries"/>
 </head>
+
 Registries are Kubernetes secrets containing credentials used to authenticate with [private container registries](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 
 The word "registry" can mean two things, depending on whether it is used to refer to a container or Kubernetes registry:

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/layer-4-and-layer-7-load-balancing.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/layer-4-and-layer-7-load-balancing.md
@@ -6,6 +6,7 @@ description: "Kubernetes supports load balancing in two ways: Layer-4 Load Balan
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/layer-4-and-layer-7-load-balancing"/>
 </head>
+
 Kubernetes supports load balancing in two ways: Layer-4 Load Balancing and Layer-7 Load Balancing.
 
 ## Layer-4 Load Balancer

--- a/versioned_docs/version-2.7/pages-for-subheaders/create-kubernetes-persistent-storage.md
+++ b/versioned_docs/version-2.7/pages-for-subheaders/create-kubernetes-persistent-storage.md
@@ -6,6 +6,7 @@ description: "Learn about the two ways with which you can create persistent stor
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/create-kubernetes-persistent-storage"/>
 </head>
+
 When deploying an application that needs to retain data, you'll need to create persistent storage. Persistent storage allows you to store application data external from the pod running your application. This storage practice allows you to maintain application data, even if the application's pod fails.
 
 The documents in this section assume that you understand the Kubernetes concepts of persistent volumes, persistent volume claims, and storage classes. For more information, refer to the section on [how storage works.](../how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/manage-persistent-storage/about-persistent-storage.md)

--- a/versioned_docs/version-2.7/pages-for-subheaders/enable-experimental-features.md
+++ b/versioned_docs/version-2.7/pages-for-subheaders/enable-experimental-features.md
@@ -5,6 +5,7 @@ title: Enabling Experimental Features
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/enable-experimental-features"/>
 </head>
+
 Rancher includes some features that are experimental and disabled by default. You might want to enable these features, for example, if you decide that the benefits of using an [unsupported storage type](../how-to-guides/advanced-user-guides/enable-experimental-features/unsupported-storage-drivers.md) outweighs the risk of using an untested feature. Feature flags were introduced to allow you to try these features that are not enabled by default.
 
 The features can be enabled in three ways:

--- a/versioned_docs/version-2.7/pages-for-subheaders/vsphere.md
+++ b/versioned_docs/version-2.7/pages-for-subheaders/vsphere.md
@@ -6,6 +6,7 @@ description: Use Rancher to create a vSphere cluster. It may consist of groups o
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/vsphere"/>
 </head>
+
 import YouTube from '@site/src/components/YouTube'
 
 By using Rancher with vSphere, you can bring cloud operations on-premises.


### PR DESCRIPTION
Resolves #801

Adding canonical link tags in some cases broke import statements at the start of files. I also repaired some other cases where the tag was directly above text. This didn't seem to break formatting but it was not good style.