### PR TITLE
#420 - canonicized cis-scan-guides

### DIFF
--- a/docs/how-to-guides/advanced-user-guides/cis-scan-guides/configure-alerts-for-periodic-scan-on-a-schedule.md
+++ b/docs/how-to-guides/advanced-user-guides/cis-scan-guides/configure-alerts-for-periodic-scan-on-a-schedule.md
@@ -2,6 +2,10 @@
 title: Configure Alerts for Periodic Scan on a Schedule
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/configure-alerts-for-periodic-scan-on-a-schedule"/>
+</head>
+
 It is possible to run a ClusterScan on a schedule.
 
 A scheduled scan can also specify if you should receive alerts when the scan completes.

--- a/docs/how-to-guides/advanced-user-guides/cis-scan-guides/create-a-custom-benchmark-version-to-run.md
+++ b/docs/how-to-guides/advanced-user-guides/cis-scan-guides/create-a-custom-benchmark-version-to-run.md
@@ -2,6 +2,10 @@
 title: Create a Custom Benchmark Version for Running a Cluster Scan
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/create-a-custom-benchmark-version-to-run"/>
+</head>
+
 There could be some Kubernetes cluster setups that require custom configurations of the Benchmark tests. For example, the path to the Kubernetes config files or certs might be different than the standard location where the upstream CIS Benchmarks look for them.
 
 It is now possible to create a custom Benchmark Version for running a cluster scan using the `rancher-cis-benchmark` application.

--- a/docs/how-to-guides/advanced-user-guides/cis-scan-guides/enable-alerting-for-rancher-cis-benchmark.md
+++ b/docs/how-to-guides/advanced-user-guides/cis-scan-guides/enable-alerting-for-rancher-cis-benchmark.md
@@ -2,6 +2,10 @@
 title: Enable Alerting for Rancher CIS Benchmark
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/enable-alerting-for-rancher-cis-benchmark"/>
+</head>
+
 Alerts can be configured to be sent out for a scan that runs on a schedule.
 
 :::note Prerequisite:

--- a/docs/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark.md
+++ b/docs/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark.md
@@ -2,6 +2,10 @@
 title: Install Rancher CIS Benchmark
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark"/>
+</head>
+
 1. In the upper left corner, click **☰ > Cluster Management**.
 1. On the **Clusters** page, go to the cluster where you want to install CIS Benchmark and click **Explore**.
 1. In the left navigation bar, click **Apps > Charts**.

--- a/docs/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan-periodically-on-a-schedule.md
+++ b/docs/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan-periodically-on-a-schedule.md
@@ -2,6 +2,10 @@
 title: Run a Scan Periodically on a Schedule
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan-periodically-on-a-schedule"/>
+</head>
+
 To run a ClusterScan on a schedule,
 
 1. In the upper left corner, click **☰ > Cluster Management**.

--- a/docs/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan.md
+++ b/docs/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan.md
@@ -2,6 +2,10 @@
 title: Run a Scan
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan"/>
+</head>
+
 When a ClusterScan custom resource is created, it launches a new CIS scan on the cluster for the chosen ClusterScanProfile.
 
 :::note

--- a/docs/how-to-guides/advanced-user-guides/cis-scan-guides/skip-tests.md
+++ b/docs/how-to-guides/advanced-user-guides/cis-scan-guides/skip-tests.md
@@ -2,6 +2,10 @@
 title: Skip Tests
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/skip-tests"/>
+</head>
+
 CIS scans can be run using test profiles with user-defined skips.
 
 To skip tests, you will create a custom CIS scan profile. A profile contains the configuration for the CIS scan, which includes the benchmark versions to use and any specific tests to skip in that benchmark.

--- a/docs/how-to-guides/advanced-user-guides/cis-scan-guides/uninstall-rancher-cis-benchmark.md
+++ b/docs/how-to-guides/advanced-user-guides/cis-scan-guides/uninstall-rancher-cis-benchmark.md
@@ -2,6 +2,10 @@
 title: Uninstall Rancher CIS Benchmark
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/uninstall-rancher-cis-benchmark"/>
+</head>
+
 1. From the **Cluster Dashboard,** go to the left navigation bar and click **Apps > Installed Apps**.
 1. Go to the `cis-operator-system` namespace and check the boxes next to `rancher-cis-benchmark-crd` and `rancher-cis-benchmark`.
 1. Click **Delete** and confirm **Delete**.

