### PR TITLE
Fix etcd.backup_config.retention description

### DIFF
--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher-launched-kubernetes-clusters.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher-launched-kubernetes-clusters.md
@@ -67,7 +67,7 @@ The steps to enable recurring snapshots differ based on the version of RKE.
         backup_config:
           enabled: true     # enables recurring etcd snapshots
           interval_hours: 6 # time increment between snapshots
-          retention: 60     # time in days before snapshot purge
+          retention: 6     # number of snapshots to retain before rotation
           # Optional S3
           s3backupconfig:
             access_key: "myaccesskey"


### PR DESCRIPTION
Fixes #159

## Description

Fixes the retention value's description in the code block quoted in #159. I couldn't find other instances of the problematic description in 2.5 or newer docs.

- The equivalent page for [1] https://rancher.com/docs/rancher/v2.x/en/backups/backups/ha-backups/#option-a-recurring-snapshots listed in #159 is versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher-launched-kubernetes-clusters.md
- The equivalent page for [2] https://rancher.com/docs/rancher/v2.x/en/cluster-admin/backing-up-etcd/#configuring-recurring-snapshots-for-the-cluster listed in #159 is versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/manage-clusters/backing-up-etcd.md