### PR TITLE
Bump max-old-space-size. Some GH action runs still encountering OOM"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build website
         env:
-          NODE_OPTIONS: "--max_old_space_size=3096"
+          NODE_OPTIONS: "--max_old_space_size=4096"
         run: yarn build --no-minify
 
       # Popular action to deploy to GitHub Pages:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -22,5 +22,5 @@ jobs:
         run: yarn run remark --quiet --use remark-validate-links --use remark-lint-no-dead-urls ./docs
       - name: Test build website
         env:
-          NODE_OPTIONS: "--max_old_space_size=3096"
+          NODE_OPTIONS: "--max_old_space_size=4096"
         run: yarn build --no-minify

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "NODE_OPTIONS='--max-old-space-size=3096' docusaurus build",
+    "build": "NODE_OPTIONS='--max-old-space-size=4096' docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
## Description

We've just had our first action run (https://github.com/rancher/rancher-docs/actions/runs/6579478192) hit the out of memory issue during the build phase. We've had many successful builds with the current max-old-space-size, but we should bump it just in case this is not a one-off situation.