### PR TITLE
#927 Fixed typo in command

### DIFF
--- a/versioned_docs/version-2.8/reference-guides/rancher-security/rancher-webhook-hardening.md
+++ b/versioned_docs/version-2.8/reference-guides/rancher-security/rancher-webhook-hardening.md
@@ -127,7 +127,7 @@ The webhook should only accept requests from the Kubernetes API server. By defau
 6. Create a configmap in the `cattle-system` namespace on the provisioned cluster with these values:
 
     ```
-    kubectl --namespace cattle-system create configmap --from-file=rancher-webhook=values.yaml
+    kubectl --namespace cattle-system create configmap rancher-config --from-file=rancher-webhook=values.yaml
     ```
 
     The webhook will restart with these values.


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes (partially) #927 

Comments and description are copy and pasted from the original issue.

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

> Step 6 of these docs has a typo in the create configmap command:
> It's missing rancher-config after create configmap. So it should be create configmap rancher-config

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->

> These docs are also missing a section on how to do this for the local cluster of an HA Rancher. Because in this scenario the rancher-config configmap already exists. So, this command will not work in that scenario.