### PR TITLE
Typo in heading, some style fixes across versions

### DIFF
--- a/docs/pages-for-subheaders/deploy-apps-across-clusters.md
+++ b/docs/pages-for-subheaders/deploy-apps-across-clusters.md
@@ -5,14 +5,13 @@ title: Deploying Applications across Clusters
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-apps-across-clusters"/>
 </head>
-### Fleet
 
-Rancher v2.5 introduced Fleet, a new way to deploy applications across clusters.
+Rancher uses Fleet to deploy applications across clusters.
 
-Continuous Delivery with Fleet is GitOps at scale. For more information, refer to the [Fleet section.](../how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md)
+Continuous Delivery with Fleet is GitOps at scale. For more information, refer to the [Fleet section](../how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md).
 
 ### Multi-cluster Apps
 
 In Rancher before v2.5, the multi-cluster apps feature was used to deploy applications across clusters. The multi-cluster apps feature is deprecated, but still available in Rancher v2.5.
 
-Refer to the documentation [here.](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md)
+Refer to the documentation [here](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md).

--- a/docs/pages-for-subheaders/deploy-apps-across-clusters.md
+++ b/docs/pages-for-subheaders/deploy-apps-across-clusters.md
@@ -14,4 +14,4 @@ Continuous Delivery with Fleet is GitOps at scale. For more information, refer t
 
 In Rancher before v2.5, the multi-cluster apps feature was used to deploy applications across clusters. The multi-cluster apps feature is deprecated, but still available in Rancher v2.5.
 
-Refer to the documentation [here](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md).
+See the [multi-cluster app documentation](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md) for more details.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/pages-for-subheaders/deploy-apps-across-clusters.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/pages-for-subheaders/deploy-apps-across-clusters.md
@@ -2,7 +2,6 @@
 title: 跨集群部署应用
 ---
 
-### Fleet
 
 Rancher 2.5 引入了 Fleet，这是一种跨集群部署应用的新方式。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/pages-for-subheaders/deploy-apps-across-clusters.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/pages-for-subheaders/deploy-apps-across-clusters.md
@@ -2,7 +2,6 @@
 title: 跨集群部署应用
 ---
 
-### Fleet
 
 Rancher 2.5 引入了 Fleet，这是一种跨集群部署应用的新方式。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7/pages-for-subheaders/deploy-apps-across-clusters.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7/pages-for-subheaders/deploy-apps-across-clusters.md
@@ -2,7 +2,6 @@
 title: 跨集群部署应用
 ---
 
-### Fleet
 
 Rancher 2.5 引入了 Fleet，这是一种跨集群部署应用的新方式。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.8/pages-for-subheaders/deploy-apps-across-clusters.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.8/pages-for-subheaders/deploy-apps-across-clusters.md
@@ -2,7 +2,6 @@
 title: 跨集群部署应用
 ---
 
-### Fleet
 
 Rancher 2.5 引入了 Fleet，这是一种跨集群部署应用的新方式。
 

