### PR TITLE
Typo fix: deubg > debug, capitalization

### DIFF
--- a/docs/troubleshooting/other-troubleshooting-tips/logging.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/logging.md
@@ -6,7 +6,7 @@ title: Logging
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/logging"/>
 </head>
 
-## Log levels
+## Log Levels
 
 The following log levels are used in Rancher:
 
@@ -16,9 +16,9 @@ The following log levels are used in Rancher:
 | `debug` | Logs more detailed messages that can be used to debug. |
 | `trace` | Logs very detailed messages on internal functions. This is very verbose and can contain sensitive information. |
 
-### How to configure a log level
+### How to Configure a Log Level
 
-#### Kubernetes install
+#### Kubernetes Install
 
 * Configure debug log level
 
@@ -58,7 +58,7 @@ $ docker exec -ti <container_id> loglevel --set info
 OK
 ```
 
-## Rancher machine debug logs
+## Rancher Machine Debug Logs
 If you need to troubleshoot the creation of objects in your infrastructure provider of choice, `rancher-machine`
 debug logs might be helpful to you.
 
@@ -80,14 +80,14 @@ Just like the `trace` log level above, `rancher-machine` debug logs can contain 
 :::
 
 
-## Cattle-cluster-agent debug logs
+## Cattle-cluster-agent Debug Logs
 
 The `cattle-cluster-agent` log levels can be set when you initialize downstream clusters.
 
 When you create a cluster under **Cluster Configuration > Agent Environment Vars** you can set variables to define the log level.
 - Trace-level logging: Set `CATTLE_TRACE` or `RANCHER_TRACE` to `true`
 
-- Debug-level logging: Set `CATTLE_DEBUG` or `RANCHER_DEUBG` to `true`
+- Debug-level logging: Set `CATTLE_DEBUG` or `RANCHER_DEBUG` to `true`
 
 :::caution
 

--- a/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/logging.md
+++ b/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/logging.md
@@ -6,7 +6,7 @@ title: Logging
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/logging"/>
 </head>
 
-## Log levels
+## Log Levels
 
 The following log levels are used in Rancher:
 
@@ -16,9 +16,9 @@ The following log levels are used in Rancher:
 | `debug` | Logs more detailed messages that can be used to debug. |
 | `trace` | Logs very detailed messages on internal functions. This is very verbose and can contain sensitive information. |
 
-### How to configure a log level
+### How to Configure a Log Level
 
-#### Kubernetes install
+#### Kubernetes Install
 
 * Configure debug log level
 
@@ -58,7 +58,7 @@ $ docker exec -ti <container_id> loglevel --set info
 OK
 ```
 
-## Rancher machine debug logs
+## Rancher Machine Debug Logs
 If you need to troubleshoot the creation of objects in your infrastructure provider of choice, `rancher-machine`
 debug logs might be helpful to you.
 
@@ -80,14 +80,14 @@ Just like the `trace` log level above, `rancher-machine` debug logs can contain 
 :::
 
 
-## Cattle-cluster-agent debug logs
+## Cattle-cluster-agent Debug Logs
 
 The `cattle-cluster-agent` log levels can be set when you initialize downstream clusters.
 
 When you create a cluster under **Cluster Configuration > Agent Environment Vars** you can set variables to define the log level.
 - Trace-level logging: Set `CATTLE_TRACE` or `RANCHER_TRACE` to `true`
 
-- Debug-level logging: Set `CATTLE_DEBUG` or `RANCHER_DEUBG` to `true`
+- Debug-level logging: Set `CATTLE_DEBUG` or `RANCHER_DEBUG` to `true`
 
 :::caution
 


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

Addresses a Slack request:

> hey docs team a customer called out in slack a typo:
https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/logging    has RANCHER_DEUBG instead of RANCHER_DEBUG

Also updates capitalization of headings to be consistent with rest of docset

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->