### PR TITLE
Update CNI popularity chart numbers

### DIFF
--- a/docs/faq/container-network-interface-providers.md
+++ b/docs/faq/container-network-interface-providers.md
@@ -182,20 +182,18 @@ The following table summarizes the different features available for each CNI net
 
 - Ingress/Egress Policies: This feature allows you to manage routing control for both Kubernetes and non-Kubernetes communications.
 
-
+<!-- releaseTask -->
 ## CNI Community Popularity
 
-The following table summarizes different GitHub metrics to give you an idea of each project's popularity and activity. This data was collected in January 2022.
+The following table summarizes different GitHub metrics to give you an idea of each project's popularity and activity. This data was collected in November 2023.
 
 | Provider | Project | Stars | Forks | Contributors |
 | ---- | ---- | ---- | ---- | ---- |
-| Canal | https://github.com/projectcalico/canal | 679 | 100 | 21 |
-| Flannel | https://github.com/flannel-io/flannel | 7k | 2.5k | 185 |
-| Calico | https://github.com/projectcalico/calico | 3.1k | 741 | 224 |
-| Weave | https://github.com/weaveworks/weave/ | 6.2k | 635 | 84 |
-| Cilium | https://github.com/cilium/cilium | 10.6k | 1.3k | 352 |
-
-<br/>
+| Canal | https://github.com/projectcalico/canal | 707 | 104 | 20 |
+| Flannel | https://github.com/flannel-io/flannel | 8.3k | 2.9k | 225 |
+| Calico | https://github.com/projectcalico/calico | 5.1k | 1.2k | 328 |
+| Weave | https://github.com/weaveworks/weave/ | 6.5k | 672 | 87 |
+| Cilium | https://github.com/cilium/cilium | 17.1k | 2.5k | 677 |
 
 ## Which CNI Provider Should I Use?
 

--- a/versioned_docs/version-2.6/faq/container-network-interface-providers.md
+++ b/versioned_docs/version-2.6/faq/container-network-interface-providers.md
@@ -182,20 +182,17 @@ The following table summarizes the different features available for each CNI net
 
 - Ingress/Egress Policies: This feature allows you to manage routing control for both Kubernetes and non-Kubernetes communications.
 
-
 ## CNI Community Popularity
 
-The following table summarizes different GitHub metrics to give you an idea of each project's popularity and activity. This data was collected in January 2022.
+The following table summarizes different GitHub metrics to give you an idea of each project's popularity and activity. This data was collected in November 2023.
 
 | Provider | Project | Stars | Forks | Contributors |
 | ---- | ---- | ---- | ---- | ---- |
-| Canal | https://github.com/projectcalico/canal | 679 | 100 | 21 |
-| Flannel | https://github.com/flannel-io/flannel | 7k | 2.5k | 185 |
-| Calico | https://github.com/projectcalico/calico | 3.1k | 741 | 224 |
-| Weave | https://github.com/weaveworks/weave/ | 6.2k | 635 | 84 |
-| Cilium | https://github.com/cilium/cilium | 10.6k | 1.3k | 352 |
-
-<br/>
+| Canal | https://github.com/projectcalico/canal | 707 | 104 | 20 |
+| Flannel | https://github.com/flannel-io/flannel | 8.3k | 2.9k | 225 |
+| Calico | https://github.com/projectcalico/calico | 5.1k | 1.2k | 328 |
+| Weave | https://github.com/weaveworks/weave/ | 6.5k | 672 | 87 |
+| Cilium | https://github.com/cilium/cilium | 17.1k | 2.5k | 677 |
 
 ## Which CNI Provider Should I Use?
 

--- a/versioned_docs/version-2.7/faq/container-network-interface-providers.md
+++ b/versioned_docs/version-2.7/faq/container-network-interface-providers.md
@@ -182,20 +182,17 @@ The following table summarizes the different features available for each CNI net
 
 - Ingress/Egress Policies: This feature allows you to manage routing control for both Kubernetes and non-Kubernetes communications.
 
-
 ## CNI Community Popularity
 
-The following table summarizes different GitHub metrics to give you an idea of each project's popularity and activity. This data was collected in January 2022.
+The following table summarizes different GitHub metrics to give you an idea of each project's popularity and activity. This data was collected in November 2023.
 
 | Provider | Project | Stars | Forks | Contributors |
 | ---- | ---- | ---- | ---- | ---- |
-| Canal | https://github.com/projectcalico/canal | 679 | 100 | 21 |
-| Flannel | https://github.com/flannel-io/flannel | 7k | 2.5k | 185 |
-| Calico | https://github.com/projectcalico/calico | 3.1k | 741 | 224 |
-| Weave | https://github.com/weaveworks/weave/ | 6.2k | 635 | 84 |
-| Cilium | https://github.com/cilium/cilium | 10.6k | 1.3k | 352 |
-
-<br/>
+| Canal | https://github.com/projectcalico/canal | 707 | 104 | 20 |
+| Flannel | https://github.com/flannel-io/flannel | 8.3k | 2.9k | 225 |
+| Calico | https://github.com/projectcalico/calico | 5.1k | 1.2k | 328 |
+| Weave | https://github.com/weaveworks/weave/ | 6.5k | 672 | 87 |
+| Cilium | https://github.com/cilium/cilium | 17.1k | 2.5k | 677 |
 
 ## Which CNI Provider Should I Use?
 

--- a/versioned_docs/version-2.8/faq/container-network-interface-providers.md
+++ b/versioned_docs/version-2.8/faq/container-network-interface-providers.md
@@ -182,20 +182,17 @@ The following table summarizes the different features available for each CNI net
 
 - Ingress/Egress Policies: This feature allows you to manage routing control for both Kubernetes and non-Kubernetes communications.
 
-
 ## CNI Community Popularity
 
-The following table summarizes different GitHub metrics to give you an idea of each project's popularity and activity. This data was collected in January 2022.
+The following table summarizes different GitHub metrics to give you an idea of each project's popularity and activity. This data was collected in November 2023.
 
 | Provider | Project | Stars | Forks | Contributors |
 | ---- | ---- | ---- | ---- | ---- |
-| Canal | https://github.com/projectcalico/canal | 679 | 100 | 21 |
-| Flannel | https://github.com/flannel-io/flannel | 7k | 2.5k | 185 |
-| Calico | https://github.com/projectcalico/calico | 3.1k | 741 | 224 |
-| Weave | https://github.com/weaveworks/weave/ | 6.2k | 635 | 84 |
-| Cilium | https://github.com/cilium/cilium | 10.6k | 1.3k | 352 |
-
-<br/>
+| Canal | https://github.com/projectcalico/canal | 707 | 104 | 20 |
+| Flannel | https://github.com/flannel-io/flannel | 8.3k | 2.9k | 225 |
+| Calico | https://github.com/projectcalico/calico | 5.1k | 1.2k | 328 |
+| Weave | https://github.com/weaveworks/weave/ | 6.5k | 672 | 87 |
+| Cilium | https://github.com/cilium/cilium | 17.1k | 2.5k | 677 |
 
 ## Which CNI Provider Should I Use?
 


### PR DESCRIPTION
## Description

This ports https://github.com/rancher/docs/pull/4377 to our current docs repository. Credits to @amitmavgupta for the original PR. I've also amended the original PR to include the latest data for the Cilium and all other CNIs.

## Comments

We'll probably want to re-evaluate this table since the data (stars, forks, contributors) we're listing changes daily and will always be outdated.
