### PR TITLE
#420 Canonical links for smaller directories

### DIFF
--- a/docs/cluster-provisioning/rke-clusters/options/options.md
+++ b/docs/cluster-provisioning/rke-clusters/options/options.md
@@ -2,4 +2,8 @@
 title: RKE Cluster Configuration
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration"/>
+</head>
+
 This page has moved [here.](../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md)

--- a/docs/contribute-to-rancher.md
+++ b/docs/contribute-to-rancher.md
@@ -2,6 +2,10 @@
 title: Contributing to Rancher
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/contribute-to-rancher"/>
+</head>
+
 Learn about the repositories used for Rancher and Rancher docs, how to build Rancher repositories, and what information to include when you file an issue.
 
 For more detailed information on how to contribute to the development of Rancher projects, refer to the [Rancher Developer Wiki](https://github.com/rancher/rancher/wiki). The wiki has resources on many topics, including the following:

--- a/docs/rancher-manager.md
+++ b/docs/rancher-manager.md
@@ -4,6 +4,11 @@ title: "What is Rancher?"
 sidebar_label: What is Rancher?
 description: "Rancher adds significant value on top of Kubernetes: managing hundreds of clusters from one interface, centralizing RBAC, enabling monitoring and alerting. Read more."
 ---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com"/>
+</head>
+
 Rancher is a Kubernetes management tool to deploy and run clusters anywhere and on any provider.
 
 Rancher can provision Kubernetes from a hosted provider, provision compute nodes and then install Kubernetes onto them, or import existing Kubernetes clusters running anywhere.

--- a/docs/security/security-scan/security-scan.md
+++ b/docs/security/security-scan/security-scan.md
@@ -2,4 +2,8 @@
 title: Security Scans
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scan-guides"/>
+</head>
+
 The documentation about CIS security scans has moved [here.](../../pages-for-subheaders/cis-scan-guides.md)

--- a/versioned_docs/version-2.0-2.4/contribute-to-rancher.md
+++ b/versioned_docs/version-2.0-2.4/contribute-to-rancher.md
@@ -2,6 +2,10 @@
 title: Contributing to Rancher
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/contribute-to-rancher"/>
+</head>
+
 Learn about the repositories used for Rancher and Rancher docs, how to build Rancher repositories, and what information to include when you file an issue.
 
 For more detailed information on how to contribute to the development of Rancher projects, refer to the [Rancher Developer Wiki](https://github.com/rancher/rancher/wiki). The wiki has resources on many topics, including the following:

--- a/versioned_docs/version-2.0-2.4/security/security-scan/security-scan.md
+++ b/versioned_docs/version-2.0-2.4/security/security-scan/security-scan.md
@@ -2,4 +2,8 @@
 title: Security Scans
 ---
 
-The documentation about CIS security scans has moved [here.](cis-scans)
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scan-guides"/>
+</head>
+
+The documentation about CIS security scans has moved [here.](../../pages-for-subheaders/cis-scan-guides.md)

--- a/versioned_docs/version-2.5/contribute-to-rancher.md
+++ b/versioned_docs/version-2.5/contribute-to-rancher.md
@@ -2,6 +2,10 @@
 title: Contributing to Rancher
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/contribute-to-rancher"/>
+</head>
+
 Learn about the repositories used for Rancher and Rancher docs, how to build Rancher repositories, and what information to include when you file an issue.
 
 For more detailed information on how to contribute to the development of Rancher projects, refer to the [Rancher Developer Wiki](https://github.com/rancher/rancher/wiki). The wiki has resources on many topics, including the following:

--- a/versioned_docs/version-2.5/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md
+++ b/versioned_docs/version-2.5/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md
@@ -2,6 +2,10 @@
 title: RKE Cluster Configuration
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration"/>
+</head>
+
 In [clusters launched by RKE](../../../pages-for-subheaders/launch-kubernetes-with-rancher.md), you can edit any of the remaining options that follow.
 
 - [Configuration Options in the Rancher UI](#configuration-options-in-the-rancher-ui)

--- a/versioned_docs/version-2.5/security/security-scan/security-scan.md
+++ b/versioned_docs/version-2.5/security/security-scan/security-scan.md
@@ -2,4 +2,8 @@
 title: Security Scans
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scan-guides"/>
+</head>
+
 The documentation about CIS security scans has moved [here.](../../pages-for-subheaders/cis-scan-guides.md)

--- a/versioned_docs/version-2.6/cluster-provisioning/rke-clusters/options/options.md
+++ b/versioned_docs/version-2.6/cluster-provisioning/rke-clusters/options/options.md
@@ -2,4 +2,8 @@
 title: RKE Cluster Configuration
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration"/>
+</head>
+
 This page has moved [here.](../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md)

--- a/versioned_docs/version-2.6/contribute-to-rancher.md
+++ b/versioned_docs/version-2.6/contribute-to-rancher.md
@@ -2,6 +2,10 @@
 title: Contributing to Rancher
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/contribute-to-rancher"/>
+</head>
+
 Learn about the repositories used for Rancher and Rancher docs, how to build Rancher repositories, and what information to include when you file an issue.
 
 For more detailed information on how to contribute to the development of Rancher projects, refer to the [Rancher Developer Wiki](https://github.com/rancher/rancher/wiki). The wiki has resources on many topics, including the following:

--- a/versioned_docs/version-2.6/rancher-manager.md
+++ b/versioned_docs/version-2.6/rancher-manager.md
@@ -4,6 +4,11 @@ title: "What is Rancher?"
 sidebar_label: What is Rancher?
 description: "Rancher adds significant value on top of Kubernetes: managing hundreds of clusters from one interface, centralizing RBAC, enabling monitoring and alerting. Read more."
 ---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com"/>
+</head>
+
 Rancher is a Kubernetes management tool to deploy and run clusters anywhere and on any provider.
 
 Rancher can provision Kubernetes from a hosted provider, provision compute nodes and then install Kubernetes onto them, or import existing Kubernetes clusters running anywhere.

--- a/versioned_docs/version-2.6/security/security-scan/security-scan.md
+++ b/versioned_docs/version-2.6/security/security-scan/security-scan.md
@@ -2,4 +2,8 @@
 title: Security Scans
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scan-guides"/>
+</head>
+
 The documentation about CIS security scans has moved [here.](../../pages-for-subheaders/cis-scan-guides.md)

--- a/versioned_docs/version-2.7/cluster-provisioning/rke-clusters/options/options.md
+++ b/versioned_docs/version-2.7/cluster-provisioning/rke-clusters/options/options.md
@@ -2,4 +2,8 @@
 title: RKE Cluster Configuration
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration"/>
+</head>
+
 This page has moved [here.](../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md)

--- a/versioned_docs/version-2.7/contribute-to-rancher.md
+++ b/versioned_docs/version-2.7/contribute-to-rancher.md
@@ -2,6 +2,10 @@
 title: Contributing to Rancher
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/contribute-to-rancher"/>
+</head>
+
 Learn about the repositories used for Rancher and Rancher docs, how to build Rancher repositories, and what information to include when you file an issue.
 
 For more detailed information on how to contribute to the development of Rancher projects, refer to the [Rancher Developer Wiki](https://github.com/rancher/rancher/wiki). The wiki has resources on many topics, including the following:

--- a/versioned_docs/version-2.7/rancher-manager.md
+++ b/versioned_docs/version-2.7/rancher-manager.md
@@ -4,6 +4,11 @@ title: "What is Rancher?"
 sidebar_label: What is Rancher?
 description: "Rancher adds significant value on top of Kubernetes: managing hundreds of clusters from one interface, centralizing RBAC, enabling monitoring and alerting. Read more."
 ---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com"/>
+</head>
+ 
 Rancher is a Kubernetes management tool to deploy and run clusters anywhere and on any provider.
 
 Rancher can provision Kubernetes from a hosted provider, provision compute nodes and then install Kubernetes onto them, or import existing Kubernetes clusters running anywhere.

--- a/versioned_docs/version-2.7/security/security-scan/security-scan.md
+++ b/versioned_docs/version-2.7/security/security-scan/security-scan.md
@@ -2,4 +2,8 @@
 title: Security Scans
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scan-guides"/>
+</head>
+
 The documentation about CIS security scans has moved [here.](../../pages-for-subheaders/cis-scan-guides.md)


### PR DESCRIPTION
This adds canonical links for smaller directories and pages that are in the upper level of /docs. I'm doing it this way because there's a shared_files folder we want to avoid granting canonical links to, and running the script on the /docs directory after all other, larger directories have been addressed, would hit that folder