### PR TITLE
#420 canonical links for Troubleshooting

### DIFF
--- a/docs/troubleshooting/general-troubleshooting.md
+++ b/docs/troubleshooting/general-troubleshooting.md
@@ -2,6 +2,10 @@
 title: General Troubleshooting
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/general-troubleshooting"/>
+</head>
+
 This section contains information to help you troubleshoot issues when using Rancher.
 
 - [Kubernetes components](../pages-for-subheaders/kubernetes-components.md)

--- a/docs/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.md
+++ b/docs/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.md
@@ -2,6 +2,10 @@
 title: Troubleshooting Controlplane Nodes
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes"/>
+</head>
+
 This section applies to nodes with the `controlplane` role.
 
 ## Check if the Controlplane Containers are Running

--- a/docs/troubleshooting/kubernetes-components/troubleshooting-etcd-nodes.md
+++ b/docs/troubleshooting/kubernetes-components/troubleshooting-etcd-nodes.md
@@ -2,6 +2,10 @@
 title: Troubleshooting etcd Nodes
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-etcd-nodes"/>
+</head>
+
 This section contains commands and tips for troubleshooting nodes with the `etcd` role.
 
 

--- a/docs/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
+++ b/docs/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
@@ -2,6 +2,10 @@
 title: Troubleshooting nginx-proxy
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy"/>
+</head>
+
 The `nginx-proxy` container is deployed on every node that does not have the `controlplane` role. It provides access to all the nodes with the `controlplane` role by dynamically generating the NGINX configuration based on available nodes with the `controlplane` role.
 
 ## Check if the Container is Running

--- a/docs/troubleshooting/kubernetes-components/troubleshooting-worker-nodes-and-generic-components.md
+++ b/docs/troubleshooting/kubernetes-components/troubleshooting-worker-nodes-and-generic-components.md
@@ -2,6 +2,10 @@
 title: Troubleshooting Worker Nodes and Generic Components
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-worker-nodes-and-generic-components"/>
+</head>
+
 This section applies to every node as it includes components that run on nodes with any role.
 
 ## Check if the Containers are Running

--- a/docs/troubleshooting/other-troubleshooting-tips/dns.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/dns.md
@@ -2,6 +2,10 @@
 title: DNS
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/dns"/>
+</head>
+
 The commands/steps listed on this page can be used to check name resolution issues in your cluster.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.

--- a/docs/troubleshooting/other-troubleshooting-tips/expired-webhook-certificate-rotation.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/expired-webhook-certificate-rotation.md
@@ -2,6 +2,10 @@
 title: Rotation of Expired Webhook Certificates
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/expired-webhook-certificate-rotation"/>
+</head>
+
 For Rancher versions that have `rancher-webhook` installed, certain versions created certificates that will expire after one year. It will be necessary for you to rotate your webhook certificate if the certificate did not renew.
 
 In Rancher v2.6.3 and up, rancher-webhook deployments will automatically renew their TLS certificate when it is within 30 or fewer days of its expiration date. If you are using v2.6.2 or below, there are two methods to work around this issue:

--- a/docs/troubleshooting/other-troubleshooting-tips/kubernetes-resources.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/kubernetes-resources.md
@@ -2,6 +2,10 @@
 title: Kubernetes Resources
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/kubernetes-resources"/>
+</head>
+
 The commands/steps listed on this page can be used to check the most important Kubernetes resources and apply to [Rancher Launched Kubernetes](../../pages-for-subheaders/launch-kubernetes-with-rancher.md) clusters.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.

--- a/docs/troubleshooting/other-troubleshooting-tips/logging.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/logging.md
@@ -2,6 +2,10 @@
 title: Logging
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/logging"/>
+</head>
+
 ## Log levels
 
 The following log levels are used in Rancher:

--- a/docs/troubleshooting/other-troubleshooting-tips/networking.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/networking.md
@@ -2,6 +2,10 @@
 title: Networking
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/networking"/>
+</head>
+
 The commands/steps listed on this page can be used to check networking related issues in your cluster.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.

