### PR TITLE
Convert all helm-template instructions to helm-install

### DIFF
--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -1,5 +1,5 @@
 ---
-title: Rendering the Helm Template in an Air-Gapped Environment
+title: Upgrading in an Air-Gapped Environment
 ---
 
 <head>
@@ -12,9 +12,9 @@ These instructions assume you have already followed the instructions for a Kuber
 
 :::
 
-### Rancher Helm Template Options
+### Rancher Helm Upgrade Options
 
-Render the Rancher template using the same chosen options that were used when installing Rancher. Use the reference table below to replace each placeholder. Rancher needs to be configured to use the private registry in order to provision any Rancher launched Kubernetes clusters or Rancher tools.
+To upgrade with Helm, apply the same options that you used when installing Rancher. Refer to the reference table below to replace each placeholder. Rancher needs to be configured to use the private registry in order to provision any Rancher launched Kubernetes clusters or Rancher tools.
 
 Based on the choice you made during installation, complete one of the procedures below.
 
@@ -29,8 +29,7 @@ Placeholder | Description
 ### Option A: Default Self-signed Certificate
 
 ```
-helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
-    --no-hooks \ # prevent files for Helm hooks from being generated
+helm upgrade rancher ./rancher-<VERSION>.tgz \
 	--namespace cattle-system \
 	--set hostname=<RANCHER.YOURDOMAIN.COM> \
 	--set certmanager.version=<CERTMANAGER_VERSION> \
@@ -42,8 +41,7 @@ helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
 ### Option B: Certificates from Files using Kubernetes Secrets
 
 ```plain
-helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
-	--no-hooks \ # prevent files for Helm hooks from being generated
+helm upgrade rancher ./rancher-<VERSION>.tgz \
 	--namespace cattle-system \
 	--set hostname=<RANCHER.YOURDOMAIN.COM> \
 	--set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
@@ -55,8 +53,7 @@ helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
 If you are using a Private CA signed cert, add `--set privateCA=true` following `--set ingress.tls.source=secret`:
 
 ```plain
-helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
-	--no-hooks \ # prevent files for Helm hooks from being generated
+helm upgrade rancher ./rancher-<VERSION>.tgz \
 	--namespace cattle-system \
 	--set hostname=<RANCHER.YOURDOMAIN.COM> \
 	--set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
@@ -64,16 +61,6 @@ helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
 	--set privateCA=true \
 	--set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
 	--set useBundledSystemChart=true # Use the packaged Rancher system charts
-```
-
-### Apply the Rendered Templates
-
-Copy the rendered manifest directories to a system with access to the Rancher server cluster and apply the rendered templates.
-
-Use `kubectl` to apply the rendered manifests.
-
-```plain
-kubectl -n cattle-system apply -R -f ./rancher
 ```
 
 ## Verify the Upgrade

--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
@@ -122,7 +122,7 @@ Copy the fetched charts to a system that has access to the Rancher server cluste
 
 ##### 1. Install Cert-Manager
 
-Install cert-manager with the options you would like to use to install the chart. Remember to set the `image.repository` option to pull the image from your private registry. This will create a `cert-manager` directory with the Kubernetes manifest files.
+Install cert-manager with the same options you would use to install the chart. Remember to set the `image.repository` option to pull the image from your private registry.
 
 :::note
 
@@ -144,7 +144,7 @@ If you are using self-signed certificates, install cert-manager:
 2. Create the cert-manager CustomResourceDefinitions (CRDs).
 
     ```plain
-    kubectl apply -f cert-manager/cert-manager-crd.yaml
+    kubectl apply -f cert-manager-crd.yaml
     ```
 
 3. Install cert-manager.

--- a/docs/pages-for-subheaders/enable-experimental-features.md
+++ b/docs/pages-for-subheaders/enable-experimental-features.md
@@ -55,17 +55,14 @@ If you are installing an alpha version, Helm requires adding the `--devel` optio
 
 :::
 
-### Rendering the Helm Chart for Air Gap Installations
+### Enabling Features for Air Gap Installs
 
-For an air gap installation of Rancher, you need to add a Helm chart repository and render a Helm template before installing Rancher with Helm. For details, refer to the [air gap installation documentation.](../getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md)
+To perform an [air gap installation of Rancher](../getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md), add a Helm chart repository and download a Helm chart, then install Rancher with Helm.
 
