### PR TITLE
#982 Fix Documentation for upgrade steps on a Rancher 2.6 air-gapped (originally installed and upgraded with helm template)

### DIFF
--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -43,7 +43,7 @@ helm upgrade rancher ./rancher-<VERSION>.tgz \
 If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. To successfully upgrade Rancher, use the following command instead:
 
 ```
-helm template rancher ./rancher-<VERSION>.tgz \
+helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
     --no-hooks \ # prevent files for Helm hooks from being generated
 	--namespace cattle-system \
 	--set hostname=<RANCHER.YOURDOMAIN.COM> \

--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -40,7 +40,7 @@ helm upgrade rancher ./rancher-<VERSION>.tgz \
 
 #### Resolving UPGRADE FAILED Error
 
-If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. To successfully upgrade Rancher, use the following commands instead:
+If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. To successfully upgrade Rancher, use the following command instead:
 
 ```
 helm template rancher ./rancher-<VERSION>.tgz \
@@ -53,6 +53,11 @@ helm template rancher ./rancher-<VERSION>.tgz \
 	--set useBundledSystemChart=true # Use the packaged Rancher system charts
 ```
 
+After you run the Helm command, apply the rendered template:
+
+```
+kubectl -n cattle-system apply -R -f ./rancher
+```
 
 ### Option B: Certificates from Files using Kubernetes Secrets
 

--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -40,7 +40,7 @@ helm upgrade rancher ./rancher-<VERSION>.tgz \
 
 #### Resolving UPGRADE FAILED error
 
-If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. The `helm template` command can cause problems with Helm hooks. To successfully upgrade Rancher, use the following commands instead:
+If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. To successfully upgrade Rancher, use the following commands instead:
 
 ```
 helm template rancher ./rancher-<VERSION>.tgz \

--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -38,6 +38,36 @@ helm upgrade rancher ./rancher-<VERSION>.tgz \
 	--set useBundledSystemChart=true # Use the packaged Rancher system charts
 ```
 
+#### Resolving UPGRADE FAILED error
+
+If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. The `helm template` command can cause problems with Helm hooks. To successfully upgrade Rancher, use the following commands instead:
+
+```
+helm template rancher ./rancher-<VERSION>.tgz \
+    --no-hooks \ # prevent files for Helm hooks from being generated
+	--namespace cattle-system \
+	--set hostname=<RANCHER.YOURDOMAIN.COM> \
+	--set certmanager.version=<CERTMANAGER_VERSION> \
+	--set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
+	--set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+	--set useBundledSystemChart=true # Use the packaged Rancher system charts
+```
+
+#### Resolving UPGRADE FAILED error
+
+If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. The `helm template` command can cause problems with Helm hooks. To successfully upgrade Rancher, use the following commands instead:
+
+```
+helm template rancher ./rancher-<VERSION>.tgz \
+    --no-hooks \ # prevent files for Helm hooks from being generated
+	--namespace cattle-system \
+	--set hostname=<RANCHER.YOURDOMAIN.COM> \
+	--set certmanager.version=<CERTMANAGER_VERSION> \
+	--set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
+	--set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+	--set useBundledSystemChart=true # Use the packaged Rancher system charts
+```
+
 ### Option B: Certificates from Files using Kubernetes Secrets
 
 ```plain

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -53,6 +53,12 @@ helm template rancher ./rancher-<VERSION>.tgz \
 	--set useBundledSystemChart=true # Use the packaged Rancher system charts
 ```
 
+After you run the Helm command, apply the rendered template:
+
+```
+kubectl -n cattle-system apply -R -f ./rancher
+```
+
 ### Option B: Certificates from Files using Kubernetes Secrets
 
 ```plain

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -40,7 +40,7 @@ helm upgrade rancher ./rancher-<VERSION>.tgz \
 
 #### Resolving UPGRADE FAILED Error
 
