### PR TITLE
Bump heap size allocation - some builds not passing again

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build website
         env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: "--max_old_space_size=4608"
         run: yarn build --no-minify
 
       # Popular action to deploy to GitHub Pages:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -24,5 +24,5 @@ jobs:
         run: yarn run remark --quiet --use remark-lint-no-dead-urls ./docs
       - name: Test build website
         env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: "--max_old_space_size=4608"
         run: yarn build --no-minify

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "NODE_OPTIONS='--max-old-space-size=4096' docusaurus build",
+    "build": "NODE_OPTIONS='--max-old-space-size=4608' docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
## Description 

Increases the heap size as we're seeing the `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` error pop up again on https://github.com/rancher/rancher-docs/actions/runs/7574990138.

