### PR TITLE
add a new method for enabling the API audit log in RKE2 downstream clusters

### DIFF
--- a/docs/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
+++ b/docs/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
@@ -48,7 +48,7 @@ This feature is available in Rancher v2.7.2 and later.
 
 You can use `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and `machineGlobalConfig` to set the options on kube-apiserver.
 
-As a prerequisite, you must create a [secret](../new-user-guides/kubernetes-resources-setup/secrets.md) or [configmap](../new-user-guides/kubernetes-resources-setup/secrets.md) to be the source of the audit policy.
+As a prerequisite, you must create a [secret](../new-user-guides/kubernetes-resources-setup/secrets.md) or [configmap](../new-user-guides/kubernetes-resources-setup/configmaps.md) to be the source of the audit policy.
 
 The secret or configmap must meet the following requirements:
 
@@ -123,7 +123,7 @@ This feature is available in Rancher v2.7.2 and later.
 
 You can use `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and `machineGlobalConfig` to set the options on kube-apiserver.
 
-As a prerequisite, you must create a [secret](../new-user-guides/kubernetes-resources-setup/secrets.md) or [configmap](../new-user-guides/kubernetes-resources-setup/secrets.md) to be the source of the audit policy.
+As a prerequisite, you must create a [secret](../new-user-guides/kubernetes-resources-setup/secrets.md) or [configmap](../new-user-guides/kubernetes-resources-setup/configmaps.md) to be the source of the audit policy.
 
 The secret or configmap must meet the following requirements:
 
@@ -132,7 +132,7 @@ The secret or configmap must meet the following requirements:
 
 :::tip
 
-Rancher Dashboard provides an easy-to-use form for creating the secret or configmap.
+Rancher Dashboard provides an easy-to-use form for creating the [secret](../new-user-guides/kubernetes-resources-setup/secrets.md) or [configmap](../new-user-guides/kubernetes-resources-setup/configmaps.md).
 
 :::
 

