### PR TITLE
add docs for additionalManifest field for RKE2/K3s cluster

### DIFF
--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
@@ -231,6 +231,7 @@ spec:
   kubernetesVersion: v1.26.7+k3s1
   localClusterAuthEndpoint: {}
   rkeConfig:
+    additionalManifest: ""
     chartValues: {}
     etcd:
       snapshotRetention: 5
@@ -307,9 +308,36 @@ spec:
 ```
 </details>
 
+### additionalManifest
+
+Specify the addition manifest(s) to be delivered to the control plane nodes. 
+The value is a String, and will be placed at the path `/var/lib/rancher/k3s/server/manifests/rancher/addons.yaml` on target nodes.
+
+Example:
+
+```yaml
+additionalManifest: |-
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: name-xxxx
+```
+
+
+:::note
+
+It is discouraged to provide HelmChartConfig for customizing the system charts via `additionalManifest`,
+it could cause unexpected behavior due to how multiple HelmChartConfig for the same chart being handled.
+
+The recommended approach is to utilize the `chartValues` field which is explained below.
+
+:::
+
 ### chartValues
 
 Specify the values for the system charts installed by K3s.
+
+For more information about how K3s manges packaged components, please refer to [K3s documentation](https://docs.k3s.io/installation/packaged-components).
 
 Example:
 

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
@@ -310,7 +310,8 @@ spec:
 
 ### additionalManifest
 
-Specify the addition manifest(s) to be delivered to the control plane nodes. 
+Specify additional manifests to deliver to the control plane nodes.
+
 The value is a String, and will be placed at the path `/var/lib/rancher/k3s/server/manifests/rancher/addons.yaml` on target nodes.
 
 Example:
@@ -326,10 +327,9 @@ additionalManifest: |-
 
 :::note
 
-It is discouraged to provide HelmChartConfig for customizing the system charts via `additionalManifest`,
-it could cause unexpected behavior due to how multiple HelmChartConfig for the same chart being handled.
+If you want to customize system charts, you should use the `chartValues` field as described below.
 
-The recommended approach is to utilize the `chartValues` field which is explained below.
+Alternatives, such as using a HelmChartConfig to customize the system charts via `additionalManifest`, can cause unexpected behavior, due to having multiple HelmChartConfigs for the same chart.
 
 :::
 

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -340,7 +340,8 @@ spec:
 
 ### additionalManifest
 
-Specify the addition manifest(s) to be delivered to the control plane nodes.
+Specify additional manifests to deliver to the control plane nodes.
+
 The value is a String, and will be placed at the path `/var/lib/rancher/rke2/server/manifests/rancher/addons.yaml` on target nodes.
 
 Example:
@@ -356,10 +357,9 @@ additionalManifest: |-
 
 :::note
 
-It is discouraged to provide HelmChartConfig for customizing the system charts via `additionalManifest`,
-it could cause unexpected behavior due to how multiple HelmChartConfig for the same chart being handled.
+If you want to customize system charts, you should use the `chartValues` field as described below.
 
-The recommended approach is to utilize the `chartValues` field which is explained below.
+Alternatives, such as using a HelmChartConfig to customize the system charts via `additionalManifest`, can cause unexpected behavior, due to having multiple HelmChartConfigs for the same chart.
 
 :::
 

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -280,6 +280,7 @@ spec:
   kubernetesVersion: v1.25.12+rke2r1
   localClusterAuthEndpoint: {}
   rkeConfig:
+    additionalManifest: ""
     chartValues:
       rke2-calico: {}
     etcd:
@@ -337,9 +338,36 @@ spec:
 ```
 </details>
 
+### additionalManifest
+
+Specify the addition manifest(s) to be delivered to the control plane nodes.
+The value is a String, and will be placed at the path `/var/lib/rancher/rke2/server/manifests/rancher/addons.yaml` on target nodes.
+
+Example:
+
+```yaml
+additionalManifest: |-
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: name-xxxx
+```
+
+
+:::note
+
+It is discouraged to provide HelmChartConfig for customizing the system charts via `additionalManifest`,
+it could cause unexpected behavior due to how multiple HelmChartConfig for the same chart being handled.
+
+The recommended approach is to utilize the `chartValues` field which is explained below.
+
+:::
+
 ### chartValues
 
 Specify the values for the system charts installed by RKE2.
