### PR TITLE
Add client roles mapping section

### DIFF
--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
@@ -35,6 +35,7 @@ If you have an existing configuration using the SAML protocol and want to switch
     `Name` | `Groups Mapper`
     `Mapper Type` | `Group Membership`
     `Token Claim Name` | `groups`
+    `Full group path` | `OFF`
     `Add to ID token` | `OFF`
     `Add to access token` | `OFF`
     `Add to user info` | `ON`
@@ -46,6 +47,7 @@ If you have an existing configuration using the SAML protocol and want to switch
     `Name` | `Client Audience`
     `Mapper Type` | `Audience`
     `Included Client Audience` | &lt;CLIENT_NAME>
+    `Add to ID token` | `OFF`
     `Add to access token` | `ON`
 
   - Create a new "Groups Path" with the settings below.
@@ -56,7 +58,17 @@ If you have an existing configuration using the SAML protocol and want to switch
     `Mapper Type` | `Group Membership`
     `Token Claim Name` | `full_group_path`
     `Full group path` | `ON`
+    `Add to ID token` | `ON`
+    `Add to access token` | `ON`
     `Add to user info` | `ON`
+
+- Add the following Role Mappings to all users or groups that need to query the Keycloak users
+  ```
+  Role Mappings > Client Roles >  realm-management  
+   + query-users
+   + query-groups
+   + view-users
+  ```
 
 ## Configuring Keycloak in Rancher
 

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
@@ -62,13 +62,10 @@ If you have an existing configuration using the SAML protocol and want to switch
     `Add to access token` | `ON`
     `Add to user info` | `ON`
 
-- Add the following Role Mappings to all users or groups that need to query the Keycloak users
-  ```
-  Role Mappings > Client Roles >  realm-management  
-   + query-users
-   + query-groups
-   + view-users
-  ```
+- Go to **Role Mappings > Client Roles >  realm-management** and add the following Role Mappings to all users or groups that need to query the Keycloak users.
+  - query-users
+  - query-groups
+  - view-users
 
 ## Configuring Keycloak in Rancher
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
@@ -31,6 +31,7 @@ description: 创建 Keycloak OpenID Connect (OIDC) 客户端并配置 Rancher �
       | `Name` | `Groups Mapper` |
       | `Mapper Type` | `Group Membership` |
       | `Token Claim Name` | `groups` |
+      | `Full group path` | `OFF` |
       | `Add to ID token` | `OFF` |
       | `Add to access token` | `OFF` |
       | `Add to user info` | `ON` |
@@ -42,6 +43,7 @@ description: 创建 Keycloak OpenID Connect (OIDC) 客户端并配置 Rancher �
       | `Name` | `Client Audience` |
       | `Mapper Type` | `Audience` |
       | `Included Client Audience` | &lt;CLIENT_NAME> |
+      | `Add to ID token` | `OFF` |
       | `Add to access token` | `ON` |
 
    - 使用以下设置创建一个新的 "Groups Path"：
@@ -52,8 +54,15 @@ description: 创建 Keycloak OpenID Connect (OIDC) 客户端并配置 Rancher �
       | `Mapper Type` | `Group Membership` |
       | `Token Claim Name` | `full_group_path` |
       | `Full group path` | `ON` |
+      | `Add to ID token` | `ON` |
+      | `Add to access token` | `ON` |
       | `Add to user info` | `ON` |
 
+- Go to **Role Mappings > Client Roles >  realm-management** and add the following Role Mappings to all users or groups that need to query the Keycloak users.
+  - query-users
+  - query-groups
+  - view-users
+  
 ## 在 Rancher 中配置 Keycloak
 
 1. 在 Rancher UI 中，单击 **☰ > 用户 & 认证**。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
@@ -31,6 +31,7 @@ description: 创建 Keycloak OpenID Connect (OIDC) 客户端并配置 Rancher �
       | `Name` | `Groups Mapper` |
       | `Mapper Type` | `Group Membership` |
       | `Token Claim Name` | `groups` |
