### PR TITLE
#793 RKE2 cluster templates

### DIFF
--- a/docs/how-to-guides/new-user-guides/manage-clusters/manage-cluster-templates.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/manage-cluster-templates.md
@@ -32,8 +32,8 @@ In this section, you'll learn how to add the cluster template to the `local` clu
 
 :::note Prerequisites:
 
-- You will need permission to install Helm charts on the `local` Kubernetes cluster that Rancher is installed on.
-- In order for the chart to appear in the form for creating new clusters, the chart must have the annotation `catalog.cattle.io/type: cluster-template`.
+- You will need permission to install Helm charts on the `local` Rancher cluster.
+- To make the chart viewable in the cluster creation form, both the chart and the index.yaml file must have the annotation, `catalog.cattle.io/type: cluster-template`.
 
 :::
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/manage-cluster-templates.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/manage-cluster-templates.md
@@ -32,8 +32,8 @@ In this section, you'll learn how to add the cluster template to the `local` clu
 
 :::note Prerequisites:
 
-- You will need permission to install Helm charts on the `local` Kubernetes cluster that Rancher is installed on.
-- In order for the chart to appear in the form for creating new clusters, the chart must have the annotation `catalog.cattle.io/type: cluster-template`.
+- You will need permission to install Helm charts on the `local` Rancher cluster.
+- To make the chart viewable in the cluster creation form, both the chart and the index.yaml file must have the annotation, `catalog.cattle.io/type: cluster-template`.
 
 :::
 

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/manage-clusters/manage-cluster-templates.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/manage-clusters/manage-cluster-templates.md
@@ -32,8 +32,8 @@ In this section, you'll learn how to add the cluster template to the `local` clu
 
 :::note Prerequisites:
 
-- You will need permission to install Helm charts on the `local` Kubernetes cluster that Rancher is installed on.
-- In order for the chart to appear in the form for creating new clusters, the chart must have the annotation `catalog.cattle.io/type: cluster-template`.
+- You will need permission to install Helm charts on the `local` Rancher cluster.
+- To make the chart viewable in the cluster creation form, both the chart and the index.yaml file must have the annotation, `catalog.cattle.io/type: cluster-template`.
 
 :::
 


### PR DESCRIPTION
Fixes #793 

Had a question about versioning so opening as a draft

> Hi team,
> For RKE2 cluster templates our docs state: "In order for the chart to appear in the form for creating new clusters, the chart must have the annotation catalog.cattle.io/type: cluster-template." (https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/manage-cluster-templates#adding-a-cluster-template-to-rancher). However, if these annotations are present in the chart.yaml but not present in the index.yaml file, the templates don´t show up when you want create a cluster in Rancher UI.
Should it be clarified in our doc? I´m not an expert in helm charts, and this might be inherited or deduced per self.
>
> For testing purpose I used https://github.com/mrolmedo/cluster-template-examples. The main branch works, but test, where annotations are comment out, does not work.
Thanks for your help.