-If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. To successfully upgrade Rancher, use the following commands instead:
+If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been installed via the `helm template` command. To successfully upgrade Rancher, use the following command instead:
 
 ```
 helm template rancher ./rancher-<VERSION>.tgz --output-dir . \

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -40,7 +40,7 @@ helm upgrade rancher ./rancher-<VERSION>.tgz \
 
 #### Resolving UPGRADE FAILED error
 
-If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. The `helm template` command can cause problems with Helm hooks. To successfully upgrade Rancher, use the following commands instead:
+If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. To successfully upgrade Rancher, use the following commands instead:
 
 ```
 helm template rancher ./rancher-<VERSION>.tgz \

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -43,7 +43,7 @@ helm upgrade rancher ./rancher-<VERSION>.tgz \
 If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. To successfully upgrade Rancher, use the following commands instead:
 
 ```
-helm template rancher ./rancher-<VERSION>.tgz \
+helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
     --no-hooks \ # prevent files for Helm hooks from being generated
 	--namespace cattle-system \
 	--set hostname=<RANCHER.YOURDOMAIN.COM> \

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -38,6 +38,21 @@ helm upgrade rancher ./rancher-<VERSION>.tgz \
 	--set useBundledSystemChart=true # Use the packaged Rancher system charts
 ```
 
+#### Resolving UPGRADE FAILED error
+
+If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. The `helm template` command can cause problems with Helm hooks. To successfully upgrade Rancher, use the following commands instead:
+
+```
+helm template rancher ./rancher-<VERSION>.tgz \
+    --no-hooks \ # prevent files for Helm hooks from being generated
+	--namespace cattle-system \
+	--set hostname=<RANCHER.YOURDOMAIN.COM> \
+	--set certmanager.version=<CERTMANAGER_VERSION> \
+	--set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
+	--set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+	--set useBundledSystemChart=true # Use the packaged Rancher system charts
+```
+
 ### Option B: Certificates from Files using Kubernetes Secrets
 
 ```plain

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -53,6 +53,12 @@ helm template rancher ./rancher-<VERSION>.tgz \
 	--set useBundledSystemChart=true # Use the packaged Rancher system charts
 ```
 
+After you run the helm command, apply the rendered template:
+
+```
+kubectl -n cattle-system apply -R -f ./rancher
+```
+
 ### Option B: Certificates from Files using Kubernetes Secrets
 
 ```plain

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -40,7 +40,7 @@ helm upgrade rancher ./rancher-<VERSION>.tgz \
 
 #### Resolving UPGRADE FAILED error
 
-If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. The `helm template` command can cause problems with Helm hooks. To successfully upgrade Rancher, use the following commands instead:
+If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. To successfully upgrade Rancher, use the following commands instead:
 
 ```
 helm template rancher ./rancher-<VERSION>.tgz \

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -43,7 +43,7 @@ helm upgrade rancher ./rancher-<VERSION>.tgz \
 If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. To successfully upgrade Rancher, use the following commands instead:
 
 ```
-helm template rancher ./rancher-<VERSION>.tgz \
+helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
     --no-hooks \ # prevent files for Helm hooks from being generated
 	--namespace cattle-system \
 	--set hostname=<RANCHER.YOURDOMAIN.COM> \

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -40,7 +40,7 @@ helm upgrade rancher ./rancher-<VERSION>.tgz \
 
 #### Resolving UPGRADE FAILED Error
 
-If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. To successfully upgrade Rancher, use the following commands instead:
+If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been installed via the `helm template` command. To successfully upgrade Rancher, use the following command instead:
 
 ```
 helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
@@ -53,7 +53,7 @@ helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
 	--set useBundledSystemChart=true # Use the packaged Rancher system charts
 ```
 
-After you run the helm command, apply the rendered template:
+After you run the Helm command, apply the rendered template:
 
 ```
 kubectl -n cattle-system apply -R -f ./rancher

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -38,6 +38,21 @@ helm upgrade rancher ./rancher-<VERSION>.tgz \
 	--set useBundledSystemChart=true # Use the packaged Rancher system charts
 ```
 
+#### Resolving UPGRADE FAILED error
+
+If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. The `helm template` command can cause problems with Helm hooks. To successfully upgrade Rancher, use the following commands instead:
+
+```
+helm template rancher ./rancher-<VERSION>.tgz \
+    --no-hooks \ # prevent files for Helm hooks from being generated
+	--namespace cattle-system \
+	--set hostname=<RANCHER.YOURDOMAIN.COM> \
+	--set certmanager.version=<CERTMANAGER_VERSION> \
+	--set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
+	--set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+	--set useBundledSystemChart=true # Use the packaged Rancher system charts
+```
+
 ### Option B: Certificates from Files using Kubernetes Secrets
 
 ```plain

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -53,6 +53,12 @@ helm template rancher ./rancher-<VERSION>.tgz \
 	--set useBundledSystemChart=true # Use the packaged Rancher system charts
 ```
 
+After you run the helm command, apply the rendered template:
+
+```
+kubectl -n cattle-system apply -R -f ./rancher
+```
+
 ### Option B: Certificates from Files using Kubernetes Secrets
 
 ```plain

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -40,7 +40,7 @@ helm upgrade rancher ./rancher-<VERSION>.tgz \
 
 #### Resolving UPGRADE FAILED error
 
