### PR TITLE
Update webhook version table

### DIFF
--- a/docs/reference-guides/rancher-webhook.md
+++ b/docs/reference-guides/rancher-webhook.md
@@ -19,16 +19,7 @@ Each Rancher version is designed to be compatible with a single version of the w
 
 | Rancher Version | Webhook Version |
 |-----------------|:---------------:|
-| v2.7.0          |     v0.3.0      |
-| v2.7.1          |     v0.3.0      |
-| v2.7.2          |     v0.3.2      |
-| v2.7.3          |     v0.3.3      |
-| v2.7.4          |     v0.3.4      |
-| v2.7.5          |     v0.3.5      |
-| v2.7.6          |     v0.3.5      |
-| v2.7.7          |     v0.3.6      |
-| v2.7.8          |     v0.3.6      |
-| v2.7.9          |     v0.3.6      |
+| v2.8.0          |     v0.4.1      |
 
 ## Why Do We Need It?
 

--- a/docs/reference-guides/rancher-webhook.md
+++ b/docs/reference-guides/rancher-webhook.md
@@ -19,7 +19,7 @@ Each Rancher version is designed to be compatible with a single version of the w
 
 | Rancher Version | Webhook Version |
 |-----------------|:---------------:|
-| v2.8.0          |     v0.4.1      |
+| v2.8.0          |     v0.4.2      |
 
 ## Why Do We Need It?
 

--- a/docs/reference-guides/rancher-webhook.md
+++ b/docs/reference-guides/rancher-webhook.md
@@ -15,6 +15,8 @@ Each Rancher version is designed to be compatible with a single version of the w
 
 **Note:** Rancher manages deployment and upgrade of the webhook. Under most circumstances, no user intervention should be needed to ensure that the webhook version is compatible with the version of Rancher that you are running.
 
+<!-- releaseTask -->
+
 | Rancher Version | Webhook Version |
 |-----------------|:---------------:|
 | v2.7.0          |     v0.3.0      |
@@ -24,7 +26,9 @@ Each Rancher version is designed to be compatible with a single version of the w
 | v2.7.4          |     v0.3.4      |
 | v2.7.5          |     v0.3.5      |
 | v2.7.6          |     v0.3.5      |
-
+| v2.7.7          |     v0.3.6      |
+| v2.7.8          |     v0.3.6      |
+| v2.7.9          |     v0.3.6      |
 
 ## Why Do We Need It?
 

--- a/versioned_docs/version-2.7/reference-guides/rancher-webhook.md
+++ b/versioned_docs/version-2.7/reference-guides/rancher-webhook.md
@@ -15,6 +15,8 @@ Each Rancher version is designed to be compatible with a single version of the w
 
 **Note:** Rancher manages deployment and upgrade of the webhook. Under most circumstances, no user intervention should be needed to ensure that the webhook version is compatible with the version of Rancher that you are running.
 
+<!-- releaseTask -->
+
 | Rancher Version | Webhook Version |
 |-----------------|:---------------:|
 | v2.7.0          |     v0.3.0      |
@@ -24,7 +26,9 @@ Each Rancher version is designed to be compatible with a single version of the w
 | v2.7.4          |     v0.3.4      |
 | v2.7.5          |     v0.3.5      |
 | v2.7.6          |     v0.3.5      |
-
+| v2.7.7          |     v0.3.6      |
+| v2.7.8          |     v0.3.6      |
+| v2.7.9          |     v0.3.6      |
 
 ## Why Do We Need It?
 

--- a/versioned_docs/version-2.8/reference-guides/rancher-webhook.md
+++ b/versioned_docs/version-2.8/reference-guides/rancher-webhook.md
@@ -19,7 +19,7 @@ Each Rancher version is designed to be compatible with a single version of the w
 
 | Rancher Version | Webhook Version |
 |-----------------|:---------------:|
-| v2.8.0          |     v0.4.1      |
+| v2.8.0          |     v0.4.2      |
 
 ## Why Do We Need It?
 

--- a/versioned_docs/version-2.8/reference-guides/rancher-webhook.md
+++ b/versioned_docs/version-2.8/reference-guides/rancher-webhook.md
@@ -19,7 +19,7 @@ Each Rancher version is designed to be compatible with a single version of the w
 
 | Rancher Version | Webhook Version |
 |-----------------|:---------------:|
-| v2.8.0          |     v0.4.0      |
+| v2.8.0          |     v0.4.1      |
 
 ## Why Do We Need It?
 

--- a/versioned_docs/version-2.8/reference-guides/rancher-webhook.md
+++ b/versioned_docs/version-2.8/reference-guides/rancher-webhook.md
@@ -15,16 +15,11 @@ Each Rancher version is designed to be compatible with a single version of the w
 
 **Note:** Rancher manages deployment and upgrade of the webhook. Under most circumstances, no user intervention should be needed to ensure that the webhook version is compatible with the version of Rancher that you are running.
 
+<!-- releaseTask -->
+
 | Rancher Version | Webhook Version |
 |-----------------|:---------------:|
-| v2.7.0          |     v0.3.0      |
-| v2.7.1          |     v0.3.0      |
-| v2.7.2          |     v0.3.2      |
-| v2.7.3          |     v0.3.3      |
-| v2.7.4          |     v0.3.4      |
-| v2.7.5          |     v0.3.5      |
-| v2.7.6          |     v0.3.5      |
-
+| v2.8.0          |     v0.4.0      |
 
 ## Why Do We Need It?
 


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #1005 

## Description

Adds the missing entries for 2.7.7-2.7.9 and restarts the table for the 2.8 series.