### PR TITLE
sync v2.7 page with #797 Update k3s-hardening-guide based on CIS-1.24 and CIS-1.7

### DIFF
--- a/docs/pages-for-subheaders/k3s-hardening-guide.md
+++ b/docs/pages-for-subheaders/k3s-hardening-guide.md
@@ -21,7 +21,7 @@ This hardening guide is intended to be used for K3s clusters and is associated w
 | Rancher v2.7    | Benchmark v1.7        | Kubernetes v1.25 up to v1.26 |
 
 :::note
-- In Benchmark v1.7, the `--protect-kernel-defaults` (4.2.6) parameter isn't required anymore, and was removed by CIS.
+In Benchmark v1.7, the `--protect-kernel-defaults` (4.2.6) parameter isn't required anymore, and was removed by CIS.
 :::
 
 For more details on how to evaluate a hardened K3s cluster against the official CIS benchmark, refer to the K3s self-assessment guides for specific Kubernetes and CIS benchmark versions.

--- a/versioned_docs/version-2.7/pages-for-subheaders/k3s-hardening-guide.md
+++ b/versioned_docs/version-2.7/pages-for-subheaders/k3s-hardening-guide.md
@@ -16,10 +16,12 @@ This hardening guide is intended to be used for K3s clusters and is associated w
 
 | Rancher Version | CIS Benchmark Version | Kubernetes Version           |
 |-----------------|-----------------------|------------------------------|
-| Rancher v2.7    | Benchmark v1.23       | Kubernetes v1.23 up to v1.25 |
+| Rancher v2.7    | Benchmark v1.23       | Kubernetes v1.23             |
+| Rancher v2.7    | Benchmark v1.24       | Kubernetes v1.24             |
+| Rancher v2.7    | Benchmark v1.7        | Kubernetes v1.25 up to v1.26 |
 
 :::note
-At the time of writing, the upstream CIS Kubernetes v1.25 benchmark is not yet available in Rancher. At this time Rancher is using the CIS v1.23 benchmark when scanning Kubernetes v1.25 clusters.
+In Benchmark v1.7, the `--protect-kernel-defaults` (4.2.6) parameter isn't required anymore, and was removed by CIS.
 :::
 
 For more details on how to evaluate a hardened K3s cluster against the official CIS benchmark, refer to the K3s self-assessment guides for specific Kubernetes and CIS benchmark versions.
@@ -37,6 +39,14 @@ The first section (1.1) of the CIS Benchmark primarily focuses on  pod manifest 
 
 ### Ensure `protect-kernel-defaults` is set
 
+<Tabs groupId="k3s-version">
+<TabItem value="v1.25 and Newer" default>
+
+The `protect-kernel-defaults` is no longer required since CIS benchmark 1.7.
+
+</TabItem>
+<TabItem value="v1.24 and Older">
+
 This is a kubelet flag that will cause the kubelet to exit if the required kernel parameters are unset or are set to values that are different from the kubelet's defaults.
 
 The `protect-kernel-defaults` flag can be set in the cluster configuration in Rancher.
@@ -48,6 +58,9 @@ spec:
       - config:
           protect-kernel-defaults: true
 ```
+
+</TabItem>
+</Tabs>
 
 ### Set kernel parameters
 
@@ -721,7 +734,6 @@ spec:
       - config:
           kubelet-arg:
             - make-iptables-util-chains=true                          # CIS 4.2.7
-          protect-kernel-defaults: true                               # CIS 4.2.6
 ```
 
 </TabItem>


### PR DESCRIPTION
We need to update the versioned page to reflect changes in docs. This also removes a small typo.