--- a/docs/how-to-guides/advanced-user-guides/cis-scan-guides/view-reports.md
+++ b/docs/how-to-guides/advanced-user-guides/cis-scan-guides/view-reports.md
@@ -2,6 +2,10 @@
 title: View Reports
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/view-reports"/>
+</head>
+
 To view the generated CIS scan reports,
 
 1. In the upper left corner, click **☰ > Cluster Management**.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/cis-scan-guides/configure-alerts-for-periodic-scan-on-a-schedule.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/cis-scan-guides/configure-alerts-for-periodic-scan-on-a-schedule.md
@@ -2,6 +2,10 @@
 title: Configure Alerts for Periodic Scan on a Schedule
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/configure-alerts-for-periodic-scan-on-a-schedule"/>
+</head>
+
 Rancher provides a set of alerts for cluster scans. which are not configured to have notifiers by default:
 
 - A manual cluster scan was completed

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan-periodically-on-a-schedule.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan-periodically-on-a-schedule.md
@@ -2,6 +2,10 @@
 title: Run a Scan Periodically on a Schedule
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan-periodically-on-a-schedule"/>
+</head>
+
 Recurring scans can be scheduled to run on any RKE Kubernetes cluster.
 
 To enable recurring scans, edit the advanced options in the cluster configuration during cluster creation or after the cluster has been created.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan.md
@@ -2,6 +2,10 @@
 title: Run a Scan
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan"/>
+</head>
+
 ## Run a Scan
 
 1. From the cluster view in Rancher, click **Tools > CIS Scans.**

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/cis-scan-guides/skip-tests.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/cis-scan-guides/skip-tests.md
@@ -2,6 +2,10 @@
 title: Skip Tests
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/skip-tests"/>
+</head>
+
 You can define a set of tests that will be skipped by the CIS scan when the next report is generated.
 
 These tests will be skipped for subsequent CIS scans, including both manually triggered and scheduled scans, and the tests will be skipped with any profile.

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/configure-alerts-for-periodic-scan-on-a-schedule.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/configure-alerts-for-periodic-scan-on-a-schedule.md
@@ -2,6 +2,10 @@
 title: Configure Alerts for Periodic Scan on a Schedule
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/configure-alerts-for-periodic-scan-on-a-schedule"/>
+</head>
+
 It is possible to run a ClusterScan on a schedule.
 
 A scheduled scan can also specify if you should receive alerts when the scan completes.

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/create-a-custom-benchmark-version-to-run.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/create-a-custom-benchmark-version-to-run.md
@@ -1,6 +1,10 @@
 ---
 title: Create a Custom Benchmark Version for Running a Cluster Scan