--- a/docs/troubleshooting/other-troubleshooting-tips/rancher-ha.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/rancher-ha.md
@@ -2,6 +2,10 @@
 title: Rancher HA
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/rancher-ha"/>
+</head>
+
 The commands/steps listed on this page can be used to check your Rancher Kubernetes Installation.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml`).

--- a/docs/troubleshooting/other-troubleshooting-tips/registered-clusters.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/registered-clusters.md
@@ -2,6 +2,10 @@
 title: Registered Clusters
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/registered-clusters"/>
+</head>
+
 The commands/steps listed on this page can be used to check clusters that you are registering or that are registered in Rancher.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kubeconfig_from_imported_cluster.yml`)

--- a/docs/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs.md
@@ -2,6 +2,10 @@
 title: User ID Tracking in Audit Logs
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs"/>
+</head>
+
 The following audit logs are used in Rancher to track events occuring on the local and downstream clusters:
 
 * [Kubernetes Audit Logs](https://rancher.com/docs/rke/latest/en/config-options/audit-log/)

--- a/versioned_docs/version-2.0-2.4/troubleshooting.md
+++ b/versioned_docs/version-2.0-2.4/troubleshooting.md
@@ -2,6 +2,10 @@
 title: Troubleshooting
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/general-troubleshooting"/>
+</head>
+
 This section contains information to help you troubleshoot issues when using Rancher.
 
 - [Kubernetes components](pages-for-subheaders/kubernetes-components.md)

--- a/versioned_docs/version-2.0-2.4/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.md
+++ b/versioned_docs/version-2.0-2.4/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.md
@@ -2,6 +2,10 @@
 title: Troubleshooting Controlplane Nodes
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes"/>
+</head>
+
 This section applies to nodes with the `controlplane` role.
 
 ## Check if the Controlplane Containers are Running

--- a/versioned_docs/version-2.0-2.4/troubleshooting/kubernetes-components/troubleshooting-etcd-nodes.md
+++ b/versioned_docs/version-2.0-2.4/troubleshooting/kubernetes-components/troubleshooting-etcd-nodes.md
@@ -2,6 +2,10 @@
 title: Troubleshooting etcd Nodes
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-etcd-nodes"/>
+</head>
+
 This section contains commands and tips for troubleshooting nodes with the `etcd` role.
 
 

--- a/versioned_docs/version-2.0-2.4/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
+++ b/versioned_docs/version-2.0-2.4/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
@@ -2,6 +2,10 @@
 title: Troubleshooting nginx-proxy
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy"/>
+</head>
+
 The `nginx-proxy` container is deployed on every node that does not have the `controlplane` role. It provides access to all the nodes with the `controlplane` role by dynamically generating the NGINX configuration based on available nodes with the `controlplane` role.
 
 ## Check if the Container is Running

--- a/versioned_docs/version-2.0-2.4/troubleshooting/kubernetes-components/troubleshooting-worker-nodes-and-generic-components.md
+++ b/versioned_docs/version-2.0-2.4/troubleshooting/kubernetes-components/troubleshooting-worker-nodes-and-generic-components.md
@@ -2,6 +2,10 @@
 title: Troubleshooting Worker Nodes and Generic Components
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-worker-nodes-and-generic-components"/>
+</head>
+
 This section applies to every node as it includes components that run on nodes with any role.
 
 ## Check if the Containers are Running

--- a/versioned_docs/version-2.0-2.4/troubleshooting/other-troubleshooting-tips/dns.md
+++ b/versioned_docs/version-2.0-2.4/troubleshooting/other-troubleshooting-tips/dns.md
@@ -2,6 +2,10 @@
 title: DNS
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/dns"/>
+</head>
+
 The commands/steps listed on this page can be used to check name resolution issues in your cluster.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_rancher-cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.

--- a/versioned_docs/version-2.0-2.4/troubleshooting/other-troubleshooting-tips/kubernetes-resources.md
+++ b/versioned_docs/version-2.0-2.4/troubleshooting/other-troubleshooting-tips/kubernetes-resources.md
@@ -2,6 +2,10 @@
 title: Kubernetes resources
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/kubernetes-resources"/>
+</head>
+
 The commands/steps listed on this page can be used to check the most important Kubernetes resources and apply to [Rancher Launched Kubernetes](../../pages-for-subheaders/launch-kubernetes-with-rancher.md) clusters.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_rancher-cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.

--- a/versioned_docs/version-2.0-2.4/troubleshooting/other-troubleshooting-tips/logging.md
+++ b/versioned_docs/version-2.0-2.4/troubleshooting/other-troubleshooting-tips/logging.md
@@ -2,6 +2,10 @@
 title: Logging
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/logging"/>
+</head>
+
 The following log levels are used in Rancher:
 
 | Name    | Description |

--- a/versioned_docs/version-2.0-2.4/troubleshooting/other-troubleshooting-tips/networking.md
+++ b/versioned_docs/version-2.0-2.4/troubleshooting/other-troubleshooting-tips/networking.md
@@ -2,6 +2,10 @@
 title: Networking
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/networking"/>
+</head>
+
 The commands/steps listed on this page can be used to check networking related issues in your cluster.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_rancher-cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.

--- a/versioned_docs/version-2.0-2.4/troubleshooting/other-troubleshooting-tips/rancher-ha.md
+++ b/versioned_docs/version-2.0-2.4/troubleshooting/other-troubleshooting-tips/rancher-ha.md
@@ -2,6 +2,10 @@
 title: Rancher HA
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/rancher-ha"/>
+</head>
+
 The commands/steps listed on this page can be used to check your Rancher Kubernetes Installation.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_rancher-cluster.yml`).

--- a/versioned_docs/version-2.0-2.4/troubleshooting/other-troubleshooting-tips/registered-clusters.md
+++ b/versioned_docs/version-2.0-2.4/troubleshooting/other-troubleshooting-tips/registered-clusters.md
@@ -2,6 +2,10 @@
 title: Imported clusters
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/registered-clusters"/>
+</head>
+
 The commands/steps listed on this page can be used to check clusters that you are importing or that are imported in Rancher.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kubeconfig_from_imported_cluster.yml`)