+      | `Full group path` | `OFF` |
       | `Add to ID token` | `OFF` |
       | `Add to access token` | `OFF` |
       | `Add to user info` | `ON` |
@@ -42,6 +43,7 @@ description: 创建 Keycloak OpenID Connect (OIDC) 客户端并配置 Rancher �
       | `Name` | `Client Audience` |
       | `Mapper Type` | `Audience` |
       | `Included Client Audience` | &lt;CLIENT_NAME> |
+      | `Add to ID token` | `OFF` |
       | `Add to access token` | `ON` |
 
    - 使用以下设置创建一个新的 "Groups Path"：
@@ -52,8 +54,15 @@ description: 创建 Keycloak OpenID Connect (OIDC) 客户端并配置 Rancher �
       | `Mapper Type` | `Group Membership` |
       | `Token Claim Name` | `full_group_path` |
       | `Full group path` | `ON` |
+      | `Add to ID token` | `ON` |
+      | `Add to access token` | `ON` |
       | `Add to user info` | `ON` |
 
+- Go to **Role Mappings > Client Roles >  realm-management** and add the following Role Mappings to all users or groups that need to query the Keycloak users.
+  - query-users
+  - query-groups
+  - view-users
+  
 ## 在 Rancher 中配置 Keycloak
 
 1. 在 Rancher UI 中，单击 **☰ > 用户 & 认证**。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
@@ -31,6 +31,7 @@ description: 创建 Keycloak OpenID Connect (OIDC) 客户端并配置 Rancher �
       | `Name` | `Groups Mapper` |
       | `Mapper Type` | `Group Membership` |
       | `Token Claim Name` | `groups` |
+      | `Full group path` | `OFF` |
       | `Add to ID token` | `OFF` |
       | `Add to access token` | `OFF` |
       | `Add to user info` | `ON` |
@@ -42,6 +43,7 @@ description: 创建 Keycloak OpenID Connect (OIDC) 客户端并配置 Rancher �
       | `Name` | `Client Audience` |
       | `Mapper Type` | `Audience` |
       | `Included Client Audience` | &lt;CLIENT_NAME> |
+      | `Add to ID token` | `OFF` |
       | `Add to access token` | `ON` |
 
    - 使用以下设置创建一个新的 "Groups Path"：
@@ -52,8 +54,15 @@ description: 创建 Keycloak OpenID Connect (OIDC) 客户端并配置 Rancher �
       | `Mapper Type` | `Group Membership` |
       | `Token Claim Name` | `full_group_path` |
       | `Full group path` | `ON` |
+      | `Add to ID token` | `ON` |
+      | `Add to access token` | `ON` |
       | `Add to user info` | `ON` |
 
+- Go to **Role Mappings > Client Roles >  realm-management** and add the following Role Mappings to all users or groups that need to query the Keycloak users.
+  - query-users
+  - query-groups
+  - view-users
+  
 ## 在 Rancher 中配置 Keycloak
 
 1. 在 Rancher UI 中，单击 **☰ > 用户 & 认证**。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
@@ -31,6 +31,7 @@ description: 创建 Keycloak OpenID Connect (OIDC) 客户端并配置 Rancher �
       | `Name` | `Groups Mapper` |
       | `Mapper Type` | `Group Membership` |
       | `Token Claim Name` | `groups` |
+      | `Full group path` | `OFF` |
       | `Add to ID token` | `OFF` |
       | `Add to access token` | `OFF` |
       | `Add to user info` | `ON` |
@@ -42,6 +43,7 @@ description: 创建 Keycloak OpenID Connect (OIDC) 客户端并配置 Rancher �
       | `Name` | `Client Audience` |
       | `Mapper Type` | `Audience` |
       | `Included Client Audience` | &lt;CLIENT_NAME> |
+      | `Add to ID token` | `OFF` |
       | `Add to access token` | `ON` |
 
    - 使用以下设置创建一个新的 "Groups Path"：
@@ -52,8 +54,15 @@ description: 创建 Keycloak OpenID Connect (OIDC) 客户端并配置 Rancher �
       | `Mapper Type` | `Group Membership` |
       | `Token Claim Name` | `full_group_path` |
       | `Full group path` | `ON` |