--- a/versioned_docs/version-2.5/pages-for-subheaders/deploy-apps-across-clusters.md
+++ b/versioned_docs/version-2.5/pages-for-subheaders/deploy-apps-across-clusters.md
@@ -14,4 +14,4 @@ Fleet is GitOps at scale. For more information, refer to the [Fleet section](../
 
 In Rancher before v2.5, the multi-cluster apps feature was used to deploy applications across clusters. The multi-cluster apps feature is deprecated, but still available in Rancher v2.5.
 
-Refer to the documentation [here](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md).
+See the [multi-cluster app documentation](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md) for more details.

--- a/versioned_docs/version-2.5/pages-for-subheaders/deploy-apps-across-clusters.md
+++ b/versioned_docs/version-2.5/pages-for-subheaders/deploy-apps-across-clusters.md
@@ -6,14 +6,12 @@ title: Deploying Applications across Clusters
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-apps-across-clusters"/>
 </head>
 
-### Fleet
+Rancher v2.5 introduces Fleet, a new way to deploy applications across clusters.
 
-Rancher v2.5 introduced Fleet, a new way to deploy applications across clusters.
+Fleet is GitOps at scale. For more information, refer to the [Fleet section](../how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md).
 
-Fleet is GitOps at scale. For more information, refer to the [Fleet section.](../how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md)
-
-### Multi-cluster Apps
+## Multi-cluster Apps
 
 In Rancher before v2.5, the multi-cluster apps feature was used to deploy applications across clusters. The multi-cluster apps feature is deprecated, but still available in Rancher v2.5.
 
-Refer to the documentation [here.](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md)
+Refer to the documentation [here](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md).

--- a/versioned_docs/version-2.6/pages-for-subheaders/deploy-apps-across-clusters.md
+++ b/versioned_docs/version-2.6/pages-for-subheaders/deploy-apps-across-clusters.md
@@ -14,4 +14,4 @@ Continuous Delivery with Fleet is GitOps at scale. For more information, refer t
 
 In Rancher before v2.5, the multi-cluster apps feature was used to deploy applications across clusters. The multi-cluster apps feature is deprecated, but still available in Rancher v2.5.
 
-Refer to the documentation [here](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md).
+See the [multi-cluster app documentation](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md) for more details.

--- a/versioned_docs/version-2.6/pages-for-subheaders/deploy-apps-across-clusters.md
+++ b/versioned_docs/version-2.6/pages-for-subheaders/deploy-apps-across-clusters.md
@@ -5,14 +5,13 @@ title: Deploying Applications across Clusters
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-apps-across-clusters"/>
 </head>
-### Fleet
 
 Rancher v2.5 introduced Fleet, a new way to deploy applications across clusters.
 
-Continuous Delivery with Fleet is GitOps at scale. For more information, refer to the [Fleet section.](../how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md)
+Continuous Delivery with Fleet is GitOps at scale. For more information, refer to the [Fleet section](../how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md).
 
 ### Multi-cluster Apps
 
 In Rancher before v2.5, the multi-cluster apps feature was used to deploy applications across clusters. The multi-cluster apps feature is deprecated, but still available in Rancher v2.5.
 
-Refer to the documentation [here.](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md)
+Refer to the documentation [here](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md).

--- a/versioned_docs/version-2.7/pages-for-subheaders/deploy-apps-across-clusters.md
+++ b/versioned_docs/version-2.7/pages-for-subheaders/deploy-apps-across-clusters.md
@@ -5,14 +5,13 @@ title: Deploying Applications across Clusters
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-apps-across-clusters"/>
 </head>
-### Fleet
 
-Rancher v2.5 introduced Fleet, a new way to deploy applications across clusters.
+Rancher uses Fleet to deploy applications across clusters.
 
-Continuous Delivery with Fleet is GitOps at scale. For more information, refer to the [Fleet section.](../how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md)
+Continuous Delivery with Fleet is GitOps at scale. For more information, refer to the [Fleet section](../how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md).
 
 ### Multi-cluster Apps
 
 In Rancher before v2.5, the multi-cluster apps feature was used to deploy applications across clusters. The multi-cluster apps feature is deprecated, but still available in Rancher v2.5.
 
-Refer to the documentation [here.](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md)
+Refer to the documentation [here](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md).

--- a/versioned_docs/version-2.7/pages-for-subheaders/deploy-apps-across-clusters.md
+++ b/versioned_docs/version-2.7/pages-for-subheaders/deploy-apps-across-clusters.md
@@ -14,4 +14,4 @@ Continuous Delivery with Fleet is GitOps at scale. For more information, refer t
 
 In Rancher before v2.5, the multi-cluster apps feature was used to deploy applications across clusters. The multi-cluster apps feature is deprecated, but still available in Rancher v2.5.
 
-Refer to the documentation [here](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md).
+See the [multi-cluster app documentation](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md) for more details.

--- a/versioned_docs/version-2.8/pages-for-subheaders/deploy-apps-across-clusters.md
+++ b/versioned_docs/version-2.8/pages-for-subheaders/deploy-apps-across-clusters.md
@@ -5,14 +5,13 @@ title: Deploying Applications across Clusters
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-apps-across-clusters"/>
 </head>
-### Fleet
 
-Rancher v2.5 introduced Fleet, a new way to deploy applications across clusters.
+Rancher uses Fleet to deploy applications across clusters.
 
-Continuous Delivery with Fleet is GitOps at scale. For more information, refer to the [Fleet section.](../how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md)
+Continuous Delivery with Fleet is GitOps at scale. For more information, refer to the [Fleet section](../how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md).
 
 ### Multi-cluster Apps
 
 In Rancher before v2.5, the multi-cluster apps feature was used to deploy applications across clusters. The multi-cluster apps feature is deprecated, but still available in Rancher v2.5.
 
-Refer to the documentation [here.](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md)
+Refer to the documentation [here](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md).

--- a/versioned_docs/version-2.8/pages-for-subheaders/deploy-apps-across-clusters.md
+++ b/versioned_docs/version-2.8/pages-for-subheaders/deploy-apps-across-clusters.md
@@ -14,4 +14,4 @@ Continuous Delivery with Fleet is GitOps at scale. For more information, refer t
 
 In Rancher before v2.5, the multi-cluster apps feature was used to deploy applications across clusters. The multi-cluster apps feature is deprecated, but still available in Rancher v2.5.
 
-Refer to the documentation [here](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md).
+See the [multi-cluster app documentation](../how-to-guides/new-user-guides/deploy-apps-across-clusters/multi-cluster-apps.md) for more details.


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

For some reason, the syntax for the first heading on this page was visible:

![image](https://github.com/rancher/rancher-docs/assets/19174201/0d1c3b4c-b041-4a0c-9e11-c401551e6b5f)

I removed the first heading, because having a title followed by a heading goes against our style guidelines anyway. I also fixed some other style issues and updated the pages past v2.5 so that the description of Fleet would make more sense.

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->