### PR TITLE
Add redirects for dashboard links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -192,6 +192,18 @@ module.exports = {
       {
         fromExtensions: ['html', 'htm'],
         redirects: [
+          { // Redirects for dashboard#9970
+            to: '/v2.8/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/rke1-vs-rke2-differences',
+            from: '/v2.8/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/'
+          },
+          {
+            to: '/v2.7/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/rke1-vs-rke2-differences',
+            from: '/v2.7/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/'
+          },
+          {
+            to: '/v2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/rke1-vs-rke2-differences',
+            from: '/v2.6/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/'
+          }, // Redirects for dashboard#9970 (end)
           { // Redirects for restructure from PR #234 (start)
             to: '/faq/general-faq',
             from: '/faq'


### PR DESCRIPTION
Related to https://github.com/rancher/dashboard/issues/9970.

## Description

The dashboard recently updated the docs link from the previous domain (`rancher.com/docs`) + Hugo URL path format to the new domain + Docusaurus URL path format. In the case [1] mentioned in the linked issue, only the domain got updated but the rest of the URL path is still using the format tied to the previous docs site, which leads to a 404.

Code freeze is in place so the dashboard URL updates will be made at a later time. In the meantime, we're adding redirects on the docs side so the links don't 404.

[1] https://ranchermanager.docs.rancher.com/v2.8/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/