+      | `Add to ID token` | `ON` |
+      | `Add to access token` | `ON` |
       | `Add to user info` | `ON` |
 
+- Go to **Role Mappings > Client Roles >  realm-management** and add the following Role Mappings to all users or groups that need to query the Keycloak users.
+  - query-users
+  - query-groups
+  - view-users
+  
 ## 在 Rancher 中配置 Keycloak
 
 1. 在 Rancher UI 中，单击 **☰ > 用户 & 认证**。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.9/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.9/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
@@ -31,6 +31,7 @@ description: 创建 Keycloak OpenID Connect (OIDC) 客户端并配置 Rancher �
       | `Name` | `Groups Mapper` |
       | `Mapper Type` | `Group Membership` |
       | `Token Claim Name` | `groups` |
+      | `Full group path` | `OFF` |
       | `Add to ID token` | `OFF` |
       | `Add to access token` | `OFF` |
       | `Add to user info` | `ON` |
@@ -42,6 +43,7 @@ description: 创建 Keycloak OpenID Connect (OIDC) 客户端并配置 Rancher �
       | `Name` | `Client Audience` |
       | `Mapper Type` | `Audience` |
       | `Included Client Audience` | &lt;CLIENT_NAME> |
+      | `Add to ID token` | `OFF` |
       | `Add to access token` | `ON` |
 
    - 使用以下设置创建一个新的 "Groups Path"：
@@ -52,8 +54,15 @@ description: 创建 Keycloak OpenID Connect (OIDC) 客户端并配置 Rancher �
       | `Mapper Type` | `Group Membership` |
       | `Token Claim Name` | `full_group_path` |
       | `Full group path` | `ON` |
+      | `Add to ID token` | `ON` |
+      | `Add to access token` | `ON` |
       | `Add to user info` | `ON` |
 
+- Go to **Role Mappings > Client Roles >  realm-management** and add the following Role Mappings to all users or groups that need to query the Keycloak users.
+  - query-users
+  - query-groups
+  - view-users
+  
 ## 在 Rancher 中配置 Keycloak
 
 1. 在 Rancher UI 中，单击 **☰ > 用户 & 认证**。

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
@@ -35,6 +35,7 @@ If you have an existing configuration using the SAML protocol and want to switch
     `Name` | `Groups Mapper`
     `Mapper Type` | `Group Membership`
     `Token Claim Name` | `groups`
+    `Full group path` | `OFF`
     `Add to ID token` | `OFF`
     `Add to access token` | `OFF`
     `Add to user info` | `ON`
@@ -46,6 +47,7 @@ If you have an existing configuration using the SAML protocol and want to switch
     `Name` | `Client Audience`
     `Mapper Type` | `Audience`
     `Included Client Audience` | &lt;CLIENT_NAME>
+    `Add to ID token` | `OFF`
     `Add to access token` | `ON`
 
   - Create a new "Groups Path" with the settings below.
@@ -56,8 +58,15 @@ If you have an existing configuration using the SAML protocol and want to switch
     `Mapper Type` | `Group Membership`
     `Token Claim Name` | `full_group_path`
     `Full group path` | `ON`
+    `Add to ID token` | `ON`
+    `Add to access token` | `ON`
     `Add to user info` | `ON`
 
+- Go to **Role Mappings > Client Roles >  realm-management** and add the following Role Mappings to all users or groups that need to query the Keycloak users.
+  - query-users
+  - query-groups
+  - view-users
+  
 ## Configuring Keycloak in Rancher
 
 1. In the Rancher UI, click **☰ > Users & Authentication**.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
@@ -35,6 +35,7 @@ If you have an existing configuration using the SAML protocol and want to switch
     `Name` | `Groups Mapper`
     `Mapper Type` | `Group Membership`
     `Token Claim Name` | `groups`
+    `Full group path` | `OFF`
     `Add to ID token` | `OFF`
     `Add to access token` | `OFF`
     `Add to user info` | `ON`
