### PR TITLE
Split link check into 2 steps. Enable frail mode for Markdown links

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -18,8 +18,10 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      - name: Check links
-        run: yarn run remark --quiet --use remark-validate-links --use remark-lint-no-dead-urls ./docs
+      - name: Check Markdown links
+        run: yarn run remark --quiet --use remark-validate-links ./docs
+      - name: Check External links
+        run: yarn run remark --quiet --use remark-lint-no-dead-urls ./docs
       - name: Test build website
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"


### PR DESCRIPTION
Depends on #1055

## Description

This PR splits the current link checking workflow into 2 steps so that we can enable frail mode on the Markdown link portion (i.e. PRs must have working Markdown links going forward). The split is currently needed because there are broken external links that don't have ideal fixes.
