### PR TITLE
Use relative links. Add card for K8s Distros

### DIFF
--- a/versioned_docs/version-2.8/integrations-in-rancher/integrations-in-rancher.mdx
+++ b/versioned_docs/version-2.8/integrations-in-rancher/integrations-in-rancher.mdx
@@ -24,39 +24,43 @@ To learn more and get started with Rancher Prime, please visit [this page](https
     icon={<RocketRegular />}
 >
     <Card
+        title="Kubernetes Distributions"
+        to="./integrations-in-rancher/kubernetes-distributions"
+    />
+    <Card
         title="Virtualization on Kubernetes with Harvester"
-        to="/integrations-in-rancher/harvester"
+        to="./integrations-in-rancher/harvester"
     />
     <Card
         title="Cloud Native Storage with Longhorn"
-        to="/integrations-in-rancher/longhorn"
+        to="./integrations-in-rancher/longhorn"
     />
     <Card
         title="Container Security with NeuVector"
-        to="/integrations-in-rancher/neuvector"
+        to="./integrations-in-rancher/neuvector"
     />
     <Card
         title="Advanced Policy Management with Kubewarden"
-        to="/integrations-in-rancher/kubewarden"
+        to="./integrations-in-rancher/kubewarden"
     />
     <Card
         title="Operating System Management with Elemental"
-        to="/integrations-in-rancher/elemental"
+        to="./integrations-in-rancher/elemental"
     />
     <Card
         title="Observability with Opni"
-        to="/integrations-in-rancher/opni"
+        to="./integrations-in-rancher/opni"
     />
     <Card
         title="Continuous Delivery with Fleet"
-        to="/integrations-in-rancher/fleet"
+        to="./integrations-in-rancher/fleet"
     />
     <Card
         title="Kubernetes on the Desktop"
-        to="/integrations-in-rancher/rancher-desktop"
+        to="./integrations-in-rancher/rancher-desktop"
     />
     <Card
         title="Application Development Engine with Epinio"
-        to="/integrations-in-rancher/epinio"
+        to="./integrations-in-rancher/epinio"
     />
 </CardSection>


### PR DESCRIPTION
## Description

The absolute links on the tiles of the integrations index page currently lead to the page to swap to a different version (latest) of the docs. This switches it to relative links to keep navigation within the same version of docs.