### PR TITLE
#420 Canonical links for reference guides subfolders,  api and backup restore

### DIFF
--- a/docs/reference-guides/about-the-api/api-tokens.md
+++ b/docs/reference-guides/about-the-api/api-tokens.md
@@ -2,6 +2,10 @@
 title: API Tokens
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/about-the-api/api-tokens"/>
+</head>
+
 By default, some cluster-level API tokens are generated with infinite time-to-live (`ttl=0`). In other words, API tokens with `ttl=0` never expire unless you invalidate them. Tokens are not invalidated by changing a password.
 
 You can deactivate API tokens by deleting them or by deactivating the user account.

--- a/docs/reference-guides/backup-restore-configuration/backup-configuration.md
+++ b/docs/reference-guides/backup-restore-configuration/backup-configuration.md
@@ -2,6 +2,10 @@
 title: Backup Configuration
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/backup-restore-configuration/backup-configuration"/>
+</head>
+
 The Backup Create page lets you configure a schedule, enable encryption and specify the storage location for your backups.
 
 

--- a/docs/reference-guides/backup-restore-configuration/examples.md
+++ b/docs/reference-guides/backup-restore-configuration/examples.md
@@ -2,6 +2,10 @@
 title: Examples
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/backup-restore-configuration/examples"/>
+</head>
+
 This section contains examples of Backup and Restore custom resources.
 
 The default backup storage location is configured when the `rancher-backup` operator is installed or upgraded.

--- a/docs/reference-guides/backup-restore-configuration/restore-configuration.md
+++ b/docs/reference-guides/backup-restore-configuration/restore-configuration.md
@@ -2,6 +2,10 @@
 title: Restore Configuration
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/backup-restore-configuration/restore-configuration"/>
+</head>
+
 The Restore Create page lets you provide details of the backup to restore from
 
 ![](/img/backup_restore/restore/restore.png)

--- a/docs/reference-guides/backup-restore-configuration/storage-configuration.md
+++ b/docs/reference-guides/backup-restore-configuration/storage-configuration.md
@@ -2,6 +2,10 @@
 title: Backup Storage Location Configuration
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/backup-restore-configuration/storage-configuration"/>
+</head>
+
 Configure a storage location where all backups are saved by default. You will have the option to override this with each backup, but will be limited to using an S3-compatible object store.
 
 Only one storage location can be configured at the operator level.

--- a/versioned_docs/version-2.0-2.4/reference-guides/about-the-api/api-tokens.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/about-the-api/api-tokens.md
@@ -2,6 +2,10 @@
 title: API Tokens
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/about-the-api/api-tokens"/>
+</head>
+
 By default, some cluster-level API tokens are generated with infinite time-to-live (`ttl=0`). In other words, API tokens with `ttl=0` never expire unless you invalidate them. Tokens are not invalidated by changing a password.
 
 You can deactivate API tokens by deleting them or by deactivating the user account.

--- a/versioned_docs/version-2.5/reference-guides/about-the-api/api-tokens.md
+++ b/versioned_docs/version-2.5/reference-guides/about-the-api/api-tokens.md
@@ -2,6 +2,10 @@
 title: API Tokens
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/about-the-api/api-tokens"/>
+</head>
+
 By default, some cluster-level API tokens are generated with infinite time-to-live (`ttl=0`). In other words, API tokens with `ttl=0` never expire unless you invalidate them. Tokens are not invalidated by changing a password.
 
 You can deactivate API tokens by deleting them or by deactivating the user account.

--- a/versioned_docs/version-2.5/reference-guides/backup-restore-configuration/backup-configuration.md
+++ b/versioned_docs/version-2.5/reference-guides/backup-restore-configuration/backup-configuration.md
@@ -2,6 +2,10 @@
 title: Backup Configuration
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/backup-restore-configuration/backup-configuration"/>
+</head>
+
 The Backup Create page lets you configure a schedule, enable encryption and specify the storage location for your backups.
 
 ![](/img/backup_restore/backup/backup.png)

--- a/versioned_docs/version-2.5/reference-guides/backup-restore-configuration/examples.md
+++ b/versioned_docs/version-2.5/reference-guides/backup-restore-configuration/examples.md
@@ -2,6 +2,10 @@
 title: Examples
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/backup-restore-configuration/examples"/>
+</head>
+
 This section contains examples of Backup and Restore custom resources.
 
 The default backup storage location is configured when the `rancher-backup` operator is installed or upgraded.

--- a/versioned_docs/version-2.5/reference-guides/backup-restore-configuration/restore-configuration.md
+++ b/versioned_docs/version-2.5/reference-guides/backup-restore-configuration/restore-configuration.md
@@ -2,6 +2,10 @@
 title: Restore Configuration
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/backup-restore-configuration/restore-configuration"/>
+</head>
+
 The Restore Create page lets you provide details of the backup to restore from
 
 ![](/img/backup_restore/restore/restore.png)

