### PR TITLE
Remove 2.8 content that was missed during previous cleanup

### DIFF
--- a/docs/pages-for-subheaders/rancher-security.md
+++ b/docs/pages-for-subheaders/rancher-security.md
@@ -87,7 +87,3 @@ Rancher is committed to informing the community of security issues in our produc
 ### Kubernetes Security Best Practices
 
 For recommendations on securing your Kubernetes cluster, refer to the [Kubernetes Security Best Practices](../reference-guides/rancher-security/kubernetes-security-best-practices.md) guide.
-
-### Rancher Webhook Hardening
-
-The Rancher webhook deploys on both the upstream Rancher cluster and all provisioned clusters. For recommendations on hardening the Rancher webhook, see the [Hardening the Rancher Webhook](../reference-guides/rancher-security/rancher-webhook-hardening.md) guide.


### PR DESCRIPTION
## Description

Some 2.8-specific content is currently showing on latest (/docs), which is intended for 2.7.
