### PR TITLE
Test reducing build memory allocation and including memory setting by default

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build website
         env:
-          NODE_OPTIONS: "--max_old_space_size=6144"
+          NODE_OPTIONS: "--max_old_space_size=3096"
         run: yarn build --no-minify
 
       # Popular action to deploy to GitHub Pages:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -22,5 +22,5 @@ jobs:
         run: yarn run remark --quiet --use remark-validate-links --use remark-lint-no-dead-urls ./docs
       - name: Test build website
         env:
-          NODE_OPTIONS: "--max_old_space_size=6144"
+          NODE_OPTIONS: "--max_old_space_size=3096"
         run: yarn build --no-minify

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "NODE_OPTIONS='--max-old-space-size=3096' docusaurus start",
-    "build": "docusaurus build",
+    "start": "docusaurus start",
+    "build": "NODE_OPTIONS='--max-old-space-size=3096' docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
## Description

Test using a lower memory value for [max-old-space-size](https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes) during builds.

Also updates the `build` script in package.json to set this value by default.

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->