### PR TITLE
remove proxy_pass directive from server block (http) in nginx example config

### DIFF
--- a/docs/how-to-guides/new-user-guides/infrastructure-setup/nginx-load-balancer.md
+++ b/docs/how-to-guides/new-user-guides/infrastructure-setup/nginx-load-balancer.md
@@ -72,7 +72,6 @@ After installing NGINX, you need to update the NGINX configuration file, `nginx.
         }
         server {
             listen 443 ssl;
-            proxy_pass rancher_servers_https;
             ssl_certificate /path/to/tls.crt;
             ssl_certificate_key /path/to/key.key;
             location / {

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/infrastructure-setup/nginx-load-balancer.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/infrastructure-setup/nginx-load-balancer.md
@@ -72,7 +72,6 @@ After installing NGINX, you need to update the NGINX configuration file, `nginx.
         }
         server {
             listen 443 ssl;
-            proxy_pass rancher_servers_https;
             ssl_certificate /path/to/tls.crt;
             ssl_certificate_key /path/to/key.key;
             location / {

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/infrastructure-setup/nginx-load-balancer.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/infrastructure-setup/nginx-load-balancer.md
@@ -72,7 +72,6 @@ After installing NGINX, you need to update the NGINX configuration file, `nginx.
         }
         server {
             listen 443 ssl;
-            proxy_pass rancher_servers_https;
             ssl_certificate /path/to/tls.crt;
             ssl_certificate_key /path/to/key.key;
             location / {


### PR DESCRIPTION
The directive proxy_pass is not allowed in a server block with http.
Removing the proxy_pass directive at this location makes the sample useable.

See http module docs: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass
