### PR TITLE
[Backport 2.7] Add cattle-cluster-agent trace/debug logs

### DIFF
--- a/docs/troubleshooting/other-troubleshooting-tips/logging.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/logging.md
@@ -89,7 +89,7 @@ When you create a cluster under **Cluster Configuration > Agent Environment Vars
 
 - Trace-level logging: Set `CATTLE_TRACE` or `RANCHER_TRACE` to `true`
 
--  Debug-level logging: Set `CATTLE_DEBUG` or `RANCHER_DEUBG` to `true`
+- Debug-level logging: Set `CATTLE_DEBUG` or `RANCHER_DEUBG` to `true`
 
 :::caution
 

--- a/docs/troubleshooting/other-troubleshooting-tips/logging.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/logging.md
@@ -82,7 +82,7 @@ Just like the `trace` log level above, `rancher-machine` debug logs can contain 
 
 ## Cattle-cluster-agent debug logs
 
-The `cattle-cluster-agent` log levels can be set when you initialize the downstream clusters.
+The `cattle-cluster-agent` log levels can be set when you initialize downstream clusters.
 
 When you create a cluster under **Cluster Configuration > Agent Environment Vars** you can set variables to define the log level.
 

--- a/docs/troubleshooting/other-troubleshooting-tips/logging.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/logging.md
@@ -78,3 +78,21 @@ possible to enable debug logs in `rancher-machine` when provisioning RKE1, RKE2 
 Just like the `trace` log level above, `rancher-machine` debug logs can contain sensitive information.
 
 :::
+
+
+## Cattle-cluster-agent debug logs
+
+The `cattle-cluster-agent` log levels can be set when you initialize the downstream clusters.
+
+When you create a cluster under **Cluster Configuration > Agent Environment Vars** you can set variables to define the log level.
+
+
+- Trace-level logging: Set `CATTLE_TRACE` or `RANCHER_TRACE` to `true`
+
+-  Debug-level logging: Set `CATTLE_DEBUG` or `RANCHER_DEUBG` to `true`
+
+:::caution
+
+The `cattle-cluster-agent` debug logs may contain sensitive information.
+
+:::

--- a/docs/troubleshooting/other-troubleshooting-tips/logging.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/logging.md
@@ -86,7 +86,6 @@ The `cattle-cluster-agent` log levels can be set when you initialize downstream 
 
 When you create a cluster under **Cluster Configuration > Agent Environment Vars** you can set variables to define the log level.
 
-
 - Trace-level logging: Set `CATTLE_TRACE` or `RANCHER_TRACE` to `true`
 
 - Debug-level logging: Set `CATTLE_DEBUG` or `RANCHER_DEUBG` to `true`

--- a/docs/troubleshooting/other-troubleshooting-tips/logging.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/logging.md
@@ -85,7 +85,6 @@ Just like the `trace` log level above, `rancher-machine` debug logs can contain 
 The `cattle-cluster-agent` log levels can be set when you initialize downstream clusters.
 
 When you create a cluster under **Cluster Configuration > Agent Environment Vars** you can set variables to define the log level.
-
 - Trace-level logging: Set `CATTLE_TRACE` or `RANCHER_TRACE` to `true`
 
 - Debug-level logging: Set `CATTLE_DEBUG` or `RANCHER_DEUBG` to `true`


### PR DESCRIPTION
This PR Was created to Replace #842.


<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

**Fixes**: There is no issue that this fix.

It adds documentation for the fix created on this issue: https://github.com/rancher/rancher/issues/42241


## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

Add to the logs doc the possibility of using Environment Variables to get logs out of the cattle-cluster-agent. 