-Here is an example of a command for passing in the feature flag names when rendering the Helm template. In the below example, two features are enabled by passing the feature flag names in a comma separated list.
-
-The Helm command is as follows:
+When you install the Helm chart, you should pass in feature flag names in a comma separated list, as in the following example:
 
 ```
-helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
-  --no-hooks \ # prevent files for Helm hooks from being generated
+helm install rancher ./rancher-<VERSION>.tgz \
   --namespace cattle-system \
   --set hostname=<RANCHER.YOURDOMAIN.COM> \
   --set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -1,5 +1,5 @@
 ---
-title: Rendering the Helm Template in an Air-Gapped Environment
+title: Upgrading in an Air-Gapped Environment
 ---
 
 <head>
@@ -12,9 +12,9 @@ These instructions assume you have already followed the instructions for a Kuber
 
 :::
 
-### Rancher Helm Template Options
+### Rancher Helm Upgrade Options
 
-Render the Rancher template using the same chosen options that were used when installing Rancher. Use the reference table below to replace each placeholder. Rancher needs to be configured to use the private registry in order to provision any Rancher launched Kubernetes clusters or Rancher tools.
+To upgrade with Helm, apply the same options that you used when installing Rancher. Refer to the reference table below to replace each placeholder. Rancher needs to be configured to use the private registry in order to provision any Rancher launched Kubernetes clusters or Rancher tools.
 
 Based on the choice you made during installation, complete one of the procedures below.
 
@@ -29,8 +29,7 @@ Placeholder | Description
 ### Option A: Default Self-signed Certificate
 
 ```
-helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
-    --no-hooks \ # prevent files for Helm hooks from being generated
+helm upgrade rancher ./rancher-<VERSION>.tgz \
 	--namespace cattle-system \
 	--set hostname=<RANCHER.YOURDOMAIN.COM> \
 	--set certmanager.version=<CERTMANAGER_VERSION> \
@@ -42,8 +41,7 @@ helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
 ### Option B: Certificates from Files using Kubernetes Secrets
 
 ```plain
-helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
-	--no-hooks \ # prevent files for Helm hooks from being generated
+helm upgrade rancher ./rancher-<VERSION>.tgz \
 	--namespace cattle-system \
 	--set hostname=<RANCHER.YOURDOMAIN.COM> \
 	--set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
@@ -55,8 +53,7 @@ helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
 If you are using a Private CA signed cert, add `--set privateCA=true` following `--set ingress.tls.source=secret`:
 
 ```plain
-helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
-	--no-hooks \ # prevent files for Helm hooks from being generated
+helm upgrade rancher ./rancher-<VERSION>.tgz \
 	--namespace cattle-system \
 	--set hostname=<RANCHER.YOURDOMAIN.COM> \
 	--set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
@@ -64,16 +61,6 @@ helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
 	--set privateCA=true \
 	--set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
 	--set useBundledSystemChart=true # Use the packaged Rancher system charts
-```
-
-### Apply the Rendered Templates
-
-Copy the rendered manifest directories to a system with access to the Rancher server cluster and apply the rendered templates.
-
-Use `kubectl` to apply the rendered manifests.
-
-```plain
-kubectl -n cattle-system apply -R -f ./rancher
 ```
 
 ## Verify the Upgrade

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
@@ -117,7 +117,7 @@ Copy the fetched charts to a system that has access to the Rancher server cluste
 
 ##### 1. Install Cert-Manager
 
-Install cert-manager with the options you would like to use to install the chart. Remember to set the `image.repository` option to pull the image from your private registry. This will create a `cert-manager` directory with the Kubernetes manifest files.
+Install cert-manager with the same options you would use to install the chart. Remember to set the `image.repository` option to pull the image from your private registry.
 
 :::note
 
@@ -139,7 +139,7 @@ If you are using self-signed certificates, install cert-manager:
 2. Create the cert-manager CustomResourceDefinitions (CRDs).
 
     ```plain
