### PR TITLE
#790 highlight alert about folders for s3 backup config

### DIFF
--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher-launched-kubernetes-clusters.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher-launched-kubernetes-clusters.md
@@ -260,11 +260,19 @@ By default, the `local` backup target is selected. The benefits of this option i
 
 ### S3 Backup Target
 
-The `S3` backup target allows users to configure a S3 compatible backend to store the snapshots. The primary benefit of this option is that if the cluster loses all the etcd nodes, the cluster can still be restored as the snapshots are stored externally. Rancher recommends external targets like `S3` backup, however its configuration requirements do require additional effort that should be considered. Additionally, it is recommended to ensure that every cluster has a unique bucket and/or folder, as Rancher will populate snapshot information for any available snapshot that is listed in the S3 bucket/folder that is configured for the cluster.
+We recommend that you use the `S3` backup target. It lets you store snapshots externally, on an S3 compatible backend. Since the snapshots aren't stored locally, you can still restore the cluster even if you lose all etcd nodes. 
+
+Although the `S3` target offers advantages over local backup, it does require extra configuration. 
+
+:::Caution
+
+If you use an S3 backup target, make sure that every cluster has its own bucket or folder. Rancher populates snapshot information from any available snapshot listed in the S3 bucket or folder configured for that cluster.
+
+:::
 
 | Option | Description | Required|
 |---|---|---|
-|S3 Bucket Name| S3 bucket name where backups will be stored| *|
+|S3 Bucket Name| Name of S3 bucket to store backups| *|
 |S3 Region|S3 region for the backup bucket| |
 |S3 Region Endpoint|S3 regions endpoint for the backup bucket|* |
 |S3 Access Key|S3 access key with permission to access the backup bucket|*|

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher-launched-kubernetes-clusters.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher-launched-kubernetes-clusters.md
@@ -264,7 +264,7 @@ We recommend that you use the `S3` backup target. It lets you store snapshots ex
 
 Although the `S3` target offers advantages over local backup, it does require extra configuration. 
 
-:::Caution
+:::caution
 
 If you use an S3 backup target, make sure that every cluster has its own bucket or folder. Rancher populates snapshot information from any available snapshot listed in the S3 bucket or folder configured for that cluster.
 

--- a/docs/reference-guides/backup-restore-configuration/backup-configuration.md
+++ b/docs/reference-guides/backup-restore-configuration/backup-configuration.md
@@ -68,7 +68,7 @@ Selecting the first option stores this backup in the storage location configured
 
 ### S3
 
-:::Caution
+:::caution
 
 If you use an S3 backup target, make sure that every cluster has its own bucket or folder. Rancher populates snapshot information from any available snapshot listed in the S3 bucket or folder configured for that cluster.
 

--- a/docs/reference-guides/backup-restore-configuration/backup-configuration.md
+++ b/docs/reference-guides/backup-restore-configuration/backup-configuration.md
@@ -68,6 +68,12 @@ Selecting the first option stores this backup in the storage location configured
 
 ### S3
 
+:::Caution
+
+If you use an S3 backup target, make sure that every cluster has its own bucket or folder. Rancher populates snapshot information from any available snapshot listed in the S3 bucket or folder configured for that cluster.
+
+:::
+
 The S3 storage location contains the following configuration fields:
 
 1. **Credential Secret** (optional): If you need to use the AWS Access keys Secret keys to access s3 bucket, create a secret with your credentials with keys and the directives `accessKey` and `secretKey`. It can be in any namespace. An example secret is [here.](#example-credentialsecret) This directive is unnecessary if the nodes running your operator are in EC2 and set up with IAM permissions that allow them to access S3, as described in [this section.](#iam-permissions-for-ec2-nodes-to-access-s3) The Credential Secret dropdown lists the secrets in all namespaces.


### PR DESCRIPTION
Fixes #790 

> On [Backing up a cluster page](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher-launched-kubernetes-clusters#how-snapshots-work) we have a session called S3 Backup Target Session that contains the following information:
>
>> ... Additionally, it is recommended to ensure that every cluster has a unique bucket and/or folder, as Rancher will populate snapshot information for any available snapshot that is listed in the S3 bucket/folder that is configured for the cluster.
>
> That information is quite relevant and should be highlighted.
>
> It probably also should be described on the [Backup Configuration page](https://ranchermanager.docs.rancher.com/reference-guides/backup-restore-configuration/backup-configuration) under the Storage Location - S3.
> 
> We had some issues on rancher/rancher that could be prevented with that information.

Also revised language to remove passive voice and make sentences more clear/less verbose