--- a/versioned_docs/version-2.5/reference-guides/backup-restore-configuration/storage-configuration.md
+++ b/versioned_docs/version-2.5/reference-guides/backup-restore-configuration/storage-configuration.md
@@ -2,6 +2,10 @@
 title: Backup Storage Location Configuration
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/backup-restore-configuration/storage-configuration"/>
+</head>
+
 Configure a storage location where all backups are saved by default. You will have the option to override this with each backup, but will be limited to using an S3-compatible object store.
 
 Only one storage location can be configured at the operator level.

--- a/versioned_docs/version-2.6/reference-guides/about-the-api/api-tokens.md
+++ b/versioned_docs/version-2.6/reference-guides/about-the-api/api-tokens.md
@@ -2,6 +2,10 @@
 title: API Tokens
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/about-the-api/api-tokens"/>
+</head>
+
 By default, some cluster-level API tokens are generated with infinite time-to-live (`ttl=0`). In other words, API tokens with `ttl=0` never expire unless you invalidate them. Tokens are not invalidated by changing a password.
 
 You can deactivate API tokens by deleting them or by deactivating the user account.

--- a/versioned_docs/version-2.6/reference-guides/backup-restore-configuration/backup-configuration.md
+++ b/versioned_docs/version-2.6/reference-guides/backup-restore-configuration/backup-configuration.md
@@ -2,6 +2,10 @@
 title: Backup Configuration
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/backup-restore-configuration/backup-configuration"/>
+</head>
+
 The Backup Create page lets you configure a schedule, enable encryption and specify the storage location for your backups.
 
 

--- a/versioned_docs/version-2.6/reference-guides/backup-restore-configuration/examples.md
+++ b/versioned_docs/version-2.6/reference-guides/backup-restore-configuration/examples.md
@@ -2,6 +2,10 @@
 title: Examples
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/backup-restore-configuration/examples"/>
+</head>
+
 This section contains examples of Backup and Restore custom resources.
 
 The default backup storage location is configured when the `rancher-backup` operator is installed or upgraded.

--- a/versioned_docs/version-2.6/reference-guides/backup-restore-configuration/restore-configuration.md
+++ b/versioned_docs/version-2.6/reference-guides/backup-restore-configuration/restore-configuration.md
@@ -2,6 +2,10 @@
 title: Restore Configuration
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/backup-restore-configuration/restore-configuration"/>
+</head>
+
 The Restore Create page lets you provide details of the backup to restore from
 
 ![](/img/backup_restore/restore/restore.png)

--- a/versioned_docs/version-2.6/reference-guides/backup-restore-configuration/storage-configuration.md
+++ b/versioned_docs/version-2.6/reference-guides/backup-restore-configuration/storage-configuration.md
@@ -2,6 +2,10 @@
 title: Backup Storage Location Configuration
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/backup-restore-configuration/storage-configuration"/>
+</head>
+
 Configure a storage location where all backups are saved by default. You will have the option to override this with each backup, but will be limited to using an S3-compatible object store.
 
 Only one storage location can be configured at the operator level.

--- a/versioned_docs/version-2.7/reference-guides/about-the-api/api-tokens.md
+++ b/versioned_docs/version-2.7/reference-guides/about-the-api/api-tokens.md
@@ -2,6 +2,10 @@
 title: API Tokens
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/about-the-api/api-tokens"/>
+</head>
+
 By default, some cluster-level API tokens are generated with infinite time-to-live (`ttl=0`). In other words, API tokens with `ttl=0` never expire unless you invalidate them. Tokens are not invalidated by changing a password.
 
 You can deactivate API tokens by deleting them or by deactivating the user account.

--- a/versioned_docs/version-2.7/reference-guides/backup-restore-configuration/backup-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/backup-restore-configuration/backup-configuration.md
@@ -2,6 +2,10 @@
 title: Backup Configuration
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/backup-restore-configuration/backup-configuration"/>
+</head>
+
 The Backup Create page lets you configure a schedule, enable encryption and specify the storage location for your backups.
 
 

--- a/versioned_docs/version-2.7/reference-guides/backup-restore-configuration/examples.md
+++ b/versioned_docs/version-2.7/reference-guides/backup-restore-configuration/examples.md
@@ -2,6 +2,10 @@
 title: Examples
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/backup-restore-configuration/examples"/>
+</head>
+
 This section contains examples of Backup and Restore custom resources.
 
 The default backup storage location is configured when the `rancher-backup` operator is installed or upgraded.

--- a/versioned_docs/version-2.7/reference-guides/backup-restore-configuration/restore-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/backup-restore-configuration/restore-configuration.md
@@ -2,6 +2,10 @@
 title: Restore Configuration
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/backup-restore-configuration/restore-configuration"/>
+</head>
+
 The Restore Create page lets you provide details of the backup to restore from
 
 ![](/img/backup_restore/restore/restore.png)

--- a/versioned_docs/version-2.7/reference-guides/backup-restore-configuration/storage-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/backup-restore-configuration/storage-configuration.md
@@ -2,6 +2,10 @@
 title: Backup Storage Location Configuration
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com//reference-guides/backup-restore-configuration/storage-configuration"/>
+</head>
+
 Configure a storage location where all backups are saved by default. You will have the option to override this with each backup, but will be limited to using an S3-compatible object store.
 
 Only one storage location can be configured at the operator level.


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

#420

## Description

Adds canonical links to two of the smaller folders in the reference guide

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->