### PR TITLE
Added non-changeable options to rke2-cluster-configuration

### DIFF
--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -362,6 +362,9 @@ machineGlobalConfig:
         - key2=value2
 ```
 
+There are some configuration options which aren't supported to be changed when provisioning via Rancher:
+- data-dir (Folder to hold state), will always stay the default `/var/lib/rancher/rke2`
+
 To make it easier to put files on nodes beforehand, Rancher expects the following values to be included in the configuration, while RKE2 expects the values to be entered as file paths:
 - audit-policy-file
 - cloud-provider-config

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -362,8 +362,8 @@ machineGlobalConfig:
         - key2=value2
 ```
 
-There are some configuration options which aren't supported to be changed when provisioning via Rancher:
-- data-dir (Folder to hold state), will always stay the default `/var/lib/rancher/rke2`
+There are some configuration options that can't be changed when provisioning via Rancher:
+- data-dir (folder to hold state), which defaults to `/var/lib/rancher/rke2`.
 
 To make it easier to put files on nodes beforehand, Rancher expects the following values to be included in the configuration, while RKE2 expects the values to be entered as file paths:
 - audit-policy-file

--- a/versioned_docs/version-2.6/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/versioned_docs/version-2.6/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -331,6 +331,9 @@ machineGlobalConfig:
         - key2=value2
 ```
 
+There are some configuration options that can't be changed when provisioning via Rancher:
+- data-dir (folder to hold state), which defaults to `/var/lib/rancher/rke2`.
+
 ### machineSelectorConfig
 
 This is the same as [`machineGlobalConfig`](#machineglobalconfig) except that a [label](#kubernetes-node-labels) selector can be specified with the configuration. The configuration will only be applied to nodes that match the provided label selector.

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -362,6 +362,9 @@ machineGlobalConfig:
         - key2=value2
 ```
 
+There are some configuration options that can't be changed when provisioning via Rancher:
+- data-dir (folder to hold state), which defaults to `/var/lib/rancher/rke2`.
+
 To make it easier to put files on nodes beforehand, Rancher expects the following values to be included in the configuration, while RKE2 expects the values to be entered as file paths:
 - audit-policy-file
 - cloud-provider-config

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
@@ -331,6 +331,31 @@ machineGlobalConfig:
         - key2=value2
 ```
 
+To make it easier to put files on nodes beforehand, Rancher expects the following values to be included in the configuration, while K3s expects the values to be entered as file paths:
+- private-registry
+- flannel-conf
+
+Rancher delivers the files to the path `/var/lib/rancher/k3s/etc/config-files/<option>` in target nodes, and sets the proper options in the K3s server.
+
+Example:
+```yaml
+apiVersion: provisioning.cattle.io/v1
+kind: Cluster
+spec:
+  rkeConfig:
+    machineGlobalConfig:
+      private-registry: |
+        mirrors:
+          docker.io:
+            endpoint:
+              - "http://mycustomreg.com:5000"
+        configs:
+          "mycustomreg:5000":
+            auth:
+              username: xxxxxx # this is the registry username
+              password: xxxxxx # this is the registry password
+```
+
 ### machineSelectorConfig
 
 `machineSelectorConfig` is the same as [`machineGlobalConfig`](#machineglobalconfig) except that a [label](#kubernetes-node-labels) selector can be specified with the configuration. The configuration will only be applied to nodes that match the provided label selector.

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -361,6 +361,9 @@ machineGlobalConfig:
         - key2=value2
 ```
 
+There are some configuration options that can't be changed when provisioning via Rancher:
+- data-dir (folder to hold state), which defaults to `/var/lib/rancher/rke2`.
+
 ### machineSelectorConfig
 
 `machineSelectorConfig` is the same as [`machineGlobalConfig`](#machineglobalconfig) except that a [label](#kubernetes-node-labels) selector can be specified with the configuration. The configuration will only be applied to nodes that match the provided label selector.

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -364,6 +364,31 @@ machineGlobalConfig:
 There are some configuration options that can't be changed when provisioning via Rancher:
 - data-dir (folder to hold state), which defaults to `/var/lib/rancher/rke2`.
 
+To make it easier to put files on nodes beforehand, Rancher expects the following values to be included in the configuration, while RKE2 expects the values to be entered as file paths:
+- audit-policy-file
+- cloud-provider-config
+- private-registry
+
+Rancher delivers the files to the path `/var/lib/rancher/rke2/etc/config-files/<option>` in target nodes, and sets the proper options in the RKE2 server.
+
+Example:
+```yaml
+apiVersion: provisioning.cattle.io/v1
+kind: Cluster
+spec:
+  rkeConfig:
+    machineGlobalConfig:
+      audit-policy-file: 
+        apiVersion: audit.k8s.io/v1 
+        kind: Policy 
+        rules: 
+        - level: RequestResponse
+          resources:
+          - group: ""
+            resources: 
+            - pods
+```
+
 ### machineSelectorConfig
 
 `machineSelectorConfig` is the same as [`machineGlobalConfig`](#machineglobalconfig) except that a [label](#kubernetes-node-labels) selector can be specified with the configuration. The configuration will only be applied to nodes that match the provided label selector.


### PR DESCRIPTION
## Description

This PR adds a notice about non-changeable options with the Rancher RKE2 provisioning. Users can be confused if they add supported RKE2 options to a Rancher cluster config which afterwards aren't reflected in the provisioning process.

`data-dir` for example is such an options that is non-changeable according to RKE2 devs: https://rancher-users.slack.com/archives/C3ASABBD1/p1704389340347459?thread_ts=1704376260.746929&cid=C3ASABBD1

For this option a new paragraph is added that describes that this option will always stay default regardless of the configured value.