---- 
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/create-a-custom-benchmark-version-to-run"/>
+</head>
 
 There could be some Kubernetes cluster setups that require custom configurations of the Benchmark tests. For example, the path to the Kubernetes config files or certs might be different than the standard location where the upstream CIS Benchmarks look for them.
 

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/enable-alerting-for-rancher-cis-benchmark.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/enable-alerting-for-rancher-cis-benchmark.md
@@ -2,6 +2,10 @@
 title: Enable Alerting for Rancher CIS Benchmark
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/enable-alerting-for-rancher-cis-benchmark"/>
+</head>
+
 Alerts can be configured to be sent out for a scan that runs on a schedule.
 
 :::note Prerequisite: 

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark.md
@@ -2,6 +2,10 @@
 title: Install Rancher CIS Benchmark
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark"/>
+</head>
+
 1. In the upper left corner, click **☰ > Cluster Management**.
 1. On the **Clusters** page, go to the cluster where you want to install CIS Benchmark and click **Explore**.
 1. In the left navigation bar, click **Apps & Marketplace > Charts**.

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan-periodically-on-a-schedule.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan-periodically-on-a-schedule.md
@@ -2,6 +2,10 @@
 title: Run a Scan Periodically on a Schedule
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan-periodically-on-a-schedule"/>
+</head>
+
 To run a ClusterScan on a schedule,
 
 1. In the upper left corner, click **☰ > Cluster Management**.

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan.md
@@ -2,6 +2,10 @@
 title: Run a Scan
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan"/>
+</head>
+
 When a ClusterScan custom resource is created, it launches a new CIS scan on the cluster for the chosen ClusterScanProfile.
 
 :::note

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/skip-tests.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/skip-tests.md
@@ -2,6 +2,10 @@
 title: Skip Tests
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/skip-tests"/>
+</head>
+
 CIS scans can be run using test profiles with user-defined skips.
 
 To skip tests, you will create a custom CIS scan profile. A profile contains the configuration for the CIS scan, which includes the benchmark versions to use and any specific tests to skip in that benchmark.

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/uninstall-rancher-cis-benchmark.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/uninstall-rancher-cis-benchmark.md
@@ -2,6 +2,10 @@
 title: Uninstall Rancher CIS Benchmark
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/uninstall-rancher-cis-benchmark"/>
+</head>
+
 1. From the **Cluster Dashboard,** go to the left navigation bar and click **Apps & Marketplace > Installed Apps**.
 1. Go to the `cis-operator-system` namespace and check the boxes next to `rancher-cis-benchmark-crd` and `rancher-cis-benchmark`.
 1. Click **Delete** and confirm **Delete**.

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/view-reports.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/view-reports.md
@@ -2,6 +2,10 @@
 title: View Reports
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/view-reports"/>
+</head>
+
 To view the generated CIS scan reports,
 
 1. In the upper left corner, click **☰ > Cluster Management**.

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/configure-alerts-for-periodic-scan-on-a-schedule.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/configure-alerts-for-periodic-scan-on-a-schedule.md
@@ -2,6 +2,10 @@
 title: Configure Alerts for Periodic Scan on a Schedule
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/configure-alerts-for-periodic-scan-on-a-schedule"/>
+</head>
+
 It is possible to run a ClusterScan on a schedule.
 
 A scheduled scan can also specify if you should receive alerts when the scan completes.

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/create-a-custom-benchmark-version-to-run.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/create-a-custom-benchmark-version-to-run.md
@@ -2,6 +2,10 @@
 title: Create a Custom Benchmark Version for Running a Cluster Scan
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/create-a-custom-benchmark-version-to-run"/>
+</head>
+
 There could be some Kubernetes cluster setups that require custom configurations of the Benchmark tests. For example, the path to the Kubernetes config files or certs might be different than the standard location where the upstream CIS Benchmarks look for them.
 
 It is now possible to create a custom Benchmark Version for running a cluster scan using the `rancher-cis-benchmark` application.

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/enable-alerting-for-rancher-cis-benchmark.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/enable-alerting-for-rancher-cis-benchmark.md
@@ -2,6 +2,10 @@
 title: Enable Alerting for Rancher CIS Benchmark
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/enable-alerting-for-rancher-cis-benchmark"/>
+</head>
+
 Alerts can be configured to be sent out for a scan that runs on a schedule.
 
 :::note Prerequisite:

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark.md
@@ -2,6 +2,10 @@
 title: Install Rancher CIS Benchmark
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark"/>
+</head>
+
 <Tabs>
 <TabItem value="Rancher v2.6.5+">
 

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan-periodically-on-a-schedule.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan-periodically-on-a-schedule.md
@@ -2,6 +2,10 @@
 title: Run a Scan Periodically on a Schedule
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan-periodically-on-a-schedule"/>
+</head>
+
 To run a ClusterScan on a schedule,
 
 1. In the upper left corner, click **☰ > Cluster Management**.

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan.md
@@ -2,6 +2,10 @@
 title: Run a Scan
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan"/>
+</head>
+
 When a ClusterScan custom resource is created, it launches a new CIS scan on the cluster for the chosen ClusterScanProfile.
 
 :::note

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/skip-tests.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/skip-tests.md
@@ -2,6 +2,10 @@
 title: Skip Tests
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/skip-tests"/>
+</head>
+
 CIS scans can be run using test profiles with user-defined skips.
 
 To skip tests, you will create a custom CIS scan profile. A profile contains the configuration for the CIS scan, which includes the benchmark versions to use and any specific tests to skip in that benchmark.

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/uninstall-rancher-cis-benchmark.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/uninstall-rancher-cis-benchmark.md
@@ -2,6 +2,10 @@
 title: Uninstall Rancher CIS Benchmark
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/uninstall-rancher-cis-benchmark"/>
+</head>
+
 <Tabs>
 <TabItem value="Rancher v2.6.5+">
 

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/view-reports.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/view-reports.md
@@ -2,6 +2,10 @@
 title: View Reports
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/view-reports"/>
+</head>
+
 To view the generated CIS scan reports,
 
 1. In the upper left corner, click **☰ > Cluster Management**.

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/configure-alerts-for-periodic-scan-on-a-schedule.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/configure-alerts-for-periodic-scan-on-a-schedule.md
@@ -2,6 +2,10 @@
 title: Configure Alerts for Periodic Scan on a Schedule
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/configure-alerts-for-periodic-scan-on-a-schedule"/>
+</head>
+
 It is possible to run a ClusterScan on a schedule.
 
 A scheduled scan can also specify if you should receive alerts when the scan completes.

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/create-a-custom-benchmark-version-to-run.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/create-a-custom-benchmark-version-to-run.md
@@ -2,6 +2,10 @@
 title: Create a Custom Benchmark Version for Running a Cluster Scan
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/create-a-custom-benchmark-version-to-run"/>
+</head>
+
 There could be some Kubernetes cluster setups that require custom configurations of the Benchmark tests. For example, the path to the Kubernetes config files or certs might be different than the standard location where the upstream CIS Benchmarks look for them.
 
 It is now possible to create a custom Benchmark Version for running a cluster scan using the `rancher-cis-benchmark` application.

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/enable-alerting-for-rancher-cis-benchmark.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/enable-alerting-for-rancher-cis-benchmark.md
@@ -2,6 +2,10 @@
 title: Enable Alerting for Rancher CIS Benchmark
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/enable-alerting-for-rancher-cis-benchmark"/>
+</head>
+
 Alerts can be configured to be sent out for a scan that runs on a schedule.
 
 :::note Prerequisite:

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark.md
@@ -2,6 +2,10 @@
 title: Install Rancher CIS Benchmark
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/install-rancher-cis-benchmark"/>
+</head>
+
 1. In the upper left corner, click **☰ > Cluster Management**.
 1. On the **Clusters** page, go to the cluster where you want to install CIS Benchmark and click **Explore**.
 1. In the left navigation bar, click **Apps > Charts**.

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan-periodically-on-a-schedule.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan-periodically-on-a-schedule.md
@@ -2,6 +2,10 @@
 title: Run a Scan Periodically on a Schedule
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan-periodically-on-a-schedule"/>
+</head>
+
 To run a ClusterScan on a schedule,
 
 1. In the upper left corner, click **☰ > Cluster Management**.

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan.md
@@ -2,6 +2,10 @@
 title: Run a Scan
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/run-a-scan"/>
+</head>
+
 When a ClusterScan custom resource is created, it launches a new CIS scan on the cluster for the chosen ClusterScanProfile.
 
 :::note

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/skip-tests.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/skip-tests.md
@@ -2,6 +2,10 @@
 title: Skip Tests
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/skip-tests"/>
+</head>
+
 CIS scans can be run using test profiles with user-defined skips.
 
 To skip tests, you will create a custom CIS scan profile. A profile contains the configuration for the CIS scan, which includes the benchmark versions to use and any specific tests to skip in that benchmark.

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/uninstall-rancher-cis-benchmark.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/uninstall-rancher-cis-benchmark.md
@@ -2,6 +2,10 @@
 title: Uninstall Rancher CIS Benchmark
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/uninstall-rancher-cis-benchmark"/>
+</head>
+
 1. From the **Cluster Dashboard,** go to the left navigation bar and click **Apps > Installed Apps**.
 1. Go to the `cis-operator-system` namespace and check the boxes next to `rancher-cis-benchmark-crd` and `rancher-cis-benchmark`.
 1. Click **Delete** and confirm **Delete**.

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/view-reports.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/view-reports.md
@@ -2,6 +2,10 @@
 title: View Reports
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides/view-reports"/>
+</head>
+
 To view the generated CIS scan reports,
 
 1. In the upper left corner, click **☰ > Cluster Management**.


### PR DESCRIPTION
This is the last advanced user guides directory. After we do the remaining files in the top level of advanced-user-guides we'll have the last directory mentioned in the original #420 comment thread cleared (see https://github.com/rancher/rancher-docs/issues/420#issuecomment-1452454114). 