--- a/versioned_docs/version-2.5/troubleshooting.md
+++ b/versioned_docs/version-2.5/troubleshooting.md
@@ -2,6 +2,10 @@
 title: Troubleshooting
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/general-troubleshooting"/>
+</head>
+
 This section contains information to help you troubleshoot issues when using Rancher.
 
 - [Kubernetes components](pages-for-subheaders/kubernetes-components.md)

--- a/versioned_docs/version-2.5/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.md
+++ b/versioned_docs/version-2.5/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.md
@@ -2,6 +2,10 @@
 title: Troubleshooting Controlplane Nodes
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes"/>
+</head>
+
 This section applies to nodes with the `controlplane` role.
 
 ## Check if the Controlplane Containers are Running

--- a/versioned_docs/version-2.5/troubleshooting/kubernetes-components/troubleshooting-etcd-nodes.md
+++ b/versioned_docs/version-2.5/troubleshooting/kubernetes-components/troubleshooting-etcd-nodes.md
@@ -2,6 +2,10 @@
 title: Troubleshooting etcd Nodes
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-etcd-nodes"/>
+</head>
+
 This section contains commands and tips for troubleshooting nodes with the `etcd` role.
 
 

--- a/versioned_docs/version-2.5/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
+++ b/versioned_docs/version-2.5/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
@@ -2,6 +2,10 @@
 title: Troubleshooting nginx-proxy
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy"/>
+</head>
+
 The `nginx-proxy` container is deployed on every node that does not have the `controlplane` role. It provides access to all the nodes with the `controlplane` role by dynamically generating the NGINX configuration based on available nodes with the `controlplane` role.
 
 ## Check if the Container is Running

--- a/versioned_docs/version-2.5/troubleshooting/kubernetes-components/troubleshooting-worker-nodes-and-generic-components.md
+++ b/versioned_docs/version-2.5/troubleshooting/kubernetes-components/troubleshooting-worker-nodes-and-generic-components.md
@@ -2,6 +2,10 @@
 title: Troubleshooting Worker Nodes and Generic Components
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-worker-nodes-and-generic-components"/>
+</head>
+
 This section applies to every node as it includes components that run on nodes with any role.
 
 ## Check if the Containers are Running

