### PR TITLE
Update CNI popularity table for 2.8.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build website
         env:
-          NODE_OPTIONS: "--max_old_space_size=4608"
+          NODE_OPTIONS: "--max_old_space_size=5120"
         run: yarn build --no-minify
 
       # Popular action to deploy to GitHub Pages:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -24,5 +24,5 @@ jobs:
         run: yarn run remark --quiet --use remark-lint-no-dead-urls ./docs
       - name: Test build website
         env:
-          NODE_OPTIONS: "--max_old_space_size=4608"
+          NODE_OPTIONS: "--max_old_space_size=5120"
         run: yarn build --no-minify

--- a/docs/faq/container-network-interface-providers.md
+++ b/docs/faq/container-network-interface-providers.md
@@ -182,18 +182,11 @@ The following table summarizes the different features available for each CNI net
 
 - Ingress/Egress Policies: This feature allows you to manage routing control for both Kubernetes and non-Kubernetes communications.
 
-<!-- releaseTask -->
 ## CNI Community Popularity
 
-The following table summarizes different GitHub metrics to give you an idea of each project's popularity and activity. This data was collected in November 2023.
+import CNIPopularityTable from '/shared-files/_cni-popularity.md';
 
-| Provider | Project | Stars | Forks | Contributors |
-| ---- | ---- | ---- | ---- | ---- |
-| Canal | https://github.com/projectcalico/canal | 707 | 104 | 20 |
-| Flannel | https://github.com/flannel-io/flannel | 8.3k | 2.9k | 225 |
-| Calico | https://github.com/projectcalico/calico | 5.1k | 1.2k | 328 |
-| Weave | https://github.com/weaveworks/weave/ | 6.5k | 672 | 87 |
-| Cilium | https://github.com/cilium/cilium | 17.1k | 2.5k | 677 |
+<CNIPopularityTable />
 
 ## Which CNI Provider Should I Use?
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "NODE_OPTIONS='--max-old-space-size=4608' docusaurus build",
+    "build": "NODE_OPTIONS='--max-old-space-size=5120' docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/shared-files/_cni-popularity.md
+++ b/shared-files/_cni-popularity.md
@@ -1,0 +1,10 @@
+<!-- releaseTask -->
+The following table summarizes different GitHub metrics to give you an idea of each project's popularity and activity. This data was collected in January 2024.
+
+| Provider | Project | Stars | Forks | Contributors |
+| ---- | ---- | ---- | ---- | ---- |
+| Canal | https://github.com/projectcalico/canal | 708 | 103 | 20 |
+| Flannel | https://github.com/flannel-io/flannel | 8.3k | 2.9k | 231 |
+| Calico | https://github.com/projectcalico/calico | 5.2k | 1.2k | 332 |
+| Weave | https://github.com/weaveworks/weave/ | 6.5k | 670 | 87 |
+| Cilium | https://github.com/cilium/cilium | 17.6k | 2.6k | 689 |

--- a/shared-files/_cni-popularity.md
+++ b/shared-files/_cni-popularity.md
@@ -1,5 +1,5 @@
 <!-- releaseTask -->
-The following table summarizes different GitHub metrics to give you an idea of each project's popularity and activity. This data was collected in January 2024.
+The following table summarizes different GitHub metrics to give you an idea of each project's popularity and activity levels. This data was collected in January 2024.
 
 | Provider | Project | Stars | Forks | Contributors |
 | ---- | ---- | ---- | ---- | ---- |

--- a/versioned_docs/version-2.0-2.4/faq/container-network-interface-providers.md
+++ b/versioned_docs/version-2.0-2.4/faq/container-network-interface-providers.md
@@ -134,18 +134,12 @@ The following table summarizes the different features available for each CNI net
 
 - Ingress/Egress Policies: This feature allows you to manage routing control for both Kubernetes and non-Kubernetes communications.
 
-#### CNI Community Popularity
+### CNI Community Popularity
 
-The following table summarizes different GitHub metrics to give you an idea of each project's popularity and activity. This data was collected in January 2020.
+import CNIPopularityTable from '/shared-files/_cni-popularity.md';
 
-| Provider | Project | Stars | Forks | Contributors |
-| ---- | ---- | ---- | ---- | ---- |
-| Canal | https://github.com/projectcalico/canal | 614 | 89 | 19 |
-| flannel | https://github.com/coreos/flannel | 4977 | 1.4k | 140 |
-| Calico | https://github.com/projectcalico/calico | 1534 | 429 | 135 |
-| Weave | https://github.com/weaveworks/weave/ | 5737 | 559 | 73 |
+<CNIPopularityTable />
 
-<br/>
 ### Which CNI Provider Should I Use?
 
 It depends on your project needs. There are many different providers, which each have various features and options. There isn't one provider that meets everyone's needs.

