### PR TITLE
fix: update v2.7 cn sidebar

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current.json
+++ b/i18n/zh/docusaurus-plugin-content-docs/current.json
@@ -16,7 +16,7 @@
     "description": "The label for category Deploy Rancher in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.Deploy Workloads": {
-    "message": "部署 Rancher 工作负载",
+    "message": "部署工作负载",
     "description": "The label for category Deploy Workloads in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.Installation and Upgrade": {

--- a/i18n/zh/docusaurus-plugin-content-docs/current.json
+++ b/i18n/zh/docusaurus-plugin-content-docs/current.json
@@ -15,9 +15,9 @@
     "message": "部署 Rancher",
     "description": "The label for category Deploy Rancher in sidebar tutorialSidebar"
   },
-  "sidebar.tutorialSidebar.category.Deploy Rancher Workloads": {
+  "sidebar.tutorialSidebar.category.Deploy Workloads": {
     "message": "部署 Rancher 工作负载",
-    "description": "The label for category Deploy Rancher Workloads in sidebar tutorialSidebar"
+    "description": "The label for category Deploy Workloads in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.Installation and Upgrade": {
     "message": "安装和升级",

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.0-2.4.json
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.0-2.4.json
@@ -19,9 +19,9 @@
     "message": "Deploy Rancher",
     "description": "The label for category Deploy Rancher in sidebar tutorialSidebar"
   },
-  "sidebar.tutorialSidebar.category.Deploy Rancher Workloads": {
-    "message": "Deploy Rancher Workloads",
-    "description": "The label for category Deploy Rancher Workloads in sidebar tutorialSidebar"
+  "sidebar.tutorialSidebar.category.Deploy Workloads": {
+    "message": "Deploy Workloads",
+    "description": "The label for category Deploy Workloads in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.Installation and Upgrade": {
     "message": "Installation and Upgrade",

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.5.json
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.5.json
@@ -19,9 +19,9 @@
     "message": "Deploy Rancher",
     "description": "The label for category Deploy Rancher in sidebar tutorialSidebar"
   },
-  "sidebar.tutorialSidebar.category.Deploy Rancher Workloads": {
-    "message": "Deploy Rancher Workloads",
-    "description": "The label for category Deploy Rancher Workloads in sidebar tutorialSidebar"
+  "sidebar.tutorialSidebar.category.Deploy Workloads": {
+    "message": "Deploy Workloads",
+    "description": "The label for category Deploy Workloads in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.Installation and Upgrade": {
     "message": "Installation and Upgrade",

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6.json
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6.json
@@ -16,7 +16,7 @@
     "description": "The label for category Deploy Rancher in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.Deploy Workloads": {
-    "message": "部署 Rancher 工作负载",
+    "message": "部署工作负载",
     "description": "The label for category Deploy Workloads in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.Installation and Upgrade": {

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6.json
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6.json
@@ -15,9 +15,9 @@
     "message": "部署 Rancher",
     "description": "The label for category Deploy Rancher in sidebar tutorialSidebar"
   },
-  "sidebar.tutorialSidebar.category.Deploy Rancher Workloads": {
+  "sidebar.tutorialSidebar.category.Deploy Workloads": {
     "message": "部署 Rancher 工作负载",
-    "description": "The label for category Deploy Rancher Workloads in sidebar tutorialSidebar"
+    "description": "The label for category Deploy Workloads in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.Installation and Upgrade": {
     "message": "安装和升级",

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7.json
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7.json
@@ -16,7 +16,7 @@
     "description": "The label for category Deploy Rancher in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.Deploy Workloads": {
-    "message": "部署 Rancher 工作负载",
+    "message": "部署工作负载",
     "description": "The label for category Deploy Workloads in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.Installation and Upgrade": {

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7.json
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7.json
@@ -15,9 +15,9 @@
     "message": "部署 Rancher",
     "description": "The label for category Deploy Rancher in sidebar tutorialSidebar"
   },
-  "sidebar.tutorialSidebar.category.Deploy Rancher Workloads": {
+  "sidebar.tutorialSidebar.category.Deploy Workloads": {
     "message": "部署 Rancher 工作负载",
-    "description": "The label for category Deploy Rancher Workloads in sidebar tutorialSidebar"
+    "description": "The label for category Deploy Workloads in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.Installation and Upgrade": {
     "message": "安装和升级",

--- a/versioned_sidebars/version-2.0-2.4-sidebars.json
+++ b/versioned_sidebars/version-2.0-2.4-sidebars.json
@@ -48,7 +48,7 @@
             },
             {
               "type": "category",
-              "label": "Deploy Rancher Workloads",
+              "label": "Deploy Workloads",
               "link": {
                 "type": "doc",
                 "id": "pages-for-subheaders/deploy-rancher-workloads"

--- a/versioned_sidebars/version-2.5-sidebars.json
+++ b/versioned_sidebars/version-2.5-sidebars.json
@@ -47,7 +47,7 @@
             },
             {
               "type": "category",
-              "label": "Deploy Rancher Workloads",
+              "label": "Deploy Workloads",
               "link": {
                 "type": "doc",
                 "id": "pages-for-subheaders/deploy-rancher-workloads"

--- a/versioned_sidebars/version-2.6-sidebars.json
+++ b/versioned_sidebars/version-2.6-sidebars.json
@@ -36,7 +36,7 @@
             },
             {
               "type": "category",
-              "label": "Deploy Rancher Workloads",
+              "label": "Deploy Workloads",
               "link": {
                 "type": "doc",
                 "id": "pages-for-subheaders/deploy-rancher-workloads"

--- a/versioned_sidebars/version-2.8-sidebars.json
+++ b/versioned_sidebars/version-2.8-sidebars.json
@@ -37,7 +37,7 @@
             "getting-started/quick-start-guides/deploy-rancher-manager/prime",
             {
               "type": "category",
-              "label": "Deploy Rancher Workloads",
+              "label": "Deploy Workloads",
               "link": {
                 "type": "doc",
                 "id": "pages-for-subheaders/deploy-rancher-workloads"


### PR DESCRIPTION
## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

The goal of this pull request is to fix the English title "Deploy Workloads" in V2.7's CN doc sidebar.

As checked, the variable is defined as `"label": "Deploy Workloads",` in the English V2.7 sidebar file `versioned_sidebars/version-2.7-sidebars.json` file.

I make changes to two things in `i18n/zh/docusaurus-plugin-content-docs/version-2.7.json`:
- change `sidebar.tutorialSidebar.category.Deploy Rancher Workloads` to `sidebar.tutorialSidebar.category.Deploy Workloads`, so that it can match with English V2.7 sidebar and display out the correct Chinese.
- update its description.

<img width="1331" alt="image" src="https://github.com/rancher/rancher-docs/assets/36651058/be612cb4-8e6d-4096-b94c-c4a31e01ba5b">


## Comments

I also checked the other sidebar.js files, V2.7 is the only one with `"label": "Deploy Workloads",`, while the other ones are `"label": "Deploy Rancher Workloads",`, including V2.8 and Preview. Not sure if changing the V2.7 English sidebar file back with `"label": "Deploy Rancher Workloads",` is ok.