### PR TITLE
rm deprecation banner from v2.8

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -187,6 +187,7 @@ module.exports = {
             2.8: {
               label: 'v2.8',
               path: 'v2.8',
+              banner: 'none'
             },
             2.7: {
               label: 'v2.7',


### PR DESCRIPTION
## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

Not including `banner: 'none'` in the config file means that files in the v2.8 directory have the deprecation banner for v2.0-2.5 applied

![image](https://github.com/rancher/rancher-docs/assets/19174201/b442c8b5-fb13-47b8-8764-8637854c27e3)

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->