--- a/versioned_docs/version-2.5/faq/container-network-interface-providers.md
+++ b/versioned_docs/version-2.5/faq/container-network-interface-providers.md
@@ -132,18 +132,11 @@ The following table summarizes the different features available for each CNI net
 
 - Ingress/Egress Policies: This feature allows you to manage routing control for both Kubernetes and non-Kubernetes communications.
 
-#### CNI Community Popularity
+### CNI Community Popularity
 
-The following table summarizes different GitHub metrics to give you an idea of each project's popularity and activity. This data was collected in January 2020.
+import CNIPopularityTable from '/shared-files/_cni-popularity.md';
 
-| Provider | Project | Stars | Forks | Contributors |
-| ---- | ---- | ---- | ---- | ---- |
-| Canal | https://github.com/projectcalico/canal | 614 | 89 | 19 |
-| flannel | https://github.com/coreos/flannel | 4977 | 1.4k | 140 |
-| Calico | https://github.com/projectcalico/calico | 1534 | 429 | 135 |
-| Weave | https://github.com/weaveworks/weave/ | 5737 | 559 | 73 |
-
-<br/>
+<CNIPopularityTable />
 
 ### Which CNI Provider Should I Use?
 

--- a/versioned_docs/version-2.6/faq/container-network-interface-providers.md
+++ b/versioned_docs/version-2.6/faq/container-network-interface-providers.md
@@ -184,15 +184,9 @@ The following table summarizes the different features available for each CNI net
 
 ## CNI Community Popularity
 
-The following table summarizes different GitHub metrics to give you an idea of each project's popularity and activity. This data was collected in November 2023.
+import CNIPopularityTable from '/shared-files/_cni-popularity.md';
 
-| Provider | Project | Stars | Forks | Contributors |
-| ---- | ---- | ---- | ---- | ---- |
-| Canal | https://github.com/projectcalico/canal | 707 | 104 | 20 |
-| Flannel | https://github.com/flannel-io/flannel | 8.3k | 2.9k | 225 |
-| Calico | https://github.com/projectcalico/calico | 5.1k | 1.2k | 328 |
-| Weave | https://github.com/weaveworks/weave/ | 6.5k | 672 | 87 |
-| Cilium | https://github.com/cilium/cilium | 17.1k | 2.5k | 677 |
+<CNIPopularityTable />
 
 ## Which CNI Provider Should I Use?
 

--- a/versioned_docs/version-2.7/faq/container-network-interface-providers.md
+++ b/versioned_docs/version-2.7/faq/container-network-interface-providers.md
@@ -184,15 +184,9 @@ The following table summarizes the different features available for each CNI net
 
 ## CNI Community Popularity
 
-The following table summarizes different GitHub metrics to give you an idea of each project's popularity and activity. This data was collected in November 2023.
+import CNIPopularityTable from '/shared-files/_cni-popularity.md';
 
-| Provider | Project | Stars | Forks | Contributors |
-| ---- | ---- | ---- | ---- | ---- |
-| Canal | https://github.com/projectcalico/canal | 707 | 104 | 20 |
-| Flannel | https://github.com/flannel-io/flannel | 8.3k | 2.9k | 225 |
-| Calico | https://github.com/projectcalico/calico | 5.1k | 1.2k | 328 |
-| Weave | https://github.com/weaveworks/weave/ | 6.5k | 672 | 87 |
-| Cilium | https://github.com/cilium/cilium | 17.1k | 2.5k | 677 |
+<CNIPopularityTable />
 
 ## Which CNI Provider Should I Use?
 

--- a/versioned_docs/version-2.8/faq/container-network-interface-providers.md
+++ b/versioned_docs/version-2.8/faq/container-network-interface-providers.md
@@ -184,15 +184,9 @@ The following table summarizes the different features available for each CNI net
 
 ## CNI Community Popularity
 
-The following table summarizes different GitHub metrics to give you an idea of each project's popularity and activity. This data was collected in November 2023.
+import CNIPopularityTable from '/shared-files/_cni-popularity.md';
 
-| Provider | Project | Stars | Forks | Contributors |
-| ---- | ---- | ---- | ---- | ---- |
-| Canal | https://github.com/projectcalico/canal | 707 | 104 | 20 |
-| Flannel | https://github.com/flannel-io/flannel | 8.3k | 2.9k | 225 |
-| Calico | https://github.com/projectcalico/calico | 5.1k | 1.2k | 328 |
-| Weave | https://github.com/weaveworks/weave/ | 6.5k | 672 | 87 |
-| Cilium | https://github.com/cilium/cilium | 17.1k | 2.5k | 677 |
+<CNIPopularityTable />
 
 ## Which CNI Provider Should I Use?
 


### PR DESCRIPTION
Related to #1069 

## Description

Updates the table with the current counts as of 2.8.1 release.

Additionally, I've moved the table into a partial under a top-level shared-files directory since the table is the same for all versions. This allows us to only maintain one copy of the content.
