### PR TITLE
#795 - updated contribute-to-rancher page

### DIFF
--- a/docs/contribute-to-rancher.md
+++ b/docs/contribute-to-rancher.md
@@ -2,7 +2,7 @@
 title: Contributing to Rancher
 ---
 
-This section explains the repositories used for Rancher, how to build the repositories, and what information to include when you file an issue.
+Learn about the repositories used for Rancher and Rancher docs, how to build Rancher repositories, and what information to include when you file an issue.
 
 For more detailed information on how to contribute to the development of Rancher projects, refer to the [Rancher Developer Wiki](https://github.com/rancher/rancher/wiki). The wiki has resources on many topics, including the following:
 
@@ -14,7 +14,15 @@ For more detailed information on how to contribute to the development of Rancher
 
 On the Rancher Users Slack, the channel for developers is **#developer**.
 
-## Repositories
+## Rancher Docs
+
+If you have suggestions for the documentation on this website, [open](https://github.com/rancher/rancher-docs/issues/new/choose) an issue in the main [Rancher docs](https://github.com/rancher/rancher-docs) repository. This repo contains documentation for Rancher v2.0 and later. 
+
+See the [Rancher docs README](https://github.com/rancher/rancher-docs#readme) for more details on contributing to and building the Rancher v2.x docs repo.
+
+For documentation describing Rancher v1.6 and earlier, see the [Rancher 1.x docs](https://github.com/rancher/rancher.github.io) repo, which contains source files for https://rancher.com/docs/rancher/v1.6/en/. 
+
+## Rancher Repositories
 
 All of repositories are located within our main GitHub organization. There are many repositories used for Rancher, but we'll provide descriptions of some of the main ones used in Rancher.
 
@@ -38,19 +46,19 @@ To see all libraries/projects used in Rancher, see the [`go.mod` file](https://g
 ![Rancher diagram](/img/ranchercomponentsdiagram-2.6.svg)<br/>
 <sup>Rancher components used for provisioning/managing Kubernetes clusters.</sup>
 
-## Building
+### Building Rancher Repositories
 
 Every repository should have a Makefile and can be built using the `make` command. The `make` targets are based on the scripts in the `/scripts` directory in the repository, and each target will use [Dapper](https://github.com/rancher/dapper) to run the target in an isolated environment. The `Dockerfile.dapper` will be used for this process, and includes all the necessary build tooling needed.
 
 The default target is `ci`, and will run `./scripts/validate`, `./scripts/build`, `./scripts/test` and `./scripts/package`. The resulting binaries of the build will be in `./build/bin` and are usually also packaged in a Docker image.
 
-## Bugs, Issues or Questions
+### Rancher Bugs, Issues or Questions
 
 If you find any bugs or are having any trouble, please search the [reported issue](https://github.com/rancher/rancher/issues) as someone may have experienced the same issue or we are actively working on a solution.
 
 If you can't find anything related to your issue, contact us by [filing an issue](https://github.com/rancher/rancher/issues/new). Though we have many repositories related to Rancher, we want the bugs filed in the Rancher repository so we won't miss them! If you want to ask a question or ask fellow users about an use case, we suggest creating a post on the [Rancher Forums](https://forums.rancher.com).
 
-### Checklist for Filing Issues
+#### Checklist for Filing Issues
 
 Please follow this checklist when filing an issue which will helps us investigate and fix the issue. More info means more data we can use to determine what is causing the issue or what might be related to the issue.
 
@@ -126,11 +134,3 @@ Please remove any sensitive data as it will be publicly viewable.
     - Docker daemon logging (these might not all exist, depending on operating system)
         - `/var/log/docker.log`
 - **Metrics:** If you are experiencing performance issues, please provide as much of data (files or screenshots) of metrics which can help determining what is going on. If you have an issue related to a machine, it helps to supply output of `top`, `free -m`, `df` which shows processes/memory/disk usage.
-
-## Docs
-
-If you have any updates to our documentation, please make any pull request to our docs repo.
-
-- [Rancher 2.x Docs repository](https://github.com/rancher/docs): This repo is where all the docs for Rancher 2.x are located. They are located in the `content` folder in the repo.
-
-- [Rancher 1.x Docs repository](https://github.com/rancher/rancher.github.io): This repo is where all the docs for Rancher 1.x are located. They are located in the `rancher` folder in the repo.


### PR DESCRIPTION
Partially addresses #795. 

This moves info about contributing to the docs up to the top of the page, adds a link to the current 2.x docs repo, and updates the headings to be more specific (for the sake of Algolia search). It also slightly alters the intro sentence from the "This section..." language we want to move away from.

I kept the info and link to the 1.x repo, but it's arguable that it should be removed, since we no longer regularly check it or update it.