### PR TITLE
#135 cluster id aws tagging

### DIFF
--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
@@ -147,17 +147,19 @@ Do not tag multiple security groups. Tagging multiple groups generates an error 
 
 :::
 
-When you create an [Amazon EC2 Cluster](../../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.md), the `ClusterID` is automatically configured for the created nodes. Other resources still need to be tagged manually.
+When you create an [Amazon EC2 Cluster](../../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.md), the `ClusterID` is automatically configured for the created nodes. Other resources still need to be manually tagged.
 
 Use the following tag:
 
-**Key** = `kubernetes.io/cluster/CLUSTERID` **Value** = `owned`
+**Key** = `kubernetes.io/cluster/<cluster-id>` **Value** = `owned`
 
-`CLUSTERID` can be any string you like, as long as it is equal across all tags set.
+Setting the value of the tag to `owned` tells the cluster that all resources with this tag are owned and managed by this cluster. 
 
-Setting the value of the tag to `owned` tells the cluster that all resources with this tag are owned and managed by this cluster. If you share resources between clusters, you can change the tag to:
+If you share resources between clusters, you can change the tag to:
 
-**Key** = `kubernetes.io/cluster/CLUSTERID` **Value** = `shared`.
+**Key** = `kubernetes.io/cluster/<cluster-id>` **Value** = `shared`.
+
+The string value, `<cluster-id>`, should be the Kubernetes cluster's ID. Technically, the `<cluster-id>` value can be any string you like, as long as you use the same value across all tags set. In practice, if the `ClusterID` is automatically configured for some nodes, as it is with Amazon EC2 nodes, you should consistently use that same string across all of your resources, even if you have to manually set the tag.
 
 ### Using Amazon Elastic Container Registry (ECR)
 

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
@@ -159,7 +159,7 @@ If you share resources between clusters, you can change the tag to:
 
 **Key** = `kubernetes.io/cluster/<cluster-id>` **Value** = `shared`.
 
-The string value, `<cluster-id>`, should be the Kubernetes cluster's ID. Technically, the `<cluster-id>` value can be any string you like, as long as you use the same value across all tags set. In practice, if the `ClusterID` is automatically configured for some nodes, as it is with Amazon EC2 nodes, you should consistently use that same string across all of your resources, even if you have to manually set the tag.
+The string value, `<cluster-id>`, is the Kubernetes cluster's ID. 
 
 ### Using Amazon Elastic Container Registry (ECR)
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
@@ -147,17 +147,19 @@ Do not tag multiple security groups. Tagging multiple groups generates an error 
 
 :::
 
-When you create an [Amazon EC2 Cluster](../../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.md), the `ClusterID` is automatically configured for the created nodes. Other resources still need to be tagged manually.
+When you create an [Amazon EC2 Cluster](../../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.md), the `ClusterID` is automatically configured for the created nodes. Other resources still need to be manually tagged.
 
 Use the following tag:
 
-**Key** = `kubernetes.io/cluster/CLUSTERID` **Value** = `owned`
+**Key** = `kubernetes.io/cluster/<cluster-id>` **Value** = `owned`
 
-`CLUSTERID` can be any string you like, as long as it is equal across all tags set.
+Setting the value of the tag to `owned` tells the cluster that all resources with this tag are owned and managed by this cluster. 
 
-Setting the value of the tag to `owned` tells the cluster that all resources with this tag are owned and managed by this cluster. If you share resources between clusters, you can change the tag to:
+If you share resources between clusters, you can change the tag to:
 
-**Key** = `kubernetes.io/cluster/CLUSTERID` **Value** = `shared`.
+**Key** = `kubernetes.io/cluster/<cluster-id>` **Value** = `shared`.
+
+The string value, `<cluster-id>`, should be the Kubernetes cluster's ID. Technically, the `<cluster-id>` value can be any string you like, as long as you use the same value across all tags set. In practice, if the `ClusterID` is automatically configured for some nodes, as it is with Amazon EC2 nodes, you should consistently use that same string across all of your resources, even if you have to manually set the tag.
 
 ### Using Amazon Elastic Container Registry (ECR)
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
@@ -159,7 +159,7 @@ If you share resources between clusters, you can change the tag to:
 
 **Key** = `kubernetes.io/cluster/<cluster-id>` **Value** = `shared`.
 
-The string value, `<cluster-id>`, should be the Kubernetes cluster's ID. Technically, the `<cluster-id>` value can be any string you like, as long as you use the same value across all tags set. In practice, if the `ClusterID` is automatically configured for some nodes, as it is with Amazon EC2 nodes, you should consistently use that same string across all of your resources, even if you have to manually set the tag.
+The string value, `<cluster-id>`, is the Kubernetes cluster's ID.
 
 ### Using Amazon Elastic Container Registry (ECR)
 

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
@@ -147,17 +147,19 @@ Do not tag multiple security groups. Tagging multiple groups generates an error 
 
 :::
 
