### PR TITLE
call out the options that Rancher handles differently with the upstream RKE2 and K3s

### DIFF
--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
@@ -336,7 +336,7 @@ To make it easier to put files on nodes beforehand, Rancher expects the followin
 - private-registry
 - flannel-conf
 
-Rancher delivers the files to target nodes, and sets the proper options in the K3s server.
+Rancher delivers the files to the path `/var/lib/rancher/k3s/etc/config-files/<option>` in target nodes, and sets the proper options in the K3s server.
 
 Example:
 ```yaml

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
@@ -318,6 +318,7 @@ chartValues:
     chart-name:
         key: value
 ```
+
 ### machineGlobalConfig
 
 Specify K3s configurations. Any configuration change made here will apply to every node. The configuration options available in the [standalone version of k3s](https://docs.k3s.io/cli/server) can be applied here.
@@ -329,6 +330,31 @@ machineGlobalConfig:
     etcd-arg:
         - key1=value1
         - key2=value2
+```
+
+To ease the need to put files on nodes beforehand, Rancher expects the values of the following options to be the configuration's content,unlike K3s, where the values should be file paths:
+- private-registry
+- flannel-conf
+
+Rancher will deliver the files to target nodes, and set the proper options in the K3s Server. 
+
+Example:
+```yaml
+apiVersion: provisioning.cattle.io/v1
+kind: Cluster
+spec:
+  rkeConfig:
+    machineGlobalConfig:
+      private-registry: |
+        mirrors:
+          docker.io:
+            endpoint:
+              - "http://mycustomreg.com:5000"
+        configs:
+          "mycustomreg:5000":
+            auth:
+              username: xxxxxx # this is the registry username
+              password: xxxxxx # this is the registry password
 ```
 
 ### machineSelectorConfig
@@ -354,6 +380,7 @@ machineSelectorConfig
         key1: value1
         key2: value2
 ```
+
 ### machineSelectorFiles
 
 :::note

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
@@ -332,11 +332,11 @@ machineGlobalConfig:
         - key2=value2
 ```
 
-To ease the need to put files on nodes beforehand, Rancher expects the values of the following options to be the configuration's content,unlike K3s, where the values should be file paths:
+To make it easier to put files on nodes beforehand, Rancher expects the following values to be included in the configuration, while K3s expects the values to be entered as file paths:
 - private-registry
 - flannel-conf
 
-Rancher will deliver the files to target nodes, and set the proper options in the K3s Server. 
+Rancher delivers the files to target nodes, and sets the proper options in the K3s server.
 
 Example:
 ```yaml

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -367,7 +367,7 @@ To make it easier to put files on nodes beforehand, Rancher expects the followin
 - cloud-provider-config
 - private-registry
 
-Rancher delivers the files to target nodes, and sets the proper options in the RKE2 server.
+Rancher delivers the files to the path `/var/lib/rancher/rke2/etc/config-files/<option>` in target nodes, and sets the proper options in the RKE2 server.
 
 Example:
 ```yaml

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -362,12 +362,12 @@ machineGlobalConfig:
         - key2=value2
 ```
 
-To ease the need to put files on nodes beforehand, Rancher expects the values of the following options to be the configuration's content, unlike RKE2, where the values should be file paths:
+To make it easier to put files on nodes beforehand, Rancher expects the following values to be included in the configuration, while RKE2 expects the values to be entered as file paths:
 - audit-policy-file
 - cloud-provider-config
 - private-registry
 
-Rancher will deliver the files to target nodes, and set the proper options in the RKE2 Server.
+Rancher delivers the files to target nodes, and sets the proper options in the RKE2 server.
 
 Example:
 ```yaml
@@ -467,7 +467,7 @@ machineSelectorFiles:
 The secret or configmap must meet the following requirements:
 
 1. It must be in the `fleet-default` namespace where the Cluster object exists.
-2. It must have the annotation `rke.cattle.io/object-authorized-for-clusters: cluster-name1,cluster-name2`, which permits the target clusters to use it.  
+2. It must have the annotation `rke.cattle.io/object-authorized-for-clusters: cluster-name1,cluster-name2`, which permits the target clusters to use it.
 
 :::tip
 

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -348,6 +348,7 @@ chartValues:
     chart-name:
         key: value
 ```
+
 ### machineGlobalConfig
 
 Specify RKE2 configurations. Any configuration change made here will apply to every node. The configuration options available in the [standalone version of RKE2](https://docs.rke2.io/reference/server_config) can be applied here.
@@ -359,6 +360,31 @@ machineGlobalConfig:
     etcd-arg:
         - key1=value1
         - key2=value2
+```
+
+To ease the need to put files on nodes beforehand, Rancher expects the values of the following options to be the configuration's content, unlike RKE2, where the values should be file paths:
+- audit-policy-file
+- cloud-provider-config
+- private-registry
+
+Rancher will deliver the files to target nodes, and set the proper options in the RKE2 Server.
+
+Example:
+```yaml
+apiVersion: provisioning.cattle.io/v1
+kind: Cluster
+spec:
+  rkeConfig:
+    machineGlobalConfig:
+      audit-policy-file: 
+        apiVersion: audit.k8s.io/v1 
+        kind: Policy 
+        rules: 
+        - level: RequestResponse
+          resources:
+          - group: ""
+            resources: 
+            - pods
 ```
 
 ### machineSelectorConfig
@@ -384,6 +410,7 @@ machineSelectorConfig
         key1: value1
         key2: value2
 ```
+
 ### machineSelectorFiles
 
 :::note

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
@@ -318,6 +318,7 @@ chartValues:
     chart-name:
         key: value
 ```
+
 ### machineGlobalConfig
 
 Specify K3s configurations. Any configuration change made here will apply to every node. The configuration options available in the [standalone version of k3s](https://docs.k3s.io/cli/server) can be applied here.
@@ -331,11 +332,11 @@ machineGlobalConfig:
         - key2=value2
 ```
 
-To ease the need to put files on nodes beforehand, Rancher expects the values of the following options to be the configuration's content,unlike K3s, where the values should be file paths:
+To make it easier to put files on nodes beforehand, Rancher expects the following values to be included in the configuration, while K3s expects the values to be entered as file paths:
 - private-registry
 - flannel-conf
 
-Rancher will deliver the files to target nodes, and set the proper options in the K3s Server.
+Rancher delivers the files to target nodes, and sets the proper options in the K3s server.
 
 Example:
 ```yaml
@@ -379,6 +380,7 @@ machineSelectorConfig
         key1: value1
         key2: value2
 ```
+
 ### machineSelectorFiles
 
 :::note

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
@@ -331,6 +331,31 @@ machineGlobalConfig:
         - key2=value2
 ```
 
+To ease the need to put files on nodes beforehand, Rancher expects the values of the following options to be the configuration's content,unlike K3s, where the values should be file paths:
+- private-registry
+- flannel-conf
+
+Rancher will deliver the files to target nodes, and set the proper options in the K3s Server.
+
+Example:
+```yaml
+apiVersion: provisioning.cattle.io/v1
+kind: Cluster
+spec:
+  rkeConfig:
+    machineGlobalConfig:
+      private-registry: |
+        mirrors:
+          docker.io:
+            endpoint:
+              - "http://mycustomreg.com:5000"
+        configs:
+          "mycustomreg:5000":
+            auth:
+              username: xxxxxx # this is the registry username
+              password: xxxxxx # this is the registry password
+```
+
 ### machineSelectorConfig
 
 `machineSelectorConfig` is the same as [`machineGlobalConfig`](#machineglobalconfig) except that a [label](#kubernetes-node-labels) selector can be specified with the configuration. The configuration will only be applied to nodes that match the provided label selector.

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
@@ -336,7 +336,7 @@ To make it easier to put files on nodes beforehand, Rancher expects the followin
 - private-registry
 - flannel-conf
 
-Rancher delivers the files to target nodes, and sets the proper options in the K3s server.
+Rancher delivers the files to the path `/var/lib/rancher/k3s/etc/config-files/<option>` in target nodes, and sets the proper options in the K3s server.
 
 Example:
 ```yaml

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -367,7 +367,7 @@ To make it easier to put files on nodes beforehand, Rancher expects the followin
 - cloud-provider-config
 - private-registry
 
-Rancher delivers the files to target nodes, and sets the proper options in the RKE2 server.
+Rancher delivers the files to the path `/var/lib/rancher/rke2/etc/config-files/<option>` in target nodes, and sets the proper options in the RKE2 server.
 
 Example:
 ```yaml

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -362,6 +362,31 @@ machineGlobalConfig:
         - key2=value2
 ```
 
+To make it easier to put files on nodes beforehand, Rancher expects the following values to be included in the configuration, while RKE2 expects the values to be entered as file paths:
+- audit-policy-file
+- cloud-provider-config
+- private-registry
+
+Rancher delivers the files to target nodes, and sets the proper options in the RKE2 server.
+
+Example:
+```yaml
+apiVersion: provisioning.cattle.io/v1
+kind: Cluster
+spec:
+  rkeConfig:
+    machineGlobalConfig:
+      audit-policy-file: 
+        apiVersion: audit.k8s.io/v1 
+        kind: Policy 
+        rules: 
+        - level: RequestResponse
+          resources:
+          - group: ""
+            resources: 
+            - pods
+```
+
 ### machineSelectorConfig
 
 `machineSelectorConfig` is the same as [`machineGlobalConfig`](#machineglobalconfig) except that a [label](#kubernetes-node-labels) selector can be specified with the configuration. The configuration will only be applied to nodes that match the provided label selector.
@@ -384,31 +409,6 @@ machineSelectorConfig
       matchLabels:
         key1: value1
         key2: value2
-```
-
-To ease the need to put files on nodes beforehand, Rancher expects the values of the following options to be the configuration's content, unlike RKE2, where the values should be file paths:
-- audit-policy-file
-- cloud-provider-config
-- private-registry
-
-Rancher will deliver the files to target nodes, and set the proper options in the RKE2 Server.
-
-Example:
-```yaml
-apiVersion: provisioning.cattle.io/v1
-kind: Cluster
-spec:
-  rkeConfig:
-    machineGlobalConfig:
-      audit-policy-file: 
-        apiVersion: audit.k8s.io/v1 
-        kind: Policy 
-        rules: 
-        - level: RequestResponse
-          resources:
-          - group: ""
-            resources: 
-            - pods
 ```
 
 ### machineSelectorFiles

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -348,6 +348,7 @@ chartValues:
     chart-name:
         key: value
 ```
+
 ### machineGlobalConfig
 
 Specify RKE2 configurations. Any configuration change made here will apply to every node. The configuration options available in the [standalone version of RKE2](https://docs.rke2.io/reference/server_config) can be applied here.
@@ -384,6 +385,32 @@ machineSelectorConfig
         key1: value1
         key2: value2
 ```
+
+To ease the need to put files on nodes beforehand, Rancher expects the values of the following options to be the configuration's content, unlike RKE2, where the values should be file paths:
+- audit-policy-file
+- cloud-provider-config
+- private-registry
+
+Rancher will deliver the files to target nodes, and set the proper options in the RKE2 Server.
+
+Example:
+```yaml
+apiVersion: provisioning.cattle.io/v1
+kind: Cluster
+spec:
+  rkeConfig:
+    machineGlobalConfig:
+      audit-policy-file: 
+        apiVersion: audit.k8s.io/v1 
+        kind: Policy 
+        rules: 
+        - level: RequestResponse
+          resources:
+          - group: ""
+            resources: 
+            - pods
+```
+
 ### machineSelectorFiles
 
 :::note


### PR DESCRIPTION


<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes https://github.com/rancher/rancher-docs/issues/901

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

This PR is to add the missing documentation for the options that Rancher handles differently with the upstream RKE2 and K3s.

The same changes are applied to both the v2.8 and v2.7 lines.  

 