-    kubectl apply -f cert-manager/cert-manager-crd.yaml
+    kubectl apply -f cert-manager-crd.yaml
     ```
 
 3. Install cert-manager.

--- a/versioned_docs/version-2.6/pages-for-subheaders/enable-experimental-features.md
+++ b/versioned_docs/version-2.6/pages-for-subheaders/enable-experimental-features.md
@@ -53,17 +53,14 @@ If you are installing an alpha version, Helm requires adding the `--devel` optio
 
 :::
 
-### Rendering the Helm Chart for Air Gap Installations
+### Enabling Features for Air Gap Installs
 
-For an air gap installation of Rancher, you need to add a Helm chart repository and render a Helm template before installing Rancher with Helm. For details, refer to the [air gap installation documentation.](../getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md)
+To perform an [air gap installation of Rancher](../getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md), add a Helm chart repository and download a Helm chart, then install Rancher with Helm.
 
-Here is an example of a command for passing in the feature flag names when rendering the Helm template. In the below example, two features are enabled by passing the feature flag names in a comma separated list.
-
-The Helm command is as follows:
+When you install the Helm chart, you should pass in feature flag names in a comma separated list, as in the following example:
 
 ```
-helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
-  --no-hooks \ # prevent files for Helm hooks from being generated
+helm install rancher ./rancher-<VERSION>.tgz \
   --namespace cattle-system \
   --set hostname=<RANCHER.YOURDOMAIN.COM> \
   --set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -1,5 +1,5 @@
 ---
-title: Rendering the Helm Template in an Air-Gapped Environment
+title: Upgrading in an Air-Gapped Environment
 ---
 
 <head>
@@ -12,9 +12,9 @@ These instructions assume you have already followed the instructions for a Kuber
 
 :::
 
-### Rancher Helm Template Options
+### Rancher Helm Upgrade Options
 
-Render the Rancher template using the same chosen options that were used when installing Rancher. Use the reference table below to replace each placeholder. Rancher needs to be configured to use the private registry in order to provision any Rancher launched Kubernetes clusters or Rancher tools.
+To upgrade with Helm, apply the same options that you used when installing Rancher. Refer to the reference table below to replace each placeholder. Rancher needs to be configured to use the private registry in order to provision any Rancher launched Kubernetes clusters or Rancher tools.
 
 Based on the choice you made during installation, complete one of the procedures below.
 
@@ -29,8 +29,7 @@ Placeholder | Description
 ### Option A: Default Self-signed Certificate
 
 ```
-helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
-    --no-hooks \ # prevent files for Helm hooks from being generated
+helm upgrade rancher ./rancher-<VERSION>.tgz \
 	--namespace cattle-system \
 	--set hostname=<RANCHER.YOURDOMAIN.COM> \
 	--set certmanager.version=<CERTMANAGER_VERSION> \
@@ -42,8 +41,7 @@ helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
 ### Option B: Certificates from Files using Kubernetes Secrets
 
 ```plain
-helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
-	--no-hooks \ # prevent files for Helm hooks from being generated
+helm upgrade rancher ./rancher-<VERSION>.tgz \
 	--namespace cattle-system \
 	--set hostname=<RANCHER.YOURDOMAIN.COM> \
 	--set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
@@ -55,8 +53,7 @@ helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
 If you are using a Private CA signed cert, add `--set privateCA=true` following `--set ingress.tls.source=secret`:
 
 ```plain
-helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
-	--no-hooks \ # prevent files for Helm hooks from being generated
+helm upgrade rancher ./rancher-<VERSION>.tgz \
 	--namespace cattle-system \
 	--set hostname=<RANCHER.YOURDOMAIN.COM> \
 	--set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
@@ -64,16 +61,6 @@ helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
 	--set privateCA=true \
 	--set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
 	--set useBundledSystemChart=true # Use the packaged Rancher system charts
-```
-
-### Apply the Rendered Templates
-
-Copy the rendered manifest directories to a system with access to the Rancher server cluster and apply the rendered templates.
-
-Use `kubectl` to apply the rendered manifests.
-
-```plain
-kubectl -n cattle-system apply -R -f ./rancher
 ```
 
 ## Verify the Upgrade

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
@@ -122,7 +122,7 @@ Copy the fetched charts to a system that has access to the Rancher server cluste
 
 ##### 1. Install Cert-Manager
 