--- a/docs/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
+++ b/docs/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
@@ -18,7 +18,7 @@ For configuration details, refer to the [official Kubernetes documentation](http
 
 ### Method 1 (Recommended): Set `audit-policy-file` in `machineGlobalConfig`
 
-You can set `audit-policy-file` the configuration, Rancher delivers the file to target nodes, and sets the proper options in the RKE2 server.
+You can set `audit-policy-file` in the configuration file. Rancher delivers the file to target nodes, and sets the proper options in the RKE2 server.
 
 Example:
 ```yaml
@@ -46,9 +46,9 @@ This feature is available in Rancher v2.7.2 and later.
 
 :::
 
-You can use the `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and the `machineGlobalConfig` to set the options on kube-apiserver.
+You can use `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and `machineGlobalConfig` to set the options on kube-apiserver.
 
-As a prerequisite, you must create a secret or configmap to be the source of the audit policy.
+As a prerequisite, you must create a [secret](../new-user-guides/kubernetes-resources-setup/secrets.md) or [configmap](../new-user-guides/kubernetes-resources-setup/secrets.md) to be the source of the audit policy.
 
 The secret or configmap must meet the following requirements:
 
@@ -76,7 +76,7 @@ metadata:
   namespace: fleet-default
 ```
 
-The audit log can be enabled and configured by editing the cluster in YAML and utilizing the `machineSelectorFiles` and `machineGlobalConfig` directives.
+Enable and configure the audit log by editing the cluster in YAML, and utilizing the `machineSelectorFiles` and `machineGlobalConfig` directives.
 
 Example:
 
@@ -105,11 +105,11 @@ spec:
 
 :::tip
 
-Alternatively, you can use the directive `machineSelectorConfig` with proper machineLabelSelectors to achieve the same effect.
+You can also use the directive `machineSelectorConfig` with proper machineLabelSelectors to achieve the same effect.
 
 :::
 
-For more information about cluster configuration, refer to the RKE2 cluster configuration reference pages.
+For more information about cluster configuration, refer to the [RKE2 cluster configuration reference](../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md) pages.
 
 </TabItem>
 
@@ -121,9 +121,9 @@ This feature is available in Rancher v2.7.2 and later.
 
 :::
 
-You can use the `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and the `machineGlobalConfig` to set the options on kube-apiserver.
+You can use `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and `machineGlobalConfig` to set the options on kube-apiserver.
 
-As a prerequisite, you must create a secret or configmap to be the source of the audit policy.
+As a prerequisite, you must create a [secret](../new-user-guides/kubernetes-resources-setup/secrets.md) or [configmap](../new-user-guides/kubernetes-resources-setup/secrets.md) to be the source of the audit policy.
 
 The secret or configmap must meet the following requirements:
 
@@ -151,7 +151,7 @@ metadata:
   namespace: fleet-default
 ```
 
-The audit log can be enabled and configured by editing the cluster in YAML and utilizing the `machineSelectorFiles` and `machineGlobalConfig` directives.
+Enable and configure the audit log by editing the cluster in YAML, and utilizing the `machineSelectorFiles` and `machineGlobalConfig` directives.
 
 Example:
 
@@ -180,11 +180,11 @@ spec:
 
 :::tip
 
-Alternatively, you can use the directive `machineSelectorConfig` with proper machineLabelSelectors to achieve the same effect.
+You can also use the directive `machineSelectorConfig` with proper machineLabelSelectors to achieve the same effect.
 
 :::
 
-For more information about cluster configuration, refer to the K3s cluster configuration reference pages.
+For more information about cluster configuration, refer to the [K3s cluster configuration reference](../../reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md) pages.
 
 </TabItem>
 

--- a/docs/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
+++ b/docs/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
@@ -16,10 +16,9 @@ For configuration details, refer to the [official Kubernetes documentation](http
 <Tabs groupId="k8s-distro">
 <TabItem value="RKE2" default>
 
-### Method 1: set the `audit-policy-file` option in `machineGlobalConfig`
+### Method 1 (Recommended): Set `audit-policy-file` in `machineGlobalConfig`
 
-Unlike in the upstream RKE2 where the value of the `audit-policy-file` option is expected to be the path to the audit policy file,
-in Rancher you can set the `audit-policy-file` option with the content, and Rancher will convert it to a file and configure RKE2 server options.
+You can set `audit-policy-file` the configuration, Rancher delivers the file to target nodes, and sets the proper options in the RKE2 server.
 
 Example:
 ```yaml
@@ -39,22 +38,22 @@ spec:
             - pods
 ```
 
-### Method 2: Use the directives `machineSelectorFiles` and `machineGlobalConfig`
+### Method 2: Use the Directives, `machineSelectorFiles` and `machineGlobalConfig`
 
 :::note
 
-This feature is available in Rancher v2.7.2 and above.
+This feature is available in Rancher v2.7.2 and later.
 
 :::
 
-You can utilize the `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and the `machineGlobalConfig` to set the options on kube-apiserver.
+You can use the `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and the `machineGlobalConfig` to set the options on kube-apiserver.
 
-As a prerequisite, you need to create a secret or configmap which will be the source of the audit policy.
+As a prerequisite, you must create a secret or configmap to be the source of the audit policy.
 
-The secret or configmap must meet the following two requirements:
+The secret or configmap must meet the following requirements:
 
 1. It must be in the `fleet-default` namespace where the Cluster object exists.
-2. It must have the annotation `rke.cattle.io/object-authorized-for-clusters: cluster-name1,cluster-name2` which permits the target clusters to use it.
+2. It must have the annotation `rke.cattle.io/object-authorized-for-clusters: <cluster-name1>,<cluster-name2>` which permits the target clusters to use it.
 
 :::tip
 
@@ -73,7 +72,7 @@ kind: Secret
 metadata:
   annotations:
     rke.cattle.io/object-authorized-for-clusters: cluster1
-  name: name1
+  name: <name1>
   namespace: fleet-default
 ```
 
@@ -114,22 +113,22 @@ For more information about cluster configuration, refer to the RKE2 cluster conf
 
 </TabItem>
 
-<TabItem value="K3s" default>
+<TabItem value="K3s">
 
 :::note
 
-This feature is available in Rancher v2.7.2 and above.
+This feature is available in Rancher v2.7.2 and later.
 
 :::
 
-You can utilize the `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and the `machineGlobalConfig` to set the options on kube-apiserver.
+You can use the `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and the `machineGlobalConfig` to set the options on kube-apiserver.
 
-As a prerequisite, you need to create a secret or configmap which will be the source of the audit policy.
+As a prerequisite, you must create a secret or configmap to be the source of the audit policy.
 
-The secret or configmap must meet the following two requirements:
+The secret or configmap must meet the following requirements:
 
 1. It must be in the `fleet-default` namespace where the Cluster object exists.
-2. It must have the annotation `rke.cattle.io/object-authorized-for-clusters: cluster-name1,cluster-name2` which permits the target clusters to use it.
+2. It must have the annotation `rke.cattle.io/object-authorized-for-clusters: <cluster-name1>,<cluster-name2>` which permits the target clusters to use it.
 
 :::tip
 
@@ -148,7 +147,7 @@ kind: Secret
 metadata:
   annotations:
     rke.cattle.io/object-authorized-for-clusters: cluster1
-  name: name1
+  name: <name1>
   namespace: fleet-default
 ```
 

--- a/docs/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
+++ b/docs/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
@@ -18,7 +18,7 @@ For configuration details, refer to the [official Kubernetes documentation](http
 
 ### Method 1 (Recommended): Set `audit-policy-file` in `machineGlobalConfig`
 
-You can set `audit-policy-file` in the configuration file. Rancher delivers the file to target nodes, and sets the proper options in the RKE2 server.
+You can set `audit-policy-file` in the configuration file. Rancher delivers the file to the path `/var/lib/rancher/rke2/etc/config-files/audit-policy-file` in control plane nodes, and sets the proper options in the RKE2 server.
 
 Example:
 ```yaml

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
@@ -48,7 +48,7 @@ This feature is available in Rancher v2.7.2 and later.
 
 You can use `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and `machineGlobalConfig` to set the options on kube-apiserver.
 
-As a prerequisite, you must create a [secret](../new-user-guides/kubernetes-resources-setup/secrets.md) or [configmap](../new-user-guides/kubernetes-resources-setup/secrets.md) to be the source of the audit policy.
+As a prerequisite, you must create a [secret](../new-user-guides/kubernetes-resources-setup/secrets.md) or [configmap](../new-user-guides/kubernetes-resources-setup/configmaps.md) to be the source of the audit policy.
 
 The secret or configmap must meet the following requirements:
 
@@ -123,7 +123,7 @@ This feature is available in Rancher v2.7.2 and later.
 
 You can use `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and `machineGlobalConfig` to set the options on kube-apiserver.
 
-As a prerequisite, you must create a [secret](../new-user-guides/kubernetes-resources-setup/secrets.md) or [configmap](../new-user-guides/kubernetes-resources-setup/secrets.md) to be the source of the audit policy.
+As a prerequisite, you must create a [secret](../new-user-guides/kubernetes-resources-setup/secrets.md) or [configmap](../new-user-guides/kubernetes-resources-setup/configmaps.md) to be the source of the audit policy.
 
 The secret or configmap must meet the following requirements:
 
@@ -132,7 +132,7 @@ The secret or configmap must meet the following requirements:
 
 :::tip
 
-Rancher Dashboard provides an easy-to-use form for creating the secret or configmap.
+Rancher Dashboard provides an easy-to-use form for creating the [secret](../new-user-guides/kubernetes-resources-setup/secrets.md) or [configmap](../new-user-guides/kubernetes-resources-setup/configmaps.md).
 
 :::
 

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
@@ -18,7 +18,7 @@ For configuration details, refer to the [official Kubernetes documentation](http
 
 ### Method 1 (Recommended): Set `audit-policy-file` in `machineGlobalConfig`
 
-You can set `audit-policy-file` the configuration, Rancher delivers the file to target nodes, and sets the proper options in the RKE2 server.
+You can set `audit-policy-file` in the configuration file. Rancher delivers the file to target nodes, and sets the proper options in the RKE2 server.
 
 Example:
 ```yaml
@@ -46,9 +46,9 @@ This feature is available in Rancher v2.7.2 and later.
 
 :::
 
-You can use the `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and the `machineGlobalConfig` to set the options on kube-apiserver.
+You can use `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and `machineGlobalConfig` to set the options on kube-apiserver.
 
-As a prerequisite, you must create a secret or configmap to be the source of the audit policy.
+As a prerequisite, you must create a [secret](../new-user-guides/kubernetes-resources-setup/secrets.md) or [configmap](../new-user-guides/kubernetes-resources-setup/secrets.md) to be the source of the audit policy.
 
 The secret or configmap must meet the following requirements:
 
@@ -76,7 +76,7 @@ metadata:
   namespace: fleet-default
 ```
 
-The audit log can be enabled and configured by editing the cluster in YAML and utilizing the `machineSelectorFiles` and `machineGlobalConfig` directives.
+Enable and configure the audit log by editing the cluster in YAML, and utilizing the `machineSelectorFiles` and `machineGlobalConfig` directives.
 
 Example:
 
@@ -105,11 +105,11 @@ spec:
 
 :::tip
 
-Alternatively, you can use the directive `machineSelectorConfig` with proper machineLabelSelectors to achieve the same effect.
+You can also use the directive `machineSelectorConfig` with proper machineLabelSelectors to achieve the same effect.
 
 :::
 
-For more information about cluster configuration, refer to the RKE2 cluster configuration reference pages.
+For more information about cluster configuration, refer to the [RKE2 cluster configuration reference](../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md) pages.
 
 </TabItem>
 
@@ -121,9 +121,9 @@ This feature is available in Rancher v2.7.2 and later.
 
 :::
 
-You can use the `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and the `machineGlobalConfig` to set the options on kube-apiserver.
+You can use `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and `machineGlobalConfig` to set the options on kube-apiserver.
 
-As a prerequisite, you must create a secret or configmap to be the source of the audit policy.
+As a prerequisite, you must create a [secret](../new-user-guides/kubernetes-resources-setup/secrets.md) or [configmap](../new-user-guides/kubernetes-resources-setup/secrets.md) to be the source of the audit policy.
 
 The secret or configmap must meet the following requirements:
 
@@ -151,7 +151,7 @@ metadata:
   namespace: fleet-default
 ```
 
-The audit log can be enabled and configured by editing the cluster in YAML and utilizing the `machineSelectorFiles` and `machineGlobalConfig` directives.
+Enable and configure the audit log by editing the cluster in YAML, and utilizing the `machineSelectorFiles` and `machineGlobalConfig` directives.
 
 Example:
 
@@ -180,11 +180,11 @@ spec:
 
 :::tip
 
-Alternatively, you can use the directive `machineSelectorConfig` with proper machineLabelSelectors to achieve the same effect.
+You can also use the directive `machineSelectorConfig` with proper machineLabelSelectors to achieve the same effect.
 
 :::
 
-For more information about cluster configuration, refer to the K3s cluster configuration reference pages.
+For more information about cluster configuration, refer to the [K3s cluster configuration reference](../../reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md) pages.
 
 </TabItem>
 

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
@@ -14,13 +14,40 @@ For configuration details, refer to the [official Kubernetes documentation](http
 
 
 <Tabs groupId="k8s-distro">
-<TabItem value="RKE2/K3s" default>
+<TabItem value="RKE2" default>
+
+### Method 1: set the `audit-policy-file` option in `machineGlobalConfig`
+
+Unlike in the upstream RKE2 where the value of the `audit-policy-file` option is expected to be the path to the audit policy file, 
+in Rancher you can set the `audit-policy-file` option with the content, and Rancher will convert it to a file and configure RKE2 server options. 
+
+Example:
+```yaml
+apiVersion: provisioning.cattle.io/v1
+kind: Cluster
+spec:
+  rkeConfig:
+    machineGlobalConfig:
+      audit-policy-file: |
+        apiVersion: audit.k8s.io/v1 
+        kind: Policy 
+        rules: 
+        - level: RequestResponse
+          resources:
+          - group: ""
+            resources: 
+            - pods
+```
+
+### Method 2: Use the directives `machineSelectorFiles` and `machineGlobalConfig`
 
 :::note
 
 This feature is available in Rancher v2.7.2 and above.
 
 :::
+
+You can utilize the `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and the `machineGlobalConfig` to set the options on kube-apiserver. 
 
 As a prerequisite, you need to create a secret or configmap which will be the source of the audit policy.
 
@@ -77,7 +104,88 @@ spec:
             rke.cattle.io/control-plane-role: 'true'
 ```
 
-For more information about cluster configuration, refer to the REK2 or K3s cluster configuration reference pages.
+:::tip
+
+Alternatively, you can use the directive `machineSelectorConfig` with proper machineLabelSelectors to achieve the same effect.
+
+:::
+
+For more information about cluster configuration, refer to the RKE2 cluster configuration reference pages.
+
+</TabItem>
+
+<TabItem value="K3s" default>
+
+:::note
+
+This feature is available in Rancher v2.7.2 and above.
+
+:::
+
+You can utilize the `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and the `machineGlobalConfig` to set the options on kube-apiserver.
+
+As a prerequisite, you need to create a secret or configmap which will be the source of the audit policy.
+
+The secret or configmap must meet the following two requirements:
+
+1. It must be in the `fleet-default` namespace where the Cluster object exists.
+2. It must have the annotation `rke.cattle.io/object-authorized-for-clusters: cluster-name1,cluster-name2` which permits the target clusters to use it.
+
+:::tip
+
+Rancher Dashboard provides an easy-to-use form for creating the secret or configmap.
+
+:::
+
+Example:
+
+```yaml
+apiVersion: v1
+data:
+  audit-policy: >-
+    IyBMb2cgYWxsIHJlcXVlc3RzIGF0IHRoZSBNZXRhZGF0YSBsZXZlbC4KYXBpVmVyc2lvbjogYXVkaXQuazhzLmlvL3YxCmtpbmQ6IFBvbGljeQpydWxlczoKLSBsZXZlbDogTWV0YWRhdGE=
+kind: Secret
+metadata:
+  annotations:
+    rke.cattle.io/object-authorized-for-clusters: cluster1
+  name: name1
+  namespace: fleet-default
+```
+
+The audit log can be enabled and configured by editing the cluster in YAML and utilizing the `machineSelectorFiles` and `machineGlobalConfig` directives.
+
+Example:
+
+```yaml
+apiVersion: provisioning.cattle.io/v1
+kind: Cluster
+spec:
+  rkeConfig:
+    machineGlobalConfig:
+      kube-apiserver-arg:
+        - audit-policy-file=<customized-path>/dev-audit-policy.yaml
+        - audit-log-path=<customized-path>/dev-audit.logs
+    machineSelectorFiles:
+      - fileSources:
+          - configMap:
+              name: ''
+            secret:
+              items:
+                - key: audit-policy
+                  path: <customized-path>/dev-audit-policy.yaml
+              name: dev-audit-policy
+        machineLabelSelector:
+          matchLabels:
+            rke.cattle.io/control-plane-role: 'true'
+```
+
+:::tip
+
+Alternatively, you can use the directive `machineSelectorConfig` with proper machineLabelSelectors to achieve the same effect.
+
+:::
+
+For more information about cluster configuration, refer to the K3s cluster configuration reference pages.
 
 </TabItem>
 

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
@@ -16,10 +16,9 @@ For configuration details, refer to the [official Kubernetes documentation](http
 <Tabs groupId="k8s-distro">
 <TabItem value="RKE2" default>
 
-### Method 1: set the `audit-policy-file` option in `machineGlobalConfig`
+### Method 1 (Recommended): Set `audit-policy-file` in `machineGlobalConfig`
 
-Unlike in the upstream RKE2 where the value of the `audit-policy-file` option is expected to be the path to the audit policy file, 
-in Rancher you can set the `audit-policy-file` option with the content, and Rancher will convert it to a file and configure RKE2 server options. 
+You can set `audit-policy-file` the configuration, Rancher delivers the file to target nodes, and sets the proper options in the RKE2 server.
 
 Example:
 ```yaml
@@ -39,22 +38,22 @@ spec:
             - pods
 ```
 
-### Method 2: Use the directives `machineSelectorFiles` and `machineGlobalConfig`
+### Method 2: Use the Directives, `machineSelectorFiles` and `machineGlobalConfig`
 
 :::note
 
-This feature is available in Rancher v2.7.2 and above.
+This feature is available in Rancher v2.7.2 and later.
 
 :::
 
-You can utilize the `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and the `machineGlobalConfig` to set the options on kube-apiserver. 
+You can use the `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and the `machineGlobalConfig` to set the options on kube-apiserver.
 
-As a prerequisite, you need to create a secret or configmap which will be the source of the audit policy.
+As a prerequisite, you must create a secret or configmap to be the source of the audit policy.
 
-The secret or configmap must meet the following two requirements:
+The secret or configmap must meet the following requirements:
 
 1. It must be in the `fleet-default` namespace where the Cluster object exists.
-2. It must have the annotation `rke.cattle.io/object-authorized-for-clusters: cluster-name1,cluster-name2` which permits the target clusters to use it.
+2. It must have the annotation `rke.cattle.io/object-authorized-for-clusters: <cluster-name1>,<cluster-name2>` which permits the target clusters to use it.
 
 :::tip
 
@@ -73,7 +72,7 @@ kind: Secret
 metadata:
   annotations:
     rke.cattle.io/object-authorized-for-clusters: cluster1
-  name: name1
+  name: <name1>
   namespace: fleet-default
 ```
 
@@ -114,22 +113,22 @@ For more information about cluster configuration, refer to the RKE2 cluster conf
 
 </TabItem>
 
-<TabItem value="K3s" default>
+<TabItem value="K3s">
 
 :::note
 
-This feature is available in Rancher v2.7.2 and above.
+This feature is available in Rancher v2.7.2 and later.
 
 :::
 
-You can utilize the `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and the `machineGlobalConfig` to set the options on kube-apiserver.
+You can use the `machineSelectorFiles` to deliver the audit policy file to the control plane nodes, and the `machineGlobalConfig` to set the options on kube-apiserver.
 
-As a prerequisite, you need to create a secret or configmap which will be the source of the audit policy.
+As a prerequisite, you must create a secret or configmap to be the source of the audit policy.
 
-The secret or configmap must meet the following two requirements:
+The secret or configmap must meet the following requirements:
 
 1. It must be in the `fleet-default` namespace where the Cluster object exists.
-2. It must have the annotation `rke.cattle.io/object-authorized-for-clusters: cluster-name1,cluster-name2` which permits the target clusters to use it.
+2. It must have the annotation `rke.cattle.io/object-authorized-for-clusters: <cluster-name1>,<cluster-name2>` which permits the target clusters to use it.
 
 :::tip
 
@@ -148,7 +147,7 @@ kind: Secret
 metadata:
   annotations:
     rke.cattle.io/object-authorized-for-clusters: cluster1
-  name: name1
+  name: <name1>
   namespace: fleet-default
 ```
 

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters.md
@@ -18,7 +18,7 @@ For configuration details, refer to the [official Kubernetes documentation](http
 
 ### Method 1 (Recommended): Set `audit-policy-file` in `machineGlobalConfig`
 
-You can set `audit-policy-file` in the configuration file. Rancher delivers the file to target nodes, and sets the proper options in the RKE2 server.
+You can set `audit-policy-file` in the configuration file. Rancher delivers the file to the path `/var/lib/rancher/rke2/etc/config-files/audit-policy-file` in control plane nodes, and sets the proper options in the RKE2 server.
 
 Example:
 ```yaml


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->
 
https://github.com/rancher/rancher/issues/32784
https://github.com/rancher/rancher-docs/issues/825

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

This PR is a follow-up for the above two issues, and it is to add a 2nd method for enabling the API audit log in RKE2 downstream clusters. 

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->

This is not a new feature; in fact, the method has been available since Rancher v2.6.0; however, there is a lack of documentation.

For the same reason, the target branch is `main`.

The same changes are made to two revisions of the same file. Please review one of them. 