### PR TITLE
Add placeholders for Opni and K8s distro landing pages

### DIFF
--- a/versioned_docs/version-2.8/integrations-in-rancher/kubernetes-distributions/kubernetes-distributions.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/kubernetes-distributions/kubernetes-distributions.md
@@ -1,0 +1,7 @@
+---
+title: Kubernetes Distributions
+---
+
+## Kubernetes Distributions with Rancher 
+ 
+## Kubernetes Distributions with Rancher Prime 

--- a/versioned_docs/version-2.8/integrations-in-rancher/opni/opni.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/opni/opni.md
@@ -1,0 +1,7 @@
+---
+title: Observability with Opni
+---
+
+## Opni with Rancher 
+ 
+## Opni with Rancher Prime 

--- a/versioned_sidebars/version-2.8-sidebars.json
+++ b/versioned_sidebars/version-2.8-sidebars.json
@@ -1090,6 +1090,7 @@
         "id": "integrations-in-rancher/integrations-in-rancher"
       },
       "items": [
+        "integrations-in-rancher/kubernetes-distributions/kubernetes-distributions",
         {
           "type": "category",
           "label": "Virtualization on Kubernetes with Harvester",
@@ -1124,6 +1125,7 @@
           ]
         },
         "integrations-in-rancher/kubewarden/kubewarden",
+        "integrations-in-rancher/kubernetes-distributions/kubernetes-distributions",
         "integrations-in-rancher/rancher-desktop",
         {
           "type": "category",


### PR DESCRIPTION
## Description

Adds placeholders for the Kubernetes Distributions and Opni landing pages while waiting for the initial content to be provided. Adding placeholders so the links/tiles on the integrations index page doesn't lead to 404s.