@@ -46,6 +47,7 @@ If you have an existing configuration using the SAML protocol and want to switch
     `Name` | `Client Audience`
     `Mapper Type` | `Audience`
     `Included Client Audience` | &lt;CLIENT_NAME>
+    `Add to ID token` | `OFF`
     `Add to access token` | `ON`
 
   - Create a new "Groups Path" with the settings below.
@@ -56,8 +58,15 @@ If you have an existing configuration using the SAML protocol and want to switch
     `Mapper Type` | `Group Membership`
     `Token Claim Name` | `full_group_path`
     `Full group path` | `ON`
+    `Add to ID token` | `ON`
+    `Add to access token` | `ON`
     `Add to user info` | `ON`
 
+- Go to **Role Mappings > Client Roles >  realm-management** and add the following Role Mappings to all users or groups that need to query the Keycloak users.
+  - query-users
+  - query-groups
+  - view-users
+  
 ## Configuring Keycloak in Rancher
 
 1. In the Rancher UI, click **☰ > Users & Authentication**.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
@@ -35,6 +35,7 @@ If you have an existing configuration using the SAML protocol and want to switch
     `Name` | `Groups Mapper`
     `Mapper Type` | `Group Membership`
     `Token Claim Name` | `groups`
+    `Full group path` | `OFF`
     `Add to ID token` | `OFF`
     `Add to access token` | `OFF`
     `Add to user info` | `ON`
@@ -46,6 +47,7 @@ If you have an existing configuration using the SAML protocol and want to switch
     `Name` | `Client Audience`
     `Mapper Type` | `Audience`
     `Included Client Audience` | &lt;CLIENT_NAME>
+    `Add to ID token` | `OFF`
     `Add to access token` | `ON`
 
   - Create a new "Groups Path" with the settings below.
@@ -56,8 +58,15 @@ If you have an existing configuration using the SAML protocol and want to switch
     `Mapper Type` | `Group Membership`
     `Token Claim Name` | `full_group_path`
     `Full group path` | `ON`
+    `Add to ID token` | `ON`
+    `Add to access token` | `ON`
     `Add to user info` | `ON`
 
+- Go to **Role Mappings > Client Roles >  realm-management** and add the following Role Mappings to all users or groups that need to query the Keycloak users.
+  - query-users
+  - query-groups
+  - view-users
+  
 ## Configuring Keycloak in Rancher
 
 1. In the Rancher UI, click **☰ > Users & Authentication**.

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-oidc.md
@@ -35,6 +35,7 @@ If you have an existing configuration using the SAML protocol and want to switch
     `Name` | `Groups Mapper`
     `Mapper Type` | `Group Membership`
     `Token Claim Name` | `groups`
+    `Full group path` | `OFF`
     `Add to ID token` | `OFF`
     `Add to access token` | `OFF`
     `Add to user info` | `ON`
@@ -46,6 +47,7 @@ If you have an existing configuration using the SAML protocol and want to switch
     `Name` | `Client Audience`
     `Mapper Type` | `Audience`
     `Included Client Audience` | &lt;CLIENT_NAME>
+    `Add to ID token` | `OFF`
     `Add to access token` | `ON`
 
   - Create a new "Groups Path" with the settings below.
@@ -56,8 +58,15 @@ If you have an existing configuration using the SAML protocol and want to switch
     `Mapper Type` | `Group Membership`
     `Token Claim Name` | `full_group_path`
     `Full group path` | `ON`
+    `Add to ID token` | `ON`
+    `Add to access token` | `ON`
     `Add to user info` | `ON`
 
+- Go to **Role Mappings > Client Roles >  realm-management** and add the following Role Mappings to all users or groups that need to query the Keycloak users.
+  - query-users
+  - query-groups
+  - view-users
+  
 ## Configuring Keycloak in Rancher
 
 1. In the Rancher UI, click **☰ > Users & Authentication**.


### PR DESCRIPTION
Added section describing needed client roles in order to be able to retrieve Keycloak users from the Rancher GUI. 
Added details on Mappers. 