-When you create an [Amazon EC2 Cluster](../../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.md), the `ClusterID` is automatically configured for the created nodes. Other resources still need to be tagged manually.
+When you create an [Amazon EC2 Cluster](../../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.md), the `ClusterID` is automatically configured for the created nodes. Other resources still need to be manually tagged.
 
 Use the following tag:
 
-**Key** = `kubernetes.io/cluster/CLUSTERID` **Value** = `owned`
+**Key** = `kubernetes.io/cluster/<cluster-id>` **Value** = `owned`
 
-`CLUSTERID` can be any string you like, as long as it is equal across all tags set.
+Setting the value of the tag to `owned` tells the cluster that all resources with this tag are owned and managed by this cluster. 
 
-Setting the value of the tag to `owned` tells the cluster that all resources with this tag are owned and managed by this cluster. If you share resources between clusters, you can change the tag to:
+If you share resources between clusters, you can change the tag to:
 
-**Key** = `kubernetes.io/cluster/CLUSTERID` **Value** = `shared`.
+**Key** = `kubernetes.io/cluster/<cluster-id>` **Value** = `shared`.
+
+The string value, `<cluster-id>`, should be the Kubernetes cluster's ID. Technically, the `<cluster-id>` value can be any string you like, as long as you use the same value across all tags set. In practice, if the `ClusterID` is automatically configured for some nodes, as it is with Amazon EC2 nodes, you should consistently use that same string across all of your resources, even if you have to manually set the tag.
 
 ### Using Amazon Elastic Container Registry (ECR)
 

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
@@ -159,7 +159,7 @@ If you share resources between clusters, you can change the tag to:
 
 **Key** = `kubernetes.io/cluster/<cluster-id>` **Value** = `shared`.
 
-The string value, `<cluster-id>`, should be the Kubernetes cluster's ID. Technically, the `<cluster-id>` value can be any string you like, as long as you use the same value across all tags set. In practice, if the `ClusterID` is automatically configured for some nodes, as it is with Amazon EC2 nodes, you should consistently use that same string across all of your resources, even if you have to manually set the tag.
+The string value, `<cluster-id>`, is the Kubernetes cluster's ID. 
 
 ### Using Amazon Elastic Container Registry (ECR)
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
@@ -147,17 +147,19 @@ Do not tag multiple security groups. Tagging multiple groups generates an error 
 
 :::
 
-When you create an [Amazon EC2 Cluster](../../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.md), the `ClusterID` is automatically configured for the created nodes. Other resources still need to be tagged manually.
+When you create an [Amazon EC2 Cluster](../../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.md), the `ClusterID` is automatically configured for the created nodes. Other resources still need to be manually tagged.
 
 Use the following tag:
 
-**Key** = `kubernetes.io/cluster/CLUSTERID` **Value** = `owned`
+**Key** = `kubernetes.io/cluster/<cluster-id>` **Value** = `owned`
 
-`CLUSTERID` can be any string you like, as long as it is equal across all tags set.
+Setting the value of the tag to `owned` tells the cluster that all resources with this tag are owned and managed by this cluster. 
 
-Setting the value of the tag to `owned` tells the cluster that all resources with this tag are owned and managed by this cluster. If you share resources between clusters, you can change the tag to:
+If you share resources between clusters, you can change the tag to:
 
-**Key** = `kubernetes.io/cluster/CLUSTERID` **Value** = `shared`.
+**Key** = `kubernetes.io/cluster/<cluster-id>` **Value** = `shared`.
+
+The string value, `<cluster-id>`, should be the Kubernetes cluster's ID. Technically, the `<cluster-id>` value can be any string you like, as long as you use the same value across all tags set. In practice, if the `ClusterID` is automatically configured for some nodes, as it is with Amazon EC2 nodes, you should consistently use that same string across all of your resources, even if you have to manually set the tag.
 
 ### Using Amazon Elastic Container Registry (ECR)
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
@@ -159,7 +159,7 @@ If you share resources between clusters, you can change the tag to:
 
 **Key** = `kubernetes.io/cluster/<cluster-id>` **Value** = `shared`.
 
-The string value, `<cluster-id>`, should be the Kubernetes cluster's ID. Technically, the `<cluster-id>` value can be any string you like, as long as you use the same value across all tags set. In practice, if the `ClusterID` is automatically configured for some nodes, as it is with Amazon EC2 nodes, you should consistently use that same string across all of your resources, even if you have to manually set the tag.
+The string value, `<cluster-id>`, is the Kubernetes cluster's ID. 
 
 ### Using Amazon Elastic Container Registry (ECR)
 


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #135

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

This alters the language in the AWS doc to more clearly relate how to set the cluster ID string. There was some ambiguity, because we told users they could tag that value whatever they liked, as long as they were consistent. However, some nodes in an EC2 cluster would be automatically configured and users might manually tag resources something else entirely, resulting in confusion. 

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->

This is going to probably conflict with an open PR about out-of-tree AWS. We'll have to fix it there if that comes up.

The original issue points to the RKE docs, but the same error is present in our docs.