--- a/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/dns.md
+++ b/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/dns.md
@@ -2,6 +2,10 @@
 title: DNS
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/dns"/>
+</head>
+
 The commands/steps listed on this page can be used to check name resolution issues in your cluster.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.

--- a/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/expired-webhook-certificate-rotation.md
+++ b/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/expired-webhook-certificate-rotation.md
@@ -2,6 +2,10 @@
 title: Rotation of Expired Webhook Certificates
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/expired-webhook-certificate-rotation"/>
+</head>
+
 For Rancher versions that have `rancher-webhook` installed, certain versions created certificates that will expire after one year. It will be necessary for you to rotate your webhook certificate if the certificate did not renew.
 
 In Rancher v2.5.12 and up, rancher-webhook deployments will automatically renew their TLS certificate when it is within 30 or fewer days of its expiration date. If you are using v2.5.11 or below, there are two methods to work around this issue:

--- a/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/kubernetes-resources.md
+++ b/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/kubernetes-resources.md
@@ -2,6 +2,10 @@
 title: Kubernetes resources
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/kubernetes-resources"/>
+</head>
+
 The commands/steps listed on this page can be used to check the most important Kubernetes resources and apply to [Rancher Launched Kubernetes](../../pages-for-subheaders/launch-kubernetes-with-rancher.md) clusters.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.

--- a/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/logging.md
+++ b/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/logging.md
@@ -2,6 +2,10 @@
 title: Logging
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/logging"/>
+</head>
+
 The following log levels are used in Rancher:
 
 | Name    | Description |

--- a/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/networking.md
+++ b/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/networking.md
@@ -2,6 +2,10 @@
 title: Networking
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/networking"/>
+</head>
+
 The commands/steps listed on this page can be used to check networking related issues in your cluster.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.

--- a/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/rancher-ha.md
+++ b/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/rancher-ha.md
@@ -2,6 +2,10 @@
 title: Rancher HA
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/rancher-ha"/>
+</head>
+
 The commands/steps listed on this page can be used to check your Rancher Kubernetes Installation.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml`).

--- a/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/registered-clusters.md
+++ b/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/registered-clusters.md
@@ -2,6 +2,10 @@
 title: Registered clusters
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/registered-clusters"/>
+</head>
+
 The commands/steps listed on this page can be used to check clusters that you are registering or that are registered in Rancher.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kubeconfig_from_imported_cluster.yml`)

--- a/versioned_docs/version-2.6/troubleshooting/general-troubleshooting.md
+++ b/versioned_docs/version-2.6/troubleshooting/general-troubleshooting.md
@@ -2,6 +2,10 @@
 title: General Troubleshooting
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/general-troubleshooting"/>
+</head>
+
 This section contains information to help you troubleshoot issues when using Rancher.
 
 - [Kubernetes components](../pages-for-subheaders/kubernetes-components.md)

--- a/versioned_docs/version-2.6/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.md
+++ b/versioned_docs/version-2.6/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.md
@@ -2,6 +2,10 @@
 title: Troubleshooting Controlplane Nodes
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes"/>
+</head>
+
 This section applies to nodes with the `controlplane` role.
 
 ## Check if the Controlplane Containers are Running

--- a/versioned_docs/version-2.6/troubleshooting/kubernetes-components/troubleshooting-etcd-nodes.md
+++ b/versioned_docs/version-2.6/troubleshooting/kubernetes-components/troubleshooting-etcd-nodes.md
@@ -2,6 +2,10 @@
 title: Troubleshooting etcd Nodes
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-etcd-nodes"/>
+</head>
+
 This section contains commands and tips for troubleshooting nodes with the `etcd` role.
 
 

--- a/versioned_docs/version-2.6/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
+++ b/versioned_docs/version-2.6/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
@@ -2,6 +2,10 @@
 title: Troubleshooting nginx-proxy
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy"/>
+</head>
+
 The `nginx-proxy` container is deployed on every node that does not have the `controlplane` role. It provides access to all the nodes with the `controlplane` role by dynamically generating the NGINX configuration based on available nodes with the `controlplane` role.
 
 ## Check if the Container is Running

