### PR TITLE
Add EKS Anywhere and EKS Anywhere on Bare Metal as clusters than can be registered

### DIFF
--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -35,7 +35,7 @@ Since, by default, Google Kubernetes Engine (GKE) doesn't grant the `cluster-adm
 
 To successfully import or provision EKS, AKS, and GKE clusters from Rancher, the cluster must have at least one managed node group. 
 
-EKS-Anywhere, and EKS Anywhere on Bare Metal clusters can be imported into Rancher with an API address and credentials, as with any downstream cluster. 
+EKS Anywhere, and EKS Anywhere on Bare Metal clusters can be imported into Rancher with an API address and credentials, as with any downstream cluster. 
 
 GKE Autopilot clusters aren't supported. See [Compare GKE Autopilot and Standard](https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison) for more information about the differences between GKE modes.
 

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -31,7 +31,7 @@ kubectl create clusterrolebinding cluster-admin-binding \
 
 Since, by default, Google Kubernetes Engine (GKE) doesn't grant the `cluster-admin` role, you must run these commands on GKE clusters before you can register them. To learn more about role-based access control for GKE, please see [the official Google documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
 
-### Elastic Kubernetes Service (EKS), EKS-Anywhere, EKS Anywhere on Bare Metal, Azure Kubernetes Service (AKS), and Google Kubernetes Engine (GKE)  
+### Elastic Kubernetes Service (EKS), EKS Anywhere, EKS Anywhere on Bare Metal, Azure Kubernetes Service (AKS), and Google Kubernetes Engine (GKE)  
 
 To successfully import or provision EKS, AKS, and GKE clusters from Rancher, the cluster must have at least one managed node group. 
 

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -31,9 +31,9 @@ kubectl create clusterrolebinding cluster-admin-binding \
 
 Since, by default, Google Kubernetes Engine (GKE) doesn't grant the `cluster-admin` role, you must run these commands on GKE clusters before you can register them. To learn more about role-based access control for GKE, please see [the official Google documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
 
-### EKS, AKS and GKE Clusters
+### Elastic Kubernetes Service (EKS), EKS-Anywhere, EKS Anywhere on Bare Metal, Azure Kubernetes Service (AKS), and Google Kubernetes Engine (GKE)  
 
-To successfully import them into or provision them from Rancher, Elastic Kubernetes Service (EKS), Azure Kubernetes Service (AKS), and Google Kubernetes Engine (GKE) clusters must have at least one managed node group. In addition, GKE Autopilot clusters aren't supported. See [Compare GKE Autopilot and Standard](https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison) for more information about the difference between GKE modes.
+To successfully import or provision EKS, AKS, and GKE Clusters from Rancher, the cluster must have at least one managed node group. EKS-Anywhere, and EKS Anywhere on Bare Metal clusters can be imported into Rancher with an API address and credentials, as with any downstream cluster. In addition, GKE Autopilot clusters aren't supported. See [Compare GKE Autopilot and Standard](https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison) for more information about the difference between GKE modes.
 
 ## Registering a Cluster
 

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -33,7 +33,11 @@ Since, by default, Google Kubernetes Engine (GKE) doesn't grant the `cluster-adm
 
 ### Elastic Kubernetes Service (EKS), EKS-Anywhere, EKS Anywhere on Bare Metal, Azure Kubernetes Service (AKS), and Google Kubernetes Engine (GKE)  
 
-To successfully import or provision EKS, AKS, and GKE Clusters from Rancher, the cluster must have at least one managed node group. EKS-Anywhere, and EKS Anywhere on Bare Metal clusters can be imported into Rancher with an API address and credentials, as with any downstream cluster. In addition, GKE Autopilot clusters aren't supported. See [Compare GKE Autopilot and Standard](https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison) for more information about the difference between GKE modes.
+To successfully import or provision EKS, AKS, and GKE clusters from Rancher, the cluster must have at least one managed node group. 
+
+EKS-Anywhere, and EKS Anywhere on Bare Metal clusters can be imported into Rancher with an API address and credentials, as with any downstream cluster. 
+
+GKE Autopilot clusters aren't supported. See [Compare GKE Autopilot and Standard](https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison) for more information about the differences between GKE modes.
 
 ## Registering a Cluster
 

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -31,7 +31,7 @@ kubectl create clusterrolebinding cluster-admin-binding \
 
 Since, by default, Google Kubernetes Engine (GKE) doesn't grant the `cluster-admin` role, you must run these commands on GKE clusters before you can register them. To learn more about role-based access control for GKE, please see [the official Google documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
 
