### PR TITLE
#1031 - Note about cloud credentials and admins

### DIFF
--- a/docs/reference-guides/user-settings/manage-cloud-credentials.md
+++ b/docs/reference-guides/user-settings/manage-cloud-credentials.md
@@ -17,7 +17,7 @@ You can create cloud credentials in two contexts:
 - [During creation of a node template](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md#node-templates) for a cluster.
 - In the **User Settings**
 
-Cloud credentials are permanently bound to their creator's user profile. They **cannot** be shared between non-admin users. However, admins are able to view and manage the cloud credentials of other users.
+Cloud credentials are bound to their creator's user profile. They **cannot** be shared between non-admin users. However, admins are able to view and manage the cloud credentials of other users.
 
 ## Creating a Cloud Credential from User Settings
 

--- a/docs/reference-guides/user-settings/manage-cloud-credentials.md
+++ b/docs/reference-guides/user-settings/manage-cloud-credentials.md
@@ -17,7 +17,7 @@ You can create cloud credentials in two contexts:
 - [During creation of a node template](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md#node-templates) for a cluster.
 - In the **User Settings**
 
-All cloud credentials are bound to the user profile of whoever created them. They **cannot** be shared between non-admin users. However, admins are able to view and manage the cloud credentials of other users.
+Cloud credentials are permanently bound to their creator's user profile. They **cannot** be shared between non-admin users. However, admins are able to view and manage the cloud credentials of other users.
 
 ## Creating a Cloud Credential from User Settings
 

--- a/docs/reference-guides/user-settings/manage-cloud-credentials.md
+++ b/docs/reference-guides/user-settings/manage-cloud-credentials.md
@@ -17,7 +17,7 @@ You can create cloud credentials in two contexts:
 - [During creation of a node template](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md#node-templates) for a cluster.
 - In the **User Settings**
 
-All cloud credentials are bound to the user profile of who created it. They **cannot** be shared across users.
+All cloud credentials are bound to the user profile of whoever created them. They **cannot** be shared between non-admin users. However, admins are able to view and manage the cloud credentials of other users.
 
 ## Creating a Cloud Credential from User Settings
 

--- a/versioned_docs/version-2.0-2.4/reference-guides/user-settings/manage-cloud-credentials.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/user-settings/manage-cloud-credentials.md
@@ -19,7 +19,7 @@ You can create cloud credentials in two contexts:
 - [During creation of a node template](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md#node-templates) for a cluster.
 - In the **User Settings**
 
-All cloud credentials are bound to the user profile of who created it. They **cannot** be shared across users.
+Cloud credentials are bound to their creator's user profile. They **cannot** be shared between non-admin users. However, admins are able to view and manage the cloud credentials of other users.
 
 ## Creating a Cloud Credential from User Settings
 

--- a/versioned_docs/version-2.5/reference-guides/user-settings/manage-cloud-credentials.md
+++ b/versioned_docs/version-2.5/reference-guides/user-settings/manage-cloud-credentials.md
@@ -17,7 +17,7 @@ You can create cloud credentials in two contexts:
 - [During creation of a node template](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md#node-templates) for a cluster.
 - In the **User Settings**
 
-All cloud credentials are bound to the user profile of who created it. They **cannot** be shared across users.
+Cloud credentials are bound to their creator's user profile. They **cannot** be shared between non-admin users. However, admins are able to view and manage the cloud credentials of other users.
 
 ## Creating a Cloud Credential from User Settings
 

--- a/versioned_docs/version-2.6/reference-guides/user-settings/manage-cloud-credentials.md
+++ b/versioned_docs/version-2.6/reference-guides/user-settings/manage-cloud-credentials.md
@@ -17,7 +17,7 @@ You can create cloud credentials in two contexts:
 - [During creation of a node template](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md#node-templates) for a cluster.
 - In the **User Settings**
 
-All cloud credentials are bound to the user profile of who created it. They **cannot** be shared across users.
+Cloud credentials are bound to their creator's user profile. They **cannot** be shared between non-admin users. However, admins are able to view and manage the cloud credentials of other users.
 
 ## Creating a Cloud Credential from User Settings
 

--- a/versioned_docs/version-2.7/reference-guides/user-settings/manage-cloud-credentials.md
+++ b/versioned_docs/version-2.7/reference-guides/user-settings/manage-cloud-credentials.md
@@ -17,7 +17,7 @@ You can create cloud credentials in two contexts:
 - [During creation of a node template](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md#node-templates) for a cluster.
 - In the **User Settings**
 
-All cloud credentials are bound to the user profile of who created it. They **cannot** be shared across users.
+Cloud credentials are bound to their creator's user profile. They **cannot** be shared between non-admin users. However, admins are able to view and manage the cloud credentials of other users.
 
 ## Creating a Cloud Credential from User Settings
 

--- a/versioned_docs/version-2.8/reference-guides/user-settings/manage-cloud-credentials.md
+++ b/versioned_docs/version-2.8/reference-guides/user-settings/manage-cloud-credentials.md
@@ -17,7 +17,7 @@ You can create cloud credentials in two contexts:
 - [During creation of a node template](../../pages-for-subheaders/use-new-nodes-in-an-infra-provider.md#node-templates) for a cluster.
 - In the **User Settings**
 
-All cloud credentials are bound to the user profile of who created it. They **cannot** be shared across users.
+Cloud credentials are bound to their creator's user profile. They **cannot** be shared between non-admin users. However, admins are able to view and manage the cloud credentials of other users.
 
 ## Creating a Cloud Credential from User Settings
 


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #1031 

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

Non-admin users can't share cloud credentials between themselves. However, admins can view and manage anyone else's cloud credentials

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->