### PR TITLE
embed video on aws marketplace page

### DIFF
--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace.md
@@ -7,4 +7,8 @@ description: Use Amazon EKS to deploy Rancher server.
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace"/>
 </head>
 
-Amazon Elastic Kubernetes Service (EKS) can quickly [deploy Rancher to Amazon Web Services (AWS)](https://documentation.suse.com/trd/kubernetes/single-html/gs_rancher_aws-marketplace/). To learn more, see our [Amazon Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-go7ent7goo5ae). Watch the [demo](https://youtu.be/9dznJ7Ons0M) for a walkthrough of AWS Marketplace SUSE Rancher setup.
+import YouTube from '@site/src/components/YouTube'
+
+Amazon Elastic Kubernetes Service (EKS) can quickly [deploy Rancher to Amazon Web Services (AWS)](https://documentation.suse.com/trd/kubernetes/single-html/gs_rancher_aws-marketplace/). To learn more, see our [Amazon Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-go7ent7goo5ae). Watch the demo for a walkthrough of AWS Marketplace SUSE Rancher setup:
+
+<YouTube id="9dznJ7Ons0M"/>

--- a/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace.md
+++ b/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace.md
@@ -7,4 +7,8 @@ description: Use Amazon EKS to deploy Rancher server.
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace"/>
 </head>
 
-Amazon Elastic Kubernetes Service (EKS) can quickly [deploy Rancher to Amazon Web Services (AWS)](https://documentation.suse.com/trd/kubernetes/single-html/gs_rancher_aws-marketplace/). To learn more, see our [Amazon Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-go7ent7goo5ae). Watch the [demo](https://youtu.be/9dznJ7Ons0M) for a walkthrough of AWS Marketplace SUSE Rancher setup.
+import YouTube from '@site/src/components/YouTube'
+
+Amazon Elastic Kubernetes Service (EKS) can quickly [deploy Rancher to Amazon Web Services (AWS)](https://documentation.suse.com/trd/kubernetes/single-html/gs_rancher_aws-marketplace/). To learn more, see our [Amazon Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-go7ent7goo5ae). Watch the demo for a walkthrough of AWS Marketplace SUSE Rancher setup:
+
+<YouTube id="9dznJ7Ons0M"/>

--- a/versioned_docs/version-2.7/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace.md
+++ b/versioned_docs/version-2.7/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace.md
@@ -7,4 +7,8 @@ description: Use Amazon EKS to deploy Rancher server.
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace"/>
 </head>
 
-Amazon Elastic Kubernetes Service (EKS) can quickly [deploy Rancher to Amazon Web Services (AWS)](https://documentation.suse.com/trd/kubernetes/single-html/gs_rancher_aws-marketplace/). To learn more, see our [Amazon Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-go7ent7goo5ae). Watch the [demo](https://youtu.be/9dznJ7Ons0M) for a walkthrough of AWS Marketplace SUSE Rancher setup.
+import YouTube from '@site/src/components/YouTube'
+
+Amazon Elastic Kubernetes Service (EKS) can quickly [deploy Rancher to Amazon Web Services (AWS)](https://documentation.suse.com/trd/kubernetes/single-html/gs_rancher_aws-marketplace/). To learn more, see our [Amazon Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-go7ent7goo5ae). Watch the demo for a walkthrough of AWS Marketplace SUSE Rancher setup:
+
+<YouTube id="9dznJ7Ons0M"/>

--- a/versioned_docs/version-2.8/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace.md
+++ b/versioned_docs/version-2.8/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace.md
@@ -7,4 +7,8 @@ description: Use Amazon EKS to deploy Rancher server.
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace"/>
 </head>
 
-Amazon Elastic Kubernetes Service (EKS) can quickly [deploy Rancher to Amazon Web Services (AWS)](https://documentation.suse.com/trd/kubernetes/single-html/gs_rancher_aws-marketplace/). To learn more, see our [Amazon Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-go7ent7goo5ae). Watch the [demo](https://youtu.be/9dznJ7Ons0M) for a walkthrough of AWS Marketplace SUSE Rancher setup.
+import YouTube from '@site/src/components/YouTube'
+
+Amazon Elastic Kubernetes Service (EKS) can quickly [deploy Rancher to Amazon Web Services (AWS)](https://documentation.suse.com/trd/kubernetes/single-html/gs_rancher_aws-marketplace/). To learn more, see our [Amazon Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-go7ent7goo5ae). Watch the demo for a walkthrough of AWS Marketplace SUSE Rancher setup:
+
+<YouTube id="9dznJ7Ons0M"/>


### PR DESCRIPTION
## Description

This is a very minor update that embeds a video on the Rancher docs site instead of forcing users to navigate away to Youtube.

- Fleshes out the page so it no longer looks like a placeholder
- Retains the user on the website so they can continue to learn about Rancher
- Consolidates the information about quickstarts, so the user can simply visit the docs site instead of going directly to Youtube

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->