--- a/versioned_docs/version-2.6/troubleshooting/kubernetes-components/troubleshooting-worker-nodes-and-generic-components.md
+++ b/versioned_docs/version-2.6/troubleshooting/kubernetes-components/troubleshooting-worker-nodes-and-generic-components.md
@@ -2,6 +2,10 @@
 title: Troubleshooting Worker Nodes and Generic Components
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-worker-nodes-and-generic-components"/>
+</head>
+
 This section applies to every node as it includes components that run on nodes with any role.
 
 ## Check if the Containers are Running

--- a/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/dns.md
+++ b/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/dns.md
@@ -2,6 +2,10 @@
 title: DNS
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/dns"/>
+</head>
+
 The commands/steps listed on this page can be used to check name resolution issues in your cluster.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.

--- a/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/expired-webhook-certificate-rotation.md
+++ b/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/expired-webhook-certificate-rotation.md
@@ -2,6 +2,10 @@
 title: Rotation of Expired Webhook Certificates
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/expired-webhook-certificate-rotation"/>
+</head>
+
 For Rancher versions that have `rancher-webhook` installed, certain versions created certificates that will expire after one year. It will be necessary for you to rotate your webhook certificate if the certificate did not renew.
 
 In Rancher v2.6.3 and up, rancher-webhook deployments will automatically renew their TLS certificate when it is within 30 or fewer days of its expiration date. If you are using v2.6.2 or below, there are two methods to work around this issue:

--- a/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/kubernetes-resources.md
+++ b/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/kubernetes-resources.md
@@ -2,6 +2,10 @@
 title: Kubernetes Resources
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/kubernetes-resources"/>
+</head>
+
 The commands/steps listed on this page can be used to check the most important Kubernetes resources and apply to [Rancher Launched Kubernetes](../../pages-for-subheaders/launch-kubernetes-with-rancher.md) clusters.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.

--- a/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/logging.md
+++ b/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/logging.md
@@ -2,6 +2,10 @@
 title: Logging
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/logging"/>
+</head>
+
 ## Log levels
 
 The following log levels are used in Rancher:

--- a/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/networking.md
+++ b/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/networking.md
@@ -2,6 +2,10 @@
 title: Networking
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/networking"/>
+</head>
+
 The commands/steps listed on this page can be used to check networking related issues in your cluster.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.

--- a/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/rancher-ha.md
+++ b/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/rancher-ha.md
@@ -2,6 +2,10 @@
 title: Rancher HA
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/rancher-ha"/>
+</head>
+
 The commands/steps listed on this page can be used to check your Rancher Kubernetes Installation.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml`).

--- a/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/registered-clusters.md
+++ b/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/registered-clusters.md
@@ -2,6 +2,10 @@
 title: Registered Clusters
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/registered-clusters"/>
+</head>
+
 The commands/steps listed on this page can be used to check clusters that you are registering or that are registered in Rancher.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kubeconfig_from_imported_cluster.yml`)