+
+For more information about how RKE2 manges packaged components, please refer to [RKE2 documentation](https://docs.rke2.io/helm).
 
 Example:
 

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
@@ -310,7 +310,8 @@ spec:
 
 ### additionalManifest
 
-Specify the addition manifest(s) to be delivered to the control plane nodes.
+Specify additional manifests to deliver to the control plane nodes.
+
 The value is a String, and will be placed at the path `/var/lib/rancher/k3s/server/manifests/rancher/addons.yaml` on target nodes.
 
 Example:
@@ -326,10 +327,9 @@ additionalManifest: |-
 
 :::note
 
-It is discouraged to provide HelmChartConfig for customizing the system charts via `additionalManifest`,
-it could cause unexpected behavior due to how multiple HelmChartConfig for the same chart being handled.
+If you want to customize system charts, you should use the `chartValues` field as described below.
 
-The recommended approach is to utilize the `chartValues` field which is explained below.
+Alternatives, such as using a HelmChartConfig to customize the system charts via `additionalManifest`, can cause unexpected behavior, due to having multiple HelmChartConfigs for the same chart.
 
 :::
 

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
@@ -231,6 +231,7 @@ spec:
   kubernetesVersion: v1.26.7+k3s1
   localClusterAuthEndpoint: {}
   rkeConfig:
+    additionalManifest: ""
     chartValues: {}
     etcd:
       snapshotRetention: 5
@@ -307,9 +308,36 @@ spec:
 ```
 </details>
 
+### additionalManifest
+
+Specify the addition manifest(s) to be delivered to the control plane nodes.
+The value is a String, and will be placed at the path `/var/lib/rancher/k3s/server/manifests/rancher/addons.yaml` on target nodes.
+
+Example:
+
+```yaml
+additionalManifest: |-
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: name-xxxx
+```
+
+
+:::note
+
+It is discouraged to provide HelmChartConfig for customizing the system charts via `additionalManifest`,
+it could cause unexpected behavior due to how multiple HelmChartConfig for the same chart being handled.
+
+The recommended approach is to utilize the `chartValues` field which is explained below.
+
+:::
+
 ### chartValues
 
 Specify the values for the system charts installed by K3s.
+
+For more information about how K3s manges packaged components, please refer to [K3s documentation](https://docs.k3s.io/installation/packaged-components).
 
 Example:
 

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -340,7 +340,8 @@ spec:
 
 ### additionalManifest
 
-Specify the addition manifest(s) to be delivered to the control plane nodes.
+Specify additional manifests to deliver to the control plane nodes.
+
 The value is a String, and will be placed at the path `/var/lib/rancher/rke2/server/manifests/rancher/addons.yaml` on target nodes.
 
 Example:
@@ -356,10 +357,9 @@ additionalManifest: |-
 
 :::note
 
-It is discouraged to provide HelmChartConfig for customizing the system charts via `additionalManifest`,
-it could cause unexpected behavior due to how multiple HelmChartConfig for the same chart being handled.
+If you want to customize system charts, you should use the `chartValues` field as described below.
 
-The recommended approach is to utilize the `chartValues` field which is explained below.
+Alternatives, such as using a HelmChartConfig to customize the system charts via `additionalManifest`, can cause unexpected behavior, due to having multiple HelmChartConfigs for the same chart.
 
 :::
 

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -280,6 +280,7 @@ spec:
   kubernetesVersion: v1.25.12+rke2r1
   localClusterAuthEndpoint: {}
   rkeConfig:
+    additionalManifest: ""
     chartValues:
       rke2-calico: {}
     etcd:
@@ -337,9 +338,36 @@ spec:
 ```
 </details>
 
+### additionalManifest
+
+Specify the addition manifest(s) to be delivered to the control plane nodes.
+The value is a String, and will be placed at the path `/var/lib/rancher/rke2/server/manifests/rancher/addons.yaml` on target nodes.
+
+Example:
+
+```yaml
+additionalManifest: |-
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: name-xxxx
+```
+
+
+:::note
+
+It is discouraged to provide HelmChartConfig for customizing the system charts via `additionalManifest`,
+it could cause unexpected behavior due to how multiple HelmChartConfig for the same chart being handled.
+
+The recommended approach is to utilize the `chartValues` field which is explained below.
+
+:::
+
 ### chartValues
 
 Specify the values for the system charts installed by RKE2.
+
+For more information about how RKE2 manges packaged components, please refer to [RKE2 documentation](https://docs.rke2.io/helm).
 
 Example:
 

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
@@ -310,7 +310,8 @@ spec:
 
 ### additionalManifest
 
-Specify the addition manifest(s) to be delivered to the control plane nodes.
+Specify additional manifests to deliver to the control plane nodes.
+
 The value is a String, and will be placed at the path `/var/lib/rancher/k3s/server/manifests/rancher/addons.yaml` on target nodes.
 
 Example:
@@ -326,10 +327,9 @@ additionalManifest: |-
 
 :::note
 
-It is discouraged to provide HelmChartConfig for customizing the system charts via `additionalManifest`,
-it could cause unexpected behavior due to how multiple HelmChartConfig for the same chart being handled.
+If you want to customize system charts, you should use the `chartValues` field as described below.
 
-The recommended approach is to utilize the `chartValues` field which is explained below.
+Alternatives, such as using a HelmChartConfig to customize the system charts via `additionalManifest`, can cause unexpected behavior, due to having multiple HelmChartConfigs for the same chart.
 
 :::
 

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md
@@ -231,6 +231,7 @@ spec:
   kubernetesVersion: v1.26.7+k3s1
   localClusterAuthEndpoint: {}
   rkeConfig:
+    additionalManifest: ""
     chartValues: {}
     etcd:
       snapshotRetention: 5
@@ -307,9 +308,36 @@ spec:
 ```
 </details>
 
+### additionalManifest
+
+Specify the addition manifest(s) to be delivered to the control plane nodes.
+The value is a String, and will be placed at the path `/var/lib/rancher/k3s/server/manifests/rancher/addons.yaml` on target nodes.
+
+Example:
+
+```yaml
+additionalManifest: |-
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: name-xxxx
+```
+
+
+:::note
+
+It is discouraged to provide HelmChartConfig for customizing the system charts via `additionalManifest`,
+it could cause unexpected behavior due to how multiple HelmChartConfig for the same chart being handled.
+
+The recommended approach is to utilize the `chartValues` field which is explained below.
+
+:::
+
 ### chartValues
 
 Specify the values for the system charts installed by K3s.
+
+For more information about how K3s manges packaged components, please refer to [K3s documentation](https://docs.k3s.io/installation/packaged-components).
 
 Example:
 

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -340,7 +340,8 @@ spec:
 
 ### additionalManifest
 
-Specify the addition manifest(s) to be delivered to the control plane nodes.
+Specify additional manifests to deliver to the control plane nodes.
+
 The value is a String, and will be placed at the path `/var/lib/rancher/rke2/server/manifests/rancher/addons.yaml` on target nodes.
 
 Example:
@@ -356,10 +357,9 @@ additionalManifest: |-
 
 :::note
 
-It is discouraged to provide HelmChartConfig for customizing the system charts via `additionalManifest`,
-it could cause unexpected behavior due to how multiple HelmChartConfig for the same chart being handled.
+If you want to customize system charts, you should use the `chartValues` field as described below.
 
-The recommended approach is to utilize the `chartValues` field which is explained below.
+Alternatives, such as using a HelmChartConfig to customize the system charts via `additionalManifest`, can cause unexpected behavior, due to having multiple HelmChartConfigs for the same chart.
 
 :::
 

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md
@@ -280,6 +280,7 @@ spec:
   kubernetesVersion: v1.25.12+rke2r1
   localClusterAuthEndpoint: {}
   rkeConfig:
+    additionalManifest: ""
     chartValues:
       rke2-calico: {}
     etcd:
@@ -337,9 +338,36 @@ spec:
 ```
 </details>
 
+### additionalManifest
+
+Specify the addition manifest(s) to be delivered to the control plane nodes.
+The value is a String, and will be placed at the path `/var/lib/rancher/rke2/server/manifests/rancher/addons.yaml` on target nodes.
+
+Example:
+
+```yaml
+additionalManifest: |-
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: name-xxxx
+```
+
+
+:::note
+
+It is discouraged to provide HelmChartConfig for customizing the system charts via `additionalManifest`,
+it could cause unexpected behavior due to how multiple HelmChartConfig for the same chart being handled.
+
+The recommended approach is to utilize the `chartValues` field which is explained below.
+
+:::
+
 ### chartValues
 
 Specify the values for the system charts installed by RKE2.
+
+For more information about how RKE2 manges packaged components, please refer to [RKE2 documentation](https://docs.rke2.io/helm).
 
 Example:
 


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

https://github.com/rancher/rancher/issues/43614

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

This PR is to 
- add docs for the `additionalManifest` filed in RKE2/K3s cluster 
- add links to RKE2/K3s docs for properly using `chartValues` 

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->

The same changes are applied to the latest, the 2.8-version, and 2.7-version of the docs 