### PR TITLE
Add 2.7.8 entry to versions table

### DIFF
--- a/src/pages/versions.md
+++ b/src/pages/versions.md
@@ -10,10 +10,10 @@ Below are the documentation and release notes for the currently released version
 
 <table>
   <tr>
-    <td><b>v2.7.7</b></td>
+    <td><b>v2.7.8</b></td>
     <td><a href="https://ranchermanager.docs.rancher.com/v2.7">Documentation</a></td>
-    <td><a href="https://github.com/rancher/rancher/releases/tag/v2.7.7">Release Notes</a></td>
-    <td><a href="https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-7-7/">Support Matrix</a></td>
+    <td><a href="https://github.com/rancher/rancher/releases/tag/v2.7.8">Release Notes</a></td>
+    <td><a href="https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-7-8/">Support Matrix</a></td>
   </tr>
 </table>
 
@@ -33,6 +33,12 @@ Below are the documentation and release notes for the currently released version
 Below are the documentation and release notes for previous versions of Rancher 2.7.x:
 
 <table>
+  <tr>
+    <td><b>v2.7.7</b></td>
+    <td><a href="https://ranchermanager.docs.rancher.com/v2.7">Documentation</a></td>
+    <td><a href="https://github.com/rancher/rancher/releases/tag/v2.7.7">Release Notes</a></td>
+    <td><a href="https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-7-7/">Support Matrix</a></td>
+  </tr>
   <tr>
     <td><b>v2.7.6</b></td>
     <td><a href="https://ranchermanager.docs.rancher.com/v2.7">Documentation</a></td>


### PR DESCRIPTION
## Description

Rancher v2.7.8 was released. Adding an entry to the table so users can go directly to the relevant release notes and support matrix links.