### PR TITLE
Fix link rendering

### DIFF
--- a/docs/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
+++ b/docs/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
@@ -29,7 +29,6 @@ Rancher provides several different Helm chart repositories to choose from. We al
 | rancher-stable | `helm repo add rancher-stable https://releases.rancher.com/server-charts/stable` | Adds a repository of Helm charts for older, stable versions of Rancher. We recommend using this repo for production environments.                                                                                                                                                          |
 | rancher-alpha  | `helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha`   | Adds a repository of Helm charts for alpha versions of Rancher for previewing upcoming releases. These releases are discouraged in production environments. Upgrades _to_ or _from_ charts in the rancher-alpha repository to any other chart, regardless or repository, aren't supported. |
 
-<br/>
 Instructions on when to select these repos are available below in [Switching to a Different Helm Chart Repository](#switching-to-a-different-helm-chart-repository).
 
 :::note
@@ -40,7 +39,7 @@ All charts in the `rancher-stable` repository will correspond with any Rancher v
 
 ### Helm Chart Versions
 
-Rancher Helm chart versions match the Rancher version (i.e `appVersion`).  Once you've added the repo you can search it to show available versions with the following command:<br/>
+Rancher Helm chart versions match the Rancher version (i.e `appVersion`). Once you've added the repo you can search it to show available versions with the following command:
 &nbsp;&nbsp;&nbsp;&nbsp;`helm search repo --versions`
 
 If you have several repos you can specify the repo name, ie. `helm search repo rancher-stable/rancher --versions` <br/>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,14 +14,14 @@ module.exports = {
   projectName: 'rancher-docs', // Usually your repo name.
   trailingSlash: false,
   i18n: {
-    defaultLocale: "en",
-    locales: ["en", "zh"],
+    defaultLocale: 'en',
+    locales: ['en', 'zh'],
     localeConfigs: {
       en: {
-        label: "English",
+        label: 'English',
       },
       zh: {
-        label: "简体中文",
+        label: '简体中文',
       },
     },
   },
@@ -69,8 +69,8 @@ module.exports = {
       //... other Algolia params
     },
     colorMode: {
-      // "light" | "dark"
-      defaultMode: "light",
+      // 'light' | 'dark'
+      defaultMode: 'light',
 
       // Hides the switch in the navbar
       // Useful if you want to support a single color mode
@@ -80,7 +80,7 @@ module.exports = {
       additionalLanguages: ['rust'],
     },
     navbar: {
-      title: "",
+      title: '',
       logo: {
         alt: 'logo',
         src: 'img/rancher-logo-horiz-color.svg',
@@ -94,12 +94,12 @@ module.exports = {
           dropdownActiveClassDisabled: false,
         },
         {
-          type: "localeDropdown",
-          position: "left",
+          type: 'localeDropdown',
+          position: 'left',
         },
         {
-          type: "search",
-          position: "left",
+          type: 'search',
+          position: 'left',
         },
         {
           type: 'dropdown',
@@ -206,7 +206,7 @@ module.exports = {
         blog: false, // Optional: disable the blog plugin
         // ...
         theme: {
-          customCss: [require.resolve("./src/css/custom.css")],
+          customCss: [require.resolve('./src/css/custom.css')],
         },
         googleTagManager: {
           containerId: 'GTM-57KS2MW',
@@ -1228,61 +1228,61 @@ module.exports = {
             from: '/v2.6/explanations/integrations-in-rancher/opa-gatekeeper'
           }, // Redirects for restructure from PR #234 (end)
           {
-            to: "/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-self-assessment-guide-with-cis-v1.24-k8s-v1.24",
-            from: "/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-self-assessment-guide-with-cis-v1.23-k8s-v1.24"
+            to: '/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-self-assessment-guide-with-cis-v1.24-k8s-v1.24',
+            from: '/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-self-assessment-guide-with-cis-v1.23-k8s-v1.24'
           },
           {
-            to: "/v2.7/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-self-assessment-guide-with-cis-v1.24-k8s-v1.24",
-            from: "/2.7/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-self-assessment-guide-with-cis-v1.23-k8s-v1.24"
+            to: '/v2.7/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-self-assessment-guide-with-cis-v1.24-k8s-v1.24',
+            from: '/2.7/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-self-assessment-guide-with-cis-v1.23-k8s-v1.24'
           },
           {
-            to: "/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-self-assessment-guide-with-cis-v1.7-k8s-v1.25-v1.26-v1.27",
-            from: "/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-self-assessment-guide-with-cis-v1.23-k8s-v1.25"
+            to: '/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-self-assessment-guide-with-cis-v1.7-k8s-v1.25-v1.26-v1.27',
+            from: '/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-self-assessment-guide-with-cis-v1.23-k8s-v1.25'
           },
           {
-            to: "/v2.7/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-self-assessment-guide-with-cis-v1.7-k8s-v1.25-v1.26-v1.27",
-            from: "/v2.7/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-self-assessment-guide-with-cis-v1.23-k8s-v1.25"
+            to: '/v2.7/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-self-assessment-guide-with-cis-v1.7-k8s-v1.25-v1.26-v1.27',
+            from: '/v2.7/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-self-assessment-guide-with-cis-v1.23-k8s-v1.25'
 
           },
           {
-            to: "/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-self-assessment-guide-with-cis-v1.24-k8s-v1.24",
-            from: "/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-self-assessment-guide-with-cis-v1.23-k8s-v1.24"
+            to: '/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-self-assessment-guide-with-cis-v1.24-k8s-v1.24',
+            from: '/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-self-assessment-guide-with-cis-v1.23-k8s-v1.24'
           },
           {
-            to: "/v2.7/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-self-assessment-guide-with-cis-v1.24-k8s-v1.24",
-            from: "/v2.7/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-self-assessment-guide-with-cis-v1.23-k8s-v1.24"
+            to: '/v2.7/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-self-assessment-guide-with-cis-v1.24-k8s-v1.24',
+            from: '/v2.7/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-self-assessment-guide-with-cis-v1.23-k8s-v1.24'
           },
           {
-            to: "/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-self-assessment-guide-with-cis-v1.7-k8s-v1.25-v1.26-v1.27",
-            from: "/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-self-assessment-guide-with-cis-v1.23-k8s-v1.25"
+            to: '/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-self-assessment-guide-with-cis-v1.7-k8s-v1.25-v1.26-v1.27',
+            from: '/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-self-assessment-guide-with-cis-v1.23-k8s-v1.25'
           },
           {
-            to: "/v2.7/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-self-assessment-guide-with-cis-v1.7-k8s-v1.25-v1.26-v1.27",
-            from: "/v2.7/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-self-assessment-guide-with-cis-v1.23-k8s-v1.25"
+            to: '/v2.7/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-self-assessment-guide-with-cis-v1.7-k8s-v1.25-v1.26-v1.27',
+            from: '/v2.7/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-self-assessment-guide-with-cis-v1.23-k8s-v1.25'
           },
           {
-            to: "/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-self-assessment-guide-with-cis-v1.24-k8s-v1.24",
-            from: "/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-self-assessment-guide-with-cis-v1.23-k8s-v1.24"
+            to: '/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-self-assessment-guide-with-cis-v1.24-k8s-v1.24',
+            from: '/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-self-assessment-guide-with-cis-v1.23-k8s-v1.24'
           },
           {
-            to: "/v2.7/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-self-assessment-guide-with-cis-v1.24-k8s-v1.24",
-            from: "/v2.7/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-self-assessment-guide-with-cis-v1.23-k8s-v1.24"
+            to: '/v2.7/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-self-assessment-guide-with-cis-v1.24-k8s-v1.24',
+            from: '/v2.7/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-self-assessment-guide-with-cis-v1.23-k8s-v1.24'
           },
           {
-            to: "/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-self-assessment-guide-with-cis-v1.7-k8s-v1.25-v1.26-v1.27",
-            from: "/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-self-assessment-guide-with-cis-v1.23-k8s-v1.25"
+            to: '/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-self-assessment-guide-with-cis-v1.7-k8s-v1.25-v1.26-v1.27',
+            from: '/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-self-assessment-guide-with-cis-v1.23-k8s-v1.25'
           },
           {
-            to: "/v2.7/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-self-assessment-guide-with-cis-v1.7-k8s-v1.25-v1.26-v1.27",
-            from: "/v2.7/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-self-assessment-guide-with-cis-v1.23-k8s-v1.25"
+            to: '/v2.7/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-self-assessment-guide-with-cis-v1.7-k8s-v1.25-v1.26-v1.27',
+            from: '/v2.7/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-self-assessment-guide-with-cis-v1.23-k8s-v1.25'
           },
           {
-            to: "/reference-guides/best-practices/rancher-server/tuning-and-best-practices-for-rancher-at-scale",
-            from: "/reference-guides/best-practices/rancher-server/tips-for-scaling-rancher"
+            to: '/reference-guides/best-practices/rancher-server/tuning-and-best-practices-for-rancher-at-scale',
+            from: '/reference-guides/best-practices/rancher-server/tips-for-scaling-rancher'
           },
           {
-            to: "/v2.7/reference-guides/best-practices/rancher-server/tuning-and-best-practices-for-rancher-at-scale",
-            from: "/v2.7/reference-guides/best-practices/rancher-server/tips-for-scaling-rancher"
+            to: '/v2.7/reference-guides/best-practices/rancher-server/tuning-and-best-practices-for-rancher-at-scale',
+            from: '/v2.7/reference-guides/best-practices/rancher-server/tips-for-scaling-rancher'
           }
         ],
       },
@@ -1301,6 +1301,5 @@ module.exports = {
       type:'text/javascript',
       async: true
     },
-    // "/scripts/optanonwrapper.js"
   ],
 };

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -88,26 +88,73 @@ module.exports = {
       },
       items: [
         {
-            type: "localeDropdown",
-            position: "right",
-        },
-        {
-          href: 'https://github.com/rancher/rancher-docs',
-          label: 'GitHub',
-          position: 'right',
-          className: 'navbar__github',
-        },
-        {
-          href: 'https://www.rancher.com',
-          label: 'Rancher Home',
-          position: 'right',
-        },
-        {
           type: 'docsVersionDropdown',
           position: 'left',
           dropdownItemsAfter: [{to: '/versions', label: 'All versions'}],
           dropdownActiveClassDisabled: false,
         },
+        {
+          type: "localeDropdown",
+          position: "left",
+        },
+        {
+          type: "search",
+          position: "left",
+        },
+        {
+          type: 'dropdown',
+          label: 'Quick Links',
+          position: 'right',
+          items: [
+            {
+              href: 'https://github.com/rancher/rancher',
+              label: 'GitHub',
+            },
+            {
+              href: 'https://github.com/rancher/rancher-docs',
+              label: 'Docs GitHub',
+            },
+          ]
+        },
+        {
+          type: 'dropdown',
+          label: 'More from SUSE',
+          position: 'right',
+          items: [
+            {
+              href: 'https://www.rancher.com',
+              label: 'Rancher',
+            },
+            {
+              type: 'html',
+              value: '<hr style="margin: 0.3rem 0;">',
+            },
+            {
+              href: 'https://elemental.docs.rancher.com/',
+              label: 'Elemental',
+            },
+            {
+              href: 'https://epinio.io/',
+              label: 'Epinio',
+            },
+            {
+              href: 'https://fleet.rancher.io/',
+              label: 'Fleet',
+            },
+            {
+              href: 'https://harvesterhci.io',
+              label: 'Harvester',
+            },
+            {
+              type: 'html',
+              value: '<hr style="margin: 0.3rem 0;">',
+            },
+            {
+              href: 'https://opensource.suse.com',
+              label: 'More Projects...',
+            },
+          ]
+        }
       ],
     },
     footer: {

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
@@ -29,7 +29,6 @@ Rancher provides several different Helm chart repositories to choose from. We al
 | rancher-stable | `helm repo add rancher-stable https://releases.rancher.com/server-charts/stable` | Adds a repository of Helm charts for older, stable versions of Rancher. We recommend using this repo for production environments.                                                                                                                                                          |
 | rancher-alpha  | `helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha`   | Adds a repository of Helm charts for alpha versions of Rancher for previewing upcoming releases. These releases are discouraged in production environments. Upgrades _to_ or _from_ charts in the rancher-alpha repository to any other chart, regardless or repository, aren't supported. |
 
-<br/>
 Instructions on when to select these repos are available below in [Switching to a Different Helm Chart Repository](#switching-to-a-different-helm-chart-repository).
 
 > **Note:** The introduction of the `rancher-latest` and `rancher-stable` Helm Chart repositories was introduced after Rancher v2.1.0, so the `rancher-stable` repository contains some Rancher versions that were never marked as `rancher/rancher:stable`. The versions of Rancher that were tagged as `rancher/rancher:stable` before v2.1.0 are v2.0.4, v2.0.6, v2.0.8. Post v2.1.0, all charts in the `rancher-stable` repository will correspond with any Rancher version tagged as `stable`.

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
@@ -33,7 +33,6 @@ Rancher provides several different Helm chart repositories to choose from. We al
 | rancher-stable | `helm repo add rancher-stable https://releases.rancher.com/server-charts/stable` | Adds a repository of Helm charts for older, stable versions of Rancher. We recommend using this repo for production environments.                                                                                                                                                          |
 | rancher-alpha  | `helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha`   | Adds a repository of Helm charts for alpha versions of Rancher for previewing upcoming releases. These releases are discouraged in production environments. Upgrades _to_ or _from_ charts in the rancher-alpha repository to any other chart, regardless or repository, aren't supported. |
 
-<br/>
 Instructions on when to select these repos are available below in [Switching to a Different Helm Chart Repository](#switching-to-a-different-helm-chart-repository).
 
 > **Note:** All charts in the `rancher-stable` repository will correspond with any Rancher version tagged as `stable`.

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
@@ -29,7 +29,6 @@ Rancher provides several different Helm chart repositories to choose from. We al
 | rancher-stable | `helm repo add rancher-stable https://releases.rancher.com/server-charts/stable` | Adds a repository of Helm charts for older, stable versions of Rancher. We recommend using this repo for production environments.                                                                                                                                                          |
 | rancher-alpha  | `helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha`   | Adds a repository of Helm charts for alpha versions of Rancher for previewing upcoming releases. These releases are discouraged in production environments. Upgrades _to_ or _from_ charts in the rancher-alpha repository to any other chart, regardless or repository, aren't supported. |
 
-<br/>
 Instructions on when to select these repos are available below in [Switching to a Different Helm Chart Repository](#switching-to-a-different-helm-chart-repository).
 
 :::note

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
@@ -29,7 +29,6 @@ Rancher provides several different Helm chart repositories to choose from. We al
 | rancher-stable | `helm repo add rancher-stable https://releases.rancher.com/server-charts/stable` | Adds a repository of Helm charts for older, stable versions of Rancher. We recommend using this repo for production environments.                                                                                                                                                          |
 | rancher-alpha  | `helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha`   | Adds a repository of Helm charts for alpha versions of Rancher for previewing upcoming releases. These releases are discouraged in production environments. Upgrades _to_ or _from_ charts in the rancher-alpha repository to any other chart, regardless or repository, aren't supported. |
 
-<br/>
 Instructions on when to select these repos are available below in [Switching to a Different Helm Chart Repository](#switching-to-a-different-helm-chart-repository).
 
 :::note

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
@@ -29,7 +29,6 @@ Rancher provides several different Helm chart repositories to choose from. We al
 | rancher-stable | `helm repo add rancher-stable https://releases.rancher.com/server-charts/stable` | Adds a repository of Helm charts for older, stable versions of Rancher. We recommend using this repo for production environments.                                                                                                                                                          |
 | rancher-alpha  | `helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha`   | Adds a repository of Helm charts for alpha versions of Rancher for previewing upcoming releases. These releases are discouraged in production environments. Upgrades _to_ or _from_ charts in the rancher-alpha repository to any other chart, regardless or repository, aren't supported. |
 
-<br/>
 Instructions on when to select these repos are available below in [Switching to a Different Helm Chart Repository](#switching-to-a-different-helm-chart-repository).
 
 :::note


### PR DESCRIPTION
## Description

The link on the [Choosing a Rancher Version](https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/resources/choose-a-rancher-version#helm-chart-repositories) page is rendering as plain text due to manually added line breaks `<br/>`.

> Instructions on when to select these repos are available below in \[Switching to a Different Helm Chart Repository\](#switching-to-a-different-helm-chart-repository).
