### PR TITLE
Add `cloudcredential` as question type

### DIFF
--- a/docs/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
+++ b/docs/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
@@ -108,7 +108,7 @@ This reference contains variables that you can use in `questions.yml` nested und
 | 	variable          | string  | true    |  Define the variable name specified in the `values.yml` file, using `foo.bar` for nested objects. |
 | 	label             | string  | true      |  Define the UI label. |
 | 	description       | string  | false      |  Specify the description of the variable.|
-| 	type              | string  | false      |  Default to `string` if not specified (current supported types are string, multiline, boolean, int, enum, password, storageclass, hostname, pvc, and secret).|
+| 	type              | string  | false      |  Default to `string` if not specified (current supported types are string, multiline, boolean, int, enum, password, storageclass, hostname, pvc, secret and cloudcredential).|
 | 	default           | string  | false      |  Specify the default value. Only used if there is no corresponding value in the `values.yml` file. |
 | 	group             | string  | false      |  Group questions by input value. |
 | 	options           | []string | false     |  Specify the options when the variable type is `enum`, for example: options:<br/> - "ClusterIP" <br/> - "NodePort" <br/> - "LoadBalancer"|

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/helm-charts-in-rancher/creating-apps.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/helm-charts-in-rancher/creating-apps.md
@@ -96,7 +96,7 @@ This reference contains variables that you can use in `questions.yml` nested und
 | 	variable          | string  | true    |  Define the variable name specified in the `values.yml` file, using `foo.bar` for nested objects. |
 | 	label             | string  | true      |  Define the UI label. |
 | 	description       | string  | false      |  Specify the description of the variable.|
-| 	type              | string  | false      |  Default to `string` if not specified (current supported types are string, multiline, boolean, int, enum, password, storageclass, hostname, pvc, and secret).|
+| 	type              | string  | false      |  Default to `string` if not specified (current supported types are string, multiline, boolean, int, enum, password, storageclass, hostname, pvc, secret and cloudcredential).|
 | 	required          | bool    | false      |  Define if the variable is required or not (true \| false)|
 | 	default           | string  | false      |  Specify the default value. |
 | 	group             | string  | false      |  Group questions by input value. |

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/helm-charts-in-rancher/creating-apps.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/helm-charts-in-rancher/creating-apps.md
@@ -96,7 +96,7 @@ This reference contains variables that you can use in `questions.yml` nested und
 | 	variable          | string  | true    |  Define the variable name specified in the `values.yml` file, using `foo.bar` for nested objects. |
 | 	label             | string  | true      |  Define the UI label. |
 | 	description       | string  | false      |  Specify the description of the variable.|
-| 	type              | string  | false      |  Default to `string` if not specified (current supported types are string, multiline, boolean, int, enum, password, storageclass, hostname, pvc, secret and cloudcredential).|
+| 	type              | string  | false      |  Default to `string` if not specified (current supported types are string, multiline, boolean, int, enum, password, storageclass, hostname, pvc, and secret).|
 | 	required          | bool    | false      |  Define if the variable is required or not (true \| false)|
 | 	default           | string  | false      |  Specify the default value. |
 | 	group             | string  | false      |  Group questions by input value. |

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
@@ -112,7 +112,7 @@ This reference contains variables that you can use in `questions.yml` nested und
 | 	variable          | string  | true    |  Define the variable name specified in the `values.yml` file, using `foo.bar` for nested objects. |
 | 	label             | string  | true      |  Define the UI label. |
 | 	description       | string  | false      |  Specify the description of the variable.|
-| 	type              | string  | false      |  Default to `string` if not specified (current supported types are string, multiline, boolean, int, enum, password, storageclass, hostname, pvc, and secret).|
+| 	type              | string  | false      |  Default to `string` if not specified (current supported types are string, multiline, boolean, int, enum, password, storageclass, hostname, pvc, secret and cloudcredential).|
 | 	default           | string  | false      |  Specify the default value. Only used if there is no corresponding value in the `values.yml` file. |
 | 	group             | string  | false      |  Group questions by input value. |
 | 	options           | []string | false     |  Specify the options when the variable type is `enum`, for example: options:<br/> - "ClusterIP" <br/> - "NodePort" <br/> - "LoadBalancer"|

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
@@ -108,7 +108,7 @@ This reference contains variables that you can use in `questions.yml` nested und
 | 	variable          | string  | true    |  Define the variable name specified in the `values.yml` file, using `foo.bar` for nested objects. |
 | 	label             | string  | true      |  Define the UI label. |
 | 	description       | string  | false      |  Specify the description of the variable.|
-| 	type              | string  | false      |  Default to `string` if not specified (current supported types are string, multiline, boolean, int, enum, password, storageclass, hostname, pvc, and secret).|
+| 	type              | string  | false      |  Default to `string` if not specified (current supported types are string, multiline, boolean, int, enum, password, storageclass, hostname, pvc, secret and cloudcredential).|
 | 	default           | string  | false      |  Specify the default value. Only used if there is no corresponding value in the `values.yml` file. |
 | 	group             | string  | false      |  Group questions by input value. |
 | 	options           | []string | false     |  Specify the options when the variable type is `enum`, for example: options:<br/> - "ClusterIP" <br/> - "NodePort" <br/> - "LoadBalancer"|

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
@@ -108,7 +108,7 @@ This reference contains variables that you can use in `questions.yml` nested und
 | 	variable          | string  | true    |  Define the variable name specified in the `values.yml` file, using `foo.bar` for nested objects. |
 | 	label             | string  | true      |  Define the UI label. |
 | 	description       | string  | false      |  Specify the description of the variable.|
-| 	type              | string  | false      |  Default to `string` if not specified (current supported types are string, multiline, boolean, int, enum, password, storageclass, hostname, pvc, and secret).|
+| 	type              | string  | false      |  Default to `string` if not specified (current supported types are string, multiline, boolean, int, enum, password, storageclass, hostname, pvc, secret and cloudcredential).|
 | 	default           | string  | false      |  Specify the default value. Only used if there is no corresponding value in the `values.yml` file. |
 | 	group             | string  | false      |  Group questions by input value. |
 | 	options           | []string | false     |  Specify the options when the variable type is `enum`, for example: options:<br/> - "ClusterIP" <br/> - "NodePort" <br/> - "LoadBalancer"|


### PR DESCRIPTION
## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

I tried [this example](https://github.com/rancher/cluster-template-examples/blob/dc5c201c5415c430cdf4bcb6af975f9e516e970b/charts/questions.yaml#L13) and found that `cloudcredential` is indeed a valid type. It seems to be a drop-down menu that selects among the user's available Cloud Credentials.

![image](https://github.com/rancher/rancher-docs/assets/7773090/955fe8fe-ef95-46ea-8b28-411682792c71)