-Install cert-manager with the options you would like to use to install the chart. Remember to set the `image.repository` option to pull the image from your private registry. This will create a `cert-manager` directory with the Kubernetes manifest files.
+Install cert-manager with the same options you would use to install the chart. Remember to set the `image.repository` option to pull the image from your private registry.
 
 :::note
 
@@ -144,7 +144,7 @@ If you are using self-signed certificates, install cert-manager:
 2. Create the cert-manager CustomResourceDefinitions (CRDs).
 
     ```plain
-    kubectl apply -f cert-manager/cert-manager-crd.yaml
+    kubectl apply -f cert-manager-crd.yaml
     ```
 
 3. Install cert-manager.

--- a/versioned_docs/version-2.7/pages-for-subheaders/enable-experimental-features.md
+++ b/versioned_docs/version-2.7/pages-for-subheaders/enable-experimental-features.md
@@ -55,17 +55,14 @@ If you are installing an alpha version, Helm requires adding the `--devel` optio
 
 :::
 
-### Rendering the Helm Chart for Air Gap Installations
+### Enabling Features for Air Gap Installs
 
-For an air gap installation of Rancher, you need to add a Helm chart repository and render a Helm template before installing Rancher with Helm. For details, refer to the [air gap installation documentation.](../getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md)
+To perform an [air gap installation of Rancher](../getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md), add a Helm chart repository and download a Helm chart, then install Rancher with Helm.
 
-Here is an example of a command for passing in the feature flag names when rendering the Helm template. In the below example, two features are enabled by passing the feature flag names in a comma separated list.
-
-The Helm command is as follows:
+When you install the Helm chart, you should pass in feature flag names in a comma separated list, as in the following example:
 
 ```
-helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
-  --no-hooks \ # prevent files for Helm hooks from being generated
+helm install rancher ./rancher-<VERSION>.tgz \
   --namespace cattle-system \
   --set hostname=<RANCHER.YOURDOMAIN.COM> \
   --set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher-docs/issues/808 [edit: GH does not seem to link issues if they're listed in a header?]

## Summary

1. The first commit fixes the commands for installing cert-manager. This was converted from `helm template` to `helm install` previously but there were still some leftovers such as the `cert-manager` directory that no longer exists. Removed mentions of it and adjusted the `kubectl` command.
2. The second commit converts the remaining commands that use `helm template` in the latest supported version (`2.6`, `2.7` and latest). I have changed the title of some of those to better reflect what's happening and remove reference to "rendering". I don't think this breaks links.

## Translation

The following files need to be updated also:

**For first commit:**

Same as the english version:
- Need to remove reference to the cert-manager directory as this one is no longer created.
- The kubectl apply command should should be converted from
```
kubectl apply -f cert-manager/cert-manager-crd.yaml
```
to 
```
kubectl apply -f cert-manager-crd.yaml
```

Files list:

```
i18n/zh/docusaurus-plugin-content-docs/current/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
i18n/zh/docusaurus-plugin-content-docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
i18n/zh/docusaurus-plugin-content-docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
```

**For second commit:**

Same as english version:
- For the air-gapped-upgrades page, Helm commands need to be converted from
```
helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
	--no-hooks \ # prevent files for Helm hooks from being generated
...
```
to
```
helm upgrade rancher ./rancher-<VERSION>.tgz \
...
```
- For the experimental features page, Helm commands need to be converted from
```
helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
	--no-hooks \ # prevent files for Helm hooks from being generated
...
```
to
```
helm install rancher ./rancher-<VERSION>.tgz \
...
```
- Text should be adjusted accordingly since we're no longer "rendering" anything with the commands, Helm install/upgrade applies them right away.

Files list:

```
i18n/zh/docusaurus-plugin-content-docs/current/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
i18n/zh/docusaurus-plugin-content-docs/current/pages-for-subheaders/enable-experimental-features.md
i18n/zh/docusaurus-plugin-content-docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
i18n/zh/docusaurus-plugin-content-docs/version-2.6/pages-for-subheaders/enable-experimental-features.md
i18n/zh/docusaurus-plugin-content-docs/version-2.7/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
i18n/zh/docusaurus-plugin-content-docs/version-2.7/pages-for-subheaders/enable-experimental-features.md
```