--- a/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs.md
+++ b/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs.md
@@ -2,6 +2,10 @@
 title: User ID Tracking in Audit Logs
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs"/>
+</head>
+
 The following audit logs are used in Rancher to track events occuring on the local and downstream clusters:
 
 * [Kubernetes Audit Logs](https://rancher.com/docs/rke/latest/en/config-options/audit-log/)

--- a/versioned_docs/version-2.7/troubleshooting/general-troubleshooting.md
+++ b/versioned_docs/version-2.7/troubleshooting/general-troubleshooting.md
@@ -2,6 +2,10 @@
 title: General Troubleshooting
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/general-troubleshooting"/>
+</head>
+
 This section contains information to help you troubleshoot issues when using Rancher.
 
 - [Kubernetes components](../pages-for-subheaders/kubernetes-components.md)

--- a/versioned_docs/version-2.7/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.md
+++ b/versioned_docs/version-2.7/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.md
@@ -2,6 +2,10 @@
 title: Troubleshooting Controlplane Nodes
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes"/>
+</head>
+
 This section applies to nodes with the `controlplane` role.
 
 ## Check if the Controlplane Containers are Running

--- a/versioned_docs/version-2.7/troubleshooting/kubernetes-components/troubleshooting-etcd-nodes.md
+++ b/versioned_docs/version-2.7/troubleshooting/kubernetes-components/troubleshooting-etcd-nodes.md
@@ -2,6 +2,10 @@
 title: Troubleshooting etcd Nodes
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-etcd-nodes"/>
+</head>
+
 This section contains commands and tips for troubleshooting nodes with the `etcd` role.
 
 

--- a/versioned_docs/version-2.7/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
+++ b/versioned_docs/version-2.7/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
@@ -2,6 +2,10 @@
 title: Troubleshooting nginx-proxy
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy"/>
+</head>
+
 The `nginx-proxy` container is deployed on every node that does not have the `controlplane` role. It provides access to all the nodes with the `controlplane` role by dynamically generating the NGINX configuration based on available nodes with the `controlplane` role.
 
 ## Check if the Container is Running

--- a/versioned_docs/version-2.7/troubleshooting/kubernetes-components/troubleshooting-worker-nodes-and-generic-components.md
+++ b/versioned_docs/version-2.7/troubleshooting/kubernetes-components/troubleshooting-worker-nodes-and-generic-components.md
@@ -2,6 +2,10 @@
 title: Troubleshooting Worker Nodes and Generic Components
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-worker-nodes-and-generic-components"/>
+</head>
+
 This section applies to every node as it includes components that run on nodes with any role.
 
 ## Check if the Containers are Running

--- a/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/dns.md
+++ b/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/dns.md
@@ -2,6 +2,10 @@
 title: DNS
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/dns"/>
+</head>
+
 The commands/steps listed on this page can be used to check name resolution issues in your cluster.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.

--- a/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/expired-webhook-certificate-rotation.md
+++ b/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/expired-webhook-certificate-rotation.md
@@ -2,6 +2,10 @@
 title: Rotation of Expired Webhook Certificates
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/expired-webhook-certificate-rotation"/>
+</head>
+
 For Rancher versions that have `rancher-webhook` installed, certain versions created certificates that will expire after one year. It will be necessary for you to rotate your webhook certificate if the certificate did not renew.
 
 In Rancher v2.6.3 and up, rancher-webhook deployments will automatically renew their TLS certificate when it is within 30 or fewer days of its expiration date. If you are using v2.6.2 or below, there are two methods to work around this issue:

--- a/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/kubernetes-resources.md
+++ b/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/kubernetes-resources.md
@@ -2,6 +2,10 @@
 title: Kubernetes Resources
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/kubernetes-resources"/>
+</head>
+
 The commands/steps listed on this page can be used to check the most important Kubernetes resources and apply to [Rancher Launched Kubernetes](../../pages-for-subheaders/launch-kubernetes-with-rancher.md) clusters.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.

--- a/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/logging.md
+++ b/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/logging.md
@@ -2,6 +2,10 @@
 title: Logging
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/logging"/>
+</head>
+
 ## Log levels
 
 The following log levels are used in Rancher:

--- a/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/networking.md
+++ b/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/networking.md
@@ -2,6 +2,10 @@
 title: Networking
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/networking"/>
+</head>
+
 The commands/steps listed on this page can be used to check networking related issues in your cluster.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.

--- a/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/rancher-ha.md
+++ b/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/rancher-ha.md
@@ -2,6 +2,10 @@
 title: Rancher HA
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/rancher-ha"/>
+</head>
+
 The commands/steps listed on this page can be used to check your Rancher Kubernetes Installation.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml`).

--- a/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/registered-clusters.md
+++ b/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/registered-clusters.md
@@ -2,6 +2,10 @@
 title: Registered Clusters
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/registered-clusters"/>
+</head>
+
 The commands/steps listed on this page can be used to check clusters that you are registering or that are registered in Rancher.
 
 Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kubeconfig_from_imported_cluster.yml`)

--- a/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs.md
+++ b/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs.md
@@ -2,6 +2,10 @@
 title: User ID Tracking in Audit Logs
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs"/>
+</head>
+
 The following audit logs are used in Rancher to track events occuring on the local and downstream clusters:
 
 * [Kubernetes Audit Logs](https://rancher.com/docs/rke/latest/en/config-options/audit-log/)


### PR DESCRIPTION
This picks up where we left off on #420, which adds canonical links to pages. The remaining sections are much smaller than the how-to guides.