### PR TITLE
#795 Update issue templates, add PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-a-new-feature.md
+++ b/.github/ISSUE_TEMPLATE/request-a-new-feature.md
@@ -7,10 +7,21 @@ assignees: ''
 
 ---
 
-**Summary:**
+## Connected Issues
+
+<!--
+List any issues or tickets on other platforms that are associated with the request. For example, include a link to the issue tracking that feature in the Rancher repo, or list the Jira ticket number for the request. 
+-->
+
+## Summary
+
+<!--
 Describe the new feature. If QA has not yet tested the new feature/process, please also file a ticket with QA for their review.
+-->
 
+## Details
 
-**Details:**
+<!--
 - Include all pertinent information, e.g., screenshots, resource requirements, workarounds, links, etc.
 - List page link(s) in the current docs where the new feature applies, if applicable.
+-->

--- a/.github/ISSUE_TEMPLATE/request-a-new-feature.md
+++ b/.github/ISSUE_TEMPLATE/request-a-new-feature.md
@@ -4,10 +4,9 @@ about: For requesting new feature(s) to be added to the docs.
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
-## Connected Issues
+## Related Issues
 
 <!--
 List any issues or tickets on other platforms that are associated with the request. For example, include a link to the issue tracking that feature in the Rancher repo, or list the Jira ticket number for the request. 

--- a/.github/ISSUE_TEMPLATE/request-an-update.md
+++ b/.github/ISSUE_TEMPLATE/request-an-update.md
@@ -7,5 +7,13 @@ assignees: ''
 
 ---
 
-**Summary:**
+## Connected Issues
+<!--
+List any issues or tickets on other platforms that are associated with the request. For example, include a link to the issue tracking that feature in the Rancher repo, or list the Jira ticket number for the request.
+-->
+
+## Summary
+
+<!--
 Describe the requested update giving as much detail as possible. Please also list page link(s) in the current docs where the update applies.
+-->

--- a/.github/ISSUE_TEMPLATE/request-an-update.md
+++ b/.github/ISSUE_TEMPLATE/request-an-update.md
@@ -4,10 +4,9 @@ about: For fixing docs errors/typos, adding needed/missing information, updating
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
-## Connected Issues
+## Related Issues
 <!--
 List any issues or tickets on other platforms that are associated with the request. For example, include a link to the issue tracking that feature in the Rancher repo, or list the Jira ticket number for the request.
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,13 +2,15 @@
 Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
 -->
 
-Fixes #_
+Fixes #[issue_number]
 
 ## Reminder
 
+<!--
 Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.
 
 If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.
+-->
 
 ## Description
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+<!--
+Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
+-->
+
+Fixes #_
+
+## Reminder
+
+Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.
+
+If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.
+
+## Description
+
+<!--
+- What is the goal of this pull request? 
+- What did you change? 
+- Are there any other pull requests, tickets, or issues associated with this pull request?
+-->
+
+## Comments
+
+<!--
+Any additional notes a reviewer should know before we review.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,11 +4,13 @@ Check the Rancher docs issues to see if there is an existing issue for this pull
 
 Fixes #[issue_number]
 
-<!-- Reminder
-Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.
+## Reminders
 
-If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.
--->
+- See the [README](../README.md) for more details on how to work with the Rancher docs.
+
+- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.
+
+- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.
 
 ## Description
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,9 +4,7 @@ Check the Rancher docs issues to see if there is an existing issue for this pull
 
 Fixes #[issue_number]
 
-## Reminder
-
-<!--
+<!-- Reminder
 Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.
 
 If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.


### PR DESCRIPTION
Addresses this part of #795:

> We should have another look at our issue templates and update them as needed.

This PR adapts the format seen in the [release notes](https://raw.githubusercontent.com/rancherlabs/release-notes/main/.github/PULL_REQUEST_TEMPLATE.md?token=GHSAT0AAAAAACCYXKBERVJVCILWHU54YHIKZH3JVUQ) repo. Instructions are commented out so that the user can leave them in place when they start writing.

Also added a PR template. It encourages users to include an issue number, and reminds them about the release branch and versioning.