-### Elastic Kubernetes Service (EKS), EKS-Anywhere, EKS Anywhere on Bare Metal, Azure Kubernetes Service (AKS), and Google Kubernetes Engine (GKE)  
+### Elastic Kubernetes Service (EKS), EKS Anywhere, EKS Anywhere on Bare Metal, Azure Kubernetes Service (AKS), and Google Kubernetes Engine (GKE)  
 
 To successfully import or provision EKS, AKS, and GKE clusters from Rancher, the cluster must have at least one managed node group. 
 

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -31,9 +31,13 @@ kubectl create clusterrolebinding cluster-admin-binding \
 
 Since, by default, Google Kubernetes Engine (GKE) doesn't grant the `cluster-admin` role, you must run these commands on GKE clusters before you can register them. To learn more about role-based access control for GKE, please see [the official Google documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
 
-### EKS, AKS and GKE Clusters
+### Elastic Kubernetes Service (EKS), EKS-Anywhere, EKS Anywhere on Bare Metal, Azure Kubernetes Service (AKS), and Google Kubernetes Engine (GKE)  
 
-To successfully import them into or provision them from Rancher, Elastic Kubernetes Service (EKS), Azure Kubernetes Service (AKS), and Google Kubernetes Engine (GKE) clusters must have at least one managed node group. In addition, GKE Autopilot clusters aren't supported. See [Compare GKE Autopilot and Standard](https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison) for more information about the difference between GKE modes.
+To successfully import or provision EKS, AKS, and GKE clusters from Rancher, the cluster must have at least one managed node group. 
+
+EKS Anywhere, and EKS Anywhere on Bare Metal clusters can be imported into Rancher with an API address and credentials, as with any downstream cluster. 
+
+GKE Autopilot clusters aren't supported. See [Compare GKE Autopilot and Standard](https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison) for more information about the differences between GKE modes.
 
 ## Registering a Cluster
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -31,7 +31,7 @@ kubectl create clusterrolebinding cluster-admin-binding \
 
 Since, by default, Google Kubernetes Engine (GKE) doesn't grant the `cluster-admin` role, you must run these commands on GKE clusters before you can register them. To learn more about role-based access control for GKE, please see [the official Google documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
 
-### Elastic Kubernetes Service (EKS), EKS-Anywhere, EKS Anywhere on Bare Metal, Azure Kubernetes Service (AKS), and Google Kubernetes Engine (GKE)  
+### Elastic Kubernetes Service (EKS), EKS Anywhere, EKS Anywhere on Bare Metal, Azure Kubernetes Service (AKS), and Google Kubernetes Engine (GKE)  
 
 To successfully import or provision EKS, AKS, and GKE clusters from Rancher, the cluster must have at least one managed node group. 
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -31,9 +31,13 @@ kubectl create clusterrolebinding cluster-admin-binding \
 
 Since, by default, Google Kubernetes Engine (GKE) doesn't grant the `cluster-admin` role, you must run these commands on GKE clusters before you can register them. To learn more about role-based access control for GKE, please see [the official Google documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
 
-### EKS, AKS and GKE Clusters
+### Elastic Kubernetes Service (EKS), EKS-Anywhere, EKS Anywhere on Bare Metal, Azure Kubernetes Service (AKS), and Google Kubernetes Engine (GKE)  
 
-To successfully import them into or provision them from Rancher, Elastic Kubernetes Service (EKS), Azure Kubernetes Service (AKS), and Google Kubernetes Engine (GKE) clusters must have at least one managed node group. In addition, GKE Autopilot clusters aren't supported. See [Compare GKE Autopilot and Standard](https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison) for more information about the difference between GKE modes.
+To successfully import or provision EKS, AKS, and GKE clusters from Rancher, the cluster must have at least one managed node group. 
+
+EKS Anywhere, and EKS Anywhere on Bare Metal clusters can be imported into Rancher with an API address and credentials, as with any downstream cluster. 
+
+GKE Autopilot clusters aren't supported. See [Compare GKE Autopilot and Standard](https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison) for more information about the differences between GKE modes.
 
 ## Registering a Cluster
 


### PR DESCRIPTION
Add EKS Anywhere and EKS Anywhere on Bare Metal specifically to satisfy AWS EKS-A Service Ready Designation

<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #[issue_number]

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- Add EKS Anywhere and EKS Anywhere on Bare Metal specifically to satisfy AWS EKS-A Service Ready Designation
- What did you change? 
- Add EKS Anywhere and EKS Anywhere on Bare Metal specifically to satisfy AWS EKS-A Service Ready Designation
- Are there any other pull requests, tickets, or issues associated with this pull request? 
- No
-->

## Comments

<!--
We have tested and been qualified by AWS, importing both EKS-A and EKS-A Bare Metal clusters. 
-->