-If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. The `helm template` command can cause problems with Helm hooks. To successfully upgrade Rancher, use the following commands instead:
+If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. To successfully upgrade Rancher, use the following commands instead:
 
 ```
 helm template rancher ./rancher-<VERSION>.tgz \

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -43,7 +43,7 @@ helm upgrade rancher ./rancher-<VERSION>.tgz \
 If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. To successfully upgrade Rancher, use the following commands instead:
 
 ```
-helm template rancher ./rancher-<VERSION>.tgz \
+helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
     --no-hooks \ # prevent files for Helm hooks from being generated
 	--namespace cattle-system \
 	--set hostname=<RANCHER.YOURDOMAIN.COM> \

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -40,7 +40,7 @@ helm upgrade rancher ./rancher-<VERSION>.tgz \
 
 #### Resolving UPGRADE FAILED Error
 
-If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. To successfully upgrade Rancher, use the following commands instead:
+If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been installed via the `helm template` command. To successfully upgrade Rancher, use the following command instead:
 
 ```
 helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
@@ -53,7 +53,7 @@ helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
 	--set useBundledSystemChart=true # Use the packaged Rancher system charts
 ```
 
-After you run the helm command, apply the rendered template:
+After you run the Helm command, apply the rendered template:
 
 ```
 kubectl -n cattle-system apply -R -f ./rancher

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/air-gapped-upgrades.md
@@ -38,6 +38,21 @@ helm upgrade rancher ./rancher-<VERSION>.tgz \
 	--set useBundledSystemChart=true # Use the packaged Rancher system charts
 ```
 
+#### Resolving UPGRADE FAILED error
+
+If you encounter the error message, `Error: UPGRADE FAILED: "rancher" has no deployed releases`, Rancher might have been  installed via the `helm template` command. The `helm template` command can cause problems with Helm hooks. To successfully upgrade Rancher, use the following commands instead:
+
+```
+helm template rancher ./rancher-<VERSION>.tgz \
+    --no-hooks \ # prevent files for Helm hooks from being generated
+	--namespace cattle-system \
+	--set hostname=<RANCHER.YOURDOMAIN.COM> \
+	--set certmanager.version=<CERTMANAGER_VERSION> \
+	--set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
+	--set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+	--set useBundledSystemChart=true # Use the packaged Rancher system charts
+```
+
 ### Option B: Certificates from Files using Kubernetes Secrets
 
 ```plain


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #982 (SURE-7154)

Addresses a problem that arose with https://github.com/rancher/rancher-docs/issues/808

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

Adds advice for users who installed Rancher with `helm template`. The `helm template` command is known to cause issues with upgrades under certain circumstances, and this is called out in our [Release Notes](https://github.com/rancher/rancher/releases/v2.7.8) (but see Comments below). #808 replaced commands containing `helm template` with `helm install` -- however, that still left users who had previously used `helm template` on the (web)hook when they attempt to upgrade Rancher and encounter an UPGRADE FAILED error. Since v2.5 wasn't affected by #808, I copied the first two lines of the upgrade command from that document, which includes the `--no-hooks` flag required to prevent the error from occurring. I included edits for v2.6, v2.7, and v2.8, because presumably this affects all Rancher versions going forward from v2.5.

## Comments

Oddly, the information in our release notes about this includes links to dead issues in the docs repo.

> Requirements for air gapped environments:
When installing or upgrading Rancher in an air gapped environment, add the flag --no-hooks to the helm template command, to skip rendering files for Helm's hooks. See [#3226](https://github.com/rancher/docs/issues/3226).
If using a proxy in front of an air-gapped Rancher instance, you must pass additional parameters to NO_PROXY. See the [documentation](https://docs.ranchermanager.rancher.io/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher) and related issue [#2725](https://github.com/rancher/docs/issues/2725#issuecomment-702454584).

 I'm guessing these originally linked to the old repo and got deleted at some point. I'll look into whether they were transferred to this repo later.

<!--
Any additional notes a reviewer should know before we review.
-->