### PR TITLE
Add quick-start guide for Linode

### DIFF
--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
@@ -14,6 +14,7 @@ Use one of the following guides to deploy and provision Rancher and a Kubernetes
 - [DigitalOcean](digitalocean.md) (uses Terraform)
 - [GCP](gcp.md) (uses Terraform)
 - [Hetzner Cloud](hetzner-cloud.md) (uses Terraform)
+- [Linode](linode.md) (uses Terraform)
 - [Vagrant](vagrant.md)
 - [Equinix Metal](equinix-metal.md)
 - [Outscale](outscale-qs.md) (uses Terraform)

--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/linode.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/linode.md
@@ -38,14 +38,16 @@ Deploying to Linode will incur charges.
 
 4. Edit `terraform.tfvars` and customize the following variables:
     - `linode_token` - The Linode Personal Access Token mentioned above.
-    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
+    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters).
 
 5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Linode Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/linode) for more information. Suggestions include:
-   - `linode_region` - The target Linode region to provision the server and cluster in. (Default `eu-central`)
+   - `linode_region` - The target Linode region to provision the server and cluster in.
+     - Default: `eu-central`
      - For a complete list of regions, see the [official Region Availability page](https://www.linode.com/global-infrastructure/availability/).
    - `prefix` - The prefix for all created infrastructure.
-   - `linode_type` - The type/plan that all infrastructure Linodes should use. (Default `g6-standard-2`)
+   - `linode_type` - The type/plan that all infrastructure Linodes should use.
+     - Default: `g6-standard-2` 
      - For a complete list of plans, see the [official Plan Types page](https://www.linode.com/docs/products/compute/compute-instances/plans/).
 
 6. Run `terraform init`.
@@ -62,8 +64,8 @@ See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Lino
     workload_node_ip = yy.yy.yy.yy
     ```
 
-8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
-9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/linode`.
+8. Paste the `rancher_server_url` from the output above into the browser and log in when prompted. The default username is `admin` and the password is defined in `rancher_server_admin_password`.
+9. `ssh` into the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/linode`.
 
 #### Result
 

--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/linode.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/linode.md
@@ -1,0 +1,80 @@
+---
+title: Rancher Linode Quick Start Guide
+description: Read this step by step guide to quickly deploy a Rancher server with a single-node downstream Kubernetes cluster attached.
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/linode"/>
+</head>
+
+The following steps will quickly deploy a Rancher server on Linode in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
+
+:::caution
+
+The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation](../../installation-and-upgrade/installation-and-upgrade.md).
+
+:::
+
+## Prerequisites
+
+:::caution
+
+Deploying to Linode will incur charges.
+
+:::
+
+- [Linode Account](https://linode.com): The Linode account to run provision server and cluster under.
+- [Linode Personal Access Token](https://www.linode.com/docs/products/tools/api/guides/manage-api-tokens/): A Linode Personal Access Token to authenticate with.
+- [Terraform](https://www.terraform.io/downloads.html): Used to provision the server and cluster on Linode.
+
+
+## Getting Started
+
+1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
+
+2. Go into the Linode folder containing the Terraform files by executing `cd quickstart/rancher/linode`.
+
+3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
+
+4. Edit `terraform.tfvars` and customize the following variables:
+    - `linode_token` - The Linode Personal Access Token mentioned above.
+    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
+
+5. **Optional:** Modify optional variables within `terraform.tfvars`.
+See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Linode Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/linode) for more information. Suggestions include:
+   - `linode_region` - The target Linode region to provision the server and cluster in. (Default `eu-central`)
+     - For a complete list of regions, see the [official Region Availability page](https://www.linode.com/global-infrastructure/availability/).
+   - `prefix` - The prefix for all created infrastructure.
+   - `linode_type` - The type/plan that all infrastructure Linodes should use. (Default `g6-standard-2`)
+     - For a complete list of plans, see the [official Plan Types page](https://www.linode.com/docs/products/compute/compute-instances/plans/).
+
+6. Run `terraform init`.
+
+7. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
+
+    ```
+    Apply complete! Resources: 15 added, 0 changed, 0 destroyed.
+
+    Outputs:
+
+    rancher_node_ip = xx.xx.xx.xx
+    rancher_server_url = https://rancher.xx.xx.xx.xx.sslip.io
+    workload_node_ip = yy.yy.yy.yy
+    ```
+
+8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/linode`.
+
+#### Result
+
+Two Kubernetes clusters are deployed on your Linode account, one running Rancher Server and the other ready for experimentation deployments. Please note that while this setup is a great way to explore Rancher functionality, a production setup should follow our high availability setup guidelines. SSH keys for the VMs are auto-generated and stored in the module directory.
+
+### What's Next?
+
+Use Rancher to create a deployment. For more information, see [Creating Deployments](../deploy-workloads/deploy-workloads.md).
+
+## Destroying the Environment
+
+1. From the `quickstart/rancher/linode` folder, execute `terraform destroy --auto-approve`.
+
+2. Wait for confirmation that all resources have been destroyed.

--- a/docs/getting-started/quick-start-guides/deploy-workloads/workload-ingress.md
+++ b/docs/getting-started/quick-start-guides/deploy-workloads/workload-ingress.md
@@ -73,4 +73,5 @@ When you're done using your sandbox, destroy the Rancher Server and your cluster
 
 - [Amazon AWS: Destroying the Environment](../deploy-rancher-manager/aws.md#destroying-the-environment)
 - [DigitalOcean: Destroying the Environment](../deploy-rancher-manager/digitalocean.md#destroying-the-environment)
+- [Linode: Destroying the Environment](../deploy-rancher-manager/linode.md#destroying-the-environment)
 - [Vagrant: Destroying the Environment](../deploy-rancher-manager/vagrant.md#destroying-the-environment)

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
@@ -23,7 +23,7 @@ To create, edit, or delete drivers, you need _one_ of the following permissions:
 
 ## Activating/Deactivating Node Drivers
 
-By default, Rancher only activates drivers for the most popular cloud providers, Amazon EC2, Azure, DigitalOcean and vSphere. If you want to show or hide any node driver, you can change its status.
+By default, Rancher only activates drivers for the most popular cloud providers, Amazon EC2, Azure, DigitalOcean, Linode and vSphere. If you want to show or hide any node driver, you can change its status.
 
 1. In the upper left corner, click **☰ > Cluster Management**.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -47,6 +47,7 @@ const sidebars = {
                 "getting-started/quick-start-guides/deploy-rancher-manager/digitalocean",
                 "getting-started/quick-start-guides/deploy-rancher-manager/gcp",
                 "getting-started/quick-start-guides/deploy-rancher-manager/hetzner-cloud",
+                "getting-started/quick-start-guides/deploy-rancher-manager/linode",
                 "getting-started/quick-start-guides/deploy-rancher-manager/vagrant",
                 "getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal",
                 "getting-started/quick-start-guides/deploy-rancher-manager/outscale-qs",

--- a/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
+++ b/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
@@ -14,6 +14,7 @@ Use one of the following guides to deploy and provision Rancher and a Kubernetes
 - [DigitalOcean](digitalocean.md) (uses Terraform)
 - [GCP](gcp.md) (uses Terraform)
 - [Hetzner Cloud](hetzner-cloud.md) (uses Terraform)
+- [Linode](linode.md) (uses Terraform)
 - [Vagrant](vagrant.md)
 - [Equinix Metal](equinix-metal.md)
 - [Outscale](outscale-qs.md) (uses Terraform)

--- a/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/linode.md
+++ b/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/linode.md
@@ -1,0 +1,80 @@
+---
+title: Rancher Linode Quick Start Guide
+description: Read this step by step guide to quickly deploy a Rancher server with a single-node downstream Kubernetes cluster attached.
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/linode"/>
+</head>
+
+The following steps will quickly deploy a Rancher server on Linode in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
+
+:::caution
+
+The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation](../../installation-and-upgrade/installation-and-upgrade.md).
+
+:::
+
+## Prerequisites
+
+:::caution
+
+Deploying to Linode will incur charges.
+
+:::
+
+- [Linode Account](https://linode.com): The Linode account to run provision server and cluster under.
+- [Linode Personal Access Token](https://www.linode.com/docs/products/tools/api/guides/manage-api-tokens/): A Linode Personal Access Token to authenticate with.
+- [Terraform](https://www.terraform.io/downloads.html): Used to provision the server and cluster on Linode.
+
+
+## Getting Started
+
+1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
+
+2. Go into the Linode folder containing the Terraform files by executing `cd quickstart/rancher/linode`.
+
+3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
+
+4. Edit `terraform.tfvars` and customize the following variables:
+    - `linode_token` - The Linode Personal Access Token mentioned above.
+    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
+
+5. **Optional:** Modify optional variables within `terraform.tfvars`.
+See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Linode Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/linode) for more information. Suggestions include:
+   - `linode_region` - The target Linode region to provision the server and cluster in. (Default `eu-central`)
+     - For a complete list of regions, see the [official Region Availability page](https://www.linode.com/global-infrastructure/availability/).
+   - `prefix` - The prefix for all created infrastructure.
+   - `linode_type` - The type/plan that all infrastructure Linodes should use. (Default `g6-standard-2`)
+     - For a complete list of plans, see the [official Plan Types page](https://www.linode.com/docs/products/compute/compute-instances/plans/).
+
+6. Run `terraform init`.
+
+7. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
+
+    ```
+    Apply complete! Resources: 15 added, 0 changed, 0 destroyed.
+
+    Outputs:
+
+    rancher_node_ip = xx.xx.xx.xx
+    rancher_server_url = https://rancher.xx.xx.xx.xx.sslip.io
+    workload_node_ip = yy.yy.yy.yy
+    ```
+
+8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/linode`.
+
+#### Result
+
+Two Kubernetes clusters are deployed on your Linode account, one running Rancher Server and the other ready for experimentation deployments. Please note that while this setup is a great way to explore Rancher functionality, a production setup should follow our high availability setup guidelines. SSH keys for the VMs are auto-generated and stored in the module directory.
+
+### What's Next?
+
+Use Rancher to create a deployment. For more information, see [Creating Deployments](../deploy-workloads/deploy-workloads.md).
+
+## Destroying the Environment
+
+1. From the `quickstart/rancher/linode` folder, execute `terraform destroy --auto-approve`.
+
+2. Wait for confirmation that all resources have been destroyed.

--- a/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/linode.md
+++ b/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/linode.md
@@ -37,16 +37,18 @@ Deploying to Linode will incur charges.
 3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
 4. Edit `terraform.tfvars` and customize the following variables:
-    - `linode_token` - The Linode Personal Access Token mentioned above.
-    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
+  - `linode_token` - The Linode Personal Access Token mentioned above.
+  - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters).
 
 5. **Optional:** Modify optional variables within `terraform.tfvars`.
-See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Linode Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/linode) for more information. Suggestions include:
-   - `linode_region` - The target Linode region to provision the server and cluster in. (Default `eu-central`)
-     - For a complete list of regions, see the [official Region Availability page](https://www.linode.com/global-infrastructure/availability/).
-   - `prefix` - The prefix for all created infrastructure.
-   - `linode_type` - The type/plan that all infrastructure Linodes should use. (Default `g6-standard-2`)
-     - For a complete list of plans, see the [official Plan Types page](https://www.linode.com/docs/products/compute/compute-instances/plans/).
+   See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Linode Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/linode) for more information. Suggestions include:
+  - `linode_region` - The target Linode region to provision the server and cluster in.
+    - Default: `eu-central`
+    - For a complete list of regions, see the [official Region Availability page](https://www.linode.com/global-infrastructure/availability/).
+  - `prefix` - The prefix for all created infrastructure.
+  - `linode_type` - The type/plan that all infrastructure Linodes should use.
+    - Default: `g6-standard-2`
+    - For a complete list of plans, see the [official Plan Types page](https://www.linode.com/docs/products/compute/compute-instances/plans/).
 
 6. Run `terraform init`.
 
@@ -62,8 +64,8 @@ See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Lino
     workload_node_ip = yy.yy.yy.yy
     ```
 
-8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
-9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/linode`.
+8. Paste the `rancher_server_url` from the output above into the browser and log in when prompted. The default username is `admin` and the password is defined in `rancher_server_admin_password`.
+9. `ssh` into the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/linode`.
 
 #### Result
 

--- a/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-workloads/workload-ingress.md
+++ b/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-workloads/workload-ingress.md
@@ -73,4 +73,5 @@ When you're done using your sandbox, destroy the Rancher Server and your cluster
 
 - [Amazon AWS: Destroying the Environment](../deploy-rancher-manager/aws.md#destroying-the-environment)
 - [DigitalOcean: Destroying the Environment](../deploy-rancher-manager/digitalocean.md#destroying-the-environment)
+- [Linode: Destroying the Environment](../deploy-rancher-manager/linode.md#destroying-the-environment)
 - [Vagrant: Destroying the Environment](../deploy-rancher-manager/vagrant.md#destroying-the-environment)

--- a/versioned_docs/version-2.7/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
+++ b/versioned_docs/version-2.7/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
@@ -14,6 +14,7 @@ Use one of the following guides to deploy and provision Rancher and a Kubernetes
 - [DigitalOcean](digitalocean.md) (uses Terraform)
 - [GCP](gcp.md) (uses Terraform)
 - [Hetzner Cloud](hetzner-cloud.md) (uses Terraform)
+- [Linode](linode.md) (uses Terraform)
 - [Vagrant](vagrant.md)
 - [Equinix Metal](equinix-metal.md)
 - [Outscale](outscale-qs.md) (uses Terraform)

--- a/versioned_docs/version-2.7/getting-started/quick-start-guides/deploy-rancher-manager/linode.md
+++ b/versioned_docs/version-2.7/getting-started/quick-start-guides/deploy-rancher-manager/linode.md
@@ -1,0 +1,80 @@
+---
+title: Rancher Linode Quick Start Guide
+description: Read this step by step guide to quickly deploy a Rancher server with a single-node downstream Kubernetes cluster attached.
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/linode"/>
+</head>
+
+The following steps will quickly deploy a Rancher server on Linode in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
+
+:::caution
+
+The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation](../../installation-and-upgrade/installation-and-upgrade.md).
+
+:::
+
+## Prerequisites
+
+:::caution
+
+Deploying to Linode will incur charges.
+
+:::
+
+- [Linode Account](https://linode.com): The Linode account to run provision server and cluster under.
+- [Linode Personal Access Token](https://www.linode.com/docs/products/tools/api/guides/manage-api-tokens/): A Linode Personal Access Token to authenticate with.
+- [Terraform](https://www.terraform.io/downloads.html): Used to provision the server and cluster on Linode.
+
+
+## Getting Started
+
+1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
+
+2. Go into the Linode folder containing the Terraform files by executing `cd quickstart/rancher/linode`.
+
+3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
+
+4. Edit `terraform.tfvars` and customize the following variables:
+    - `linode_token` - The Linode Personal Access Token mentioned above.
+    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
+
+5. **Optional:** Modify optional variables within `terraform.tfvars`.
+See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Linode Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/linode) for more information. Suggestions include:
+   - `linode_region` - The target Linode region to provision the server and cluster in. (Default `eu-central`)
+     - For a complete list of regions, see the [official Region Availability page](https://www.linode.com/global-infrastructure/availability/).
+   - `prefix` - The prefix for all created infrastructure.
+   - `linode_type` - The type/plan that all infrastructure Linodes should use. (Default `g6-standard-2`)
+     - For a complete list of plans, see the [official Plan Types page](https://www.linode.com/docs/products/compute/compute-instances/plans/).
+
+6. Run `terraform init`.
+
+7. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
+
+    ```
+    Apply complete! Resources: 15 added, 0 changed, 0 destroyed.
+
+    Outputs:
+
+    rancher_node_ip = xx.xx.xx.xx
+    rancher_server_url = https://rancher.xx.xx.xx.xx.sslip.io
+    workload_node_ip = yy.yy.yy.yy
+    ```
+
+8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/linode`.
+
+#### Result
+
+Two Kubernetes clusters are deployed on your Linode account, one running Rancher Server and the other ready for experimentation deployments. Please note that while this setup is a great way to explore Rancher functionality, a production setup should follow our high availability setup guidelines. SSH keys for the VMs are auto-generated and stored in the module directory.
+
+### What's Next?
+
+Use Rancher to create a deployment. For more information, see [Creating Deployments](../deploy-workloads/deploy-workloads.md).
+
+## Destroying the Environment
+
+1. From the `quickstart/rancher/linode` folder, execute `terraform destroy --auto-approve`.
+
+2. Wait for confirmation that all resources have been destroyed.

--- a/versioned_docs/version-2.7/getting-started/quick-start-guides/deploy-rancher-manager/linode.md
+++ b/versioned_docs/version-2.7/getting-started/quick-start-guides/deploy-rancher-manager/linode.md
@@ -37,16 +37,18 @@ Deploying to Linode will incur charges.
 3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
 4. Edit `terraform.tfvars` and customize the following variables:
-    - `linode_token` - The Linode Personal Access Token mentioned above.
-    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
+  - `linode_token` - The Linode Personal Access Token mentioned above.
+  - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters).
 
 5. **Optional:** Modify optional variables within `terraform.tfvars`.
-See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Linode Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/linode) for more information. Suggestions include:
-   - `linode_region` - The target Linode region to provision the server and cluster in. (Default `eu-central`)
-     - For a complete list of regions, see the [official Region Availability page](https://www.linode.com/global-infrastructure/availability/).
-   - `prefix` - The prefix for all created infrastructure.
-   - `linode_type` - The type/plan that all infrastructure Linodes should use. (Default `g6-standard-2`)
-     - For a complete list of plans, see the [official Plan Types page](https://www.linode.com/docs/products/compute/compute-instances/plans/).
+   See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Linode Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/linode) for more information. Suggestions include:
+  - `linode_region` - The target Linode region to provision the server and cluster in.
+    - Default: `eu-central`
+    - For a complete list of regions, see the [official Region Availability page](https://www.linode.com/global-infrastructure/availability/).
+  - `prefix` - The prefix for all created infrastructure.
+  - `linode_type` - The type/plan that all infrastructure Linodes should use.
+    - Default: `g6-standard-2`
+    - For a complete list of plans, see the [official Plan Types page](https://www.linode.com/docs/products/compute/compute-instances/plans/).
 
 6. Run `terraform init`.
 
@@ -62,8 +64,8 @@ See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Lino
     workload_node_ip = yy.yy.yy.yy
     ```
 
-8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
-9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/linode`.
+8. Paste the `rancher_server_url` from the output above into the browser and log in when prompted. The default username is `admin` and the password is defined in `rancher_server_admin_password`.
+9. `ssh` into the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/linode`.
 
 #### Result
 

--- a/versioned_docs/version-2.7/getting-started/quick-start-guides/deploy-workloads/workload-ingress.md
+++ b/versioned_docs/version-2.7/getting-started/quick-start-guides/deploy-workloads/workload-ingress.md
@@ -73,4 +73,5 @@ When you're done using your sandbox, destroy the Rancher Server and your cluster
 
 - [Amazon AWS: Destroying the Environment](../deploy-rancher-manager/aws.md#destroying-the-environment)
 - [DigitalOcean: Destroying the Environment](../deploy-rancher-manager/digitalocean.md#destroying-the-environment)
+- [Linode: Destroying the Environment](../deploy-rancher-manager/linode.md#destroying-the-environment)
 - [Vagrant: Destroying the Environment](../deploy-rancher-manager/vagrant.md#destroying-the-environment)

--- a/versioned_docs/version-2.8/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
+++ b/versioned_docs/version-2.8/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
@@ -14,6 +14,7 @@ Use one of the following guides to deploy and provision Rancher and a Kubernetes
 - [DigitalOcean](digitalocean.md) (uses Terraform)
 - [GCP](gcp.md) (uses Terraform)
 - [Hetzner Cloud](hetzner-cloud.md) (uses Terraform)
+- [Linode](linode.md) (uses Terraform)
 - [Vagrant](vagrant.md)
 - [Equinix Metal](equinix-metal.md)
 - [Outscale](outscale-qs.md) (uses Terraform)

--- a/versioned_docs/version-2.8/getting-started/quick-start-guides/deploy-rancher-manager/linode.md
+++ b/versioned_docs/version-2.8/getting-started/quick-start-guides/deploy-rancher-manager/linode.md
@@ -1,0 +1,80 @@
+---
+title: Rancher Linode Quick Start Guide
+description: Read this step by step guide to quickly deploy a Rancher server with a single-node downstream Kubernetes cluster attached.
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/linode"/>
+</head>
+
+The following steps will quickly deploy a Rancher server on Linode in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
+
+:::caution
+
+The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation](../../installation-and-upgrade/installation-and-upgrade.md).
+
+:::
+
+## Prerequisites
+
+:::caution
+
+Deploying to Linode will incur charges.
+
+:::
+
+- [Linode Account](https://linode.com): The Linode account to run provision server and cluster under.
+- [Linode Personal Access Token](https://www.linode.com/docs/products/tools/api/guides/manage-api-tokens/): A Linode Personal Access Token to authenticate with.
+- [Terraform](https://www.terraform.io/downloads.html): Used to provision the server and cluster on Linode.
+
+
+## Getting Started
+
+1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
+
+2. Go into the Linode folder containing the Terraform files by executing `cd quickstart/rancher/linode`.
+
+3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
+
+4. Edit `terraform.tfvars` and customize the following variables:
+    - `linode_token` - The Linode Personal Access Token mentioned above.
+    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
+
+5. **Optional:** Modify optional variables within `terraform.tfvars`.
+See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Linode Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/linode) for more information. Suggestions include:
+   - `linode_region` - The target Linode region to provision the server and cluster in. (Default `eu-central`)
+     - For a complete list of regions, see the [official Region Availability page](https://www.linode.com/global-infrastructure/availability/).
+   - `prefix` - The prefix for all created infrastructure.
+   - `linode_type` - The type/plan that all infrastructure Linodes should use. (Default `g6-standard-2`)
+     - For a complete list of plans, see the [official Plan Types page](https://www.linode.com/docs/products/compute/compute-instances/plans/).
+
+6. Run `terraform init`.
+
+7. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
+
+    ```
+    Apply complete! Resources: 15 added, 0 changed, 0 destroyed.
+
+    Outputs:
+
+    rancher_node_ip = xx.xx.xx.xx
+    rancher_server_url = https://rancher.xx.xx.xx.xx.sslip.io
+    workload_node_ip = yy.yy.yy.yy
+    ```
+
+8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/linode`.
+
+#### Result
+
+Two Kubernetes clusters are deployed on your Linode account, one running Rancher Server and the other ready for experimentation deployments. Please note that while this setup is a great way to explore Rancher functionality, a production setup should follow our high availability setup guidelines. SSH keys for the VMs are auto-generated and stored in the module directory.
+
+### What's Next?
+
+Use Rancher to create a deployment. For more information, see [Creating Deployments](../deploy-workloads/deploy-workloads.md).
+
+## Destroying the Environment
+
+1. From the `quickstart/rancher/linode` folder, execute `terraform destroy --auto-approve`.
+
+2. Wait for confirmation that all resources have been destroyed.

--- a/versioned_docs/version-2.8/getting-started/quick-start-guides/deploy-rancher-manager/linode.md
+++ b/versioned_docs/version-2.8/getting-started/quick-start-guides/deploy-rancher-manager/linode.md
@@ -37,16 +37,18 @@ Deploying to Linode will incur charges.
 3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
 4. Edit `terraform.tfvars` and customize the following variables:
-    - `linode_token` - The Linode Personal Access Token mentioned above.
-    - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters)
+  - `linode_token` - The Linode Personal Access Token mentioned above.
+  - `rancher_server_admin_password` - Admin password for created Rancher server (minimum 12 characters).
 
 5. **Optional:** Modify optional variables within `terraform.tfvars`.
-See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Linode Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/linode) for more information. Suggestions include:
-   - `linode_region` - The target Linode region to provision the server and cluster in. (Default `eu-central`)
-     - For a complete list of regions, see the [official Region Availability page](https://www.linode.com/global-infrastructure/availability/).
-   - `prefix` - The prefix for all created infrastructure.
-   - `linode_type` - The type/plan that all infrastructure Linodes should use. (Default `g6-standard-2`)
-     - For a complete list of plans, see the [official Plan Types page](https://www.linode.com/docs/products/compute/compute-instances/plans/).
+   See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Linode Quickstart Readme](https://github.com/rancher/quickstart/tree/master/rancher/linode) for more information. Suggestions include:
+  - `linode_region` - The target Linode region to provision the server and cluster in.
+    - Default: `eu-central`
+    - For a complete list of regions, see the [official Region Availability page](https://www.linode.com/global-infrastructure/availability/).
+  - `prefix` - The prefix for all created infrastructure.
+  - `linode_type` - The type/plan that all infrastructure Linodes should use.
+    - Default: `g6-standard-2`
+    - For a complete list of plans, see the [official Plan Types page](https://www.linode.com/docs/products/compute/compute-instances/plans/).
 
 6. Run `terraform init`.
 
@@ -62,8 +64,8 @@ See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Lino
     workload_node_ip = yy.yy.yy.yy
     ```
 
-8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
-9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/linode`.
+8. Paste the `rancher_server_url` from the output above into the browser and log in when prompted. The default username is `admin` and the password is defined in `rancher_server_admin_password`.
+9. `ssh` into the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/linode`.
 
 #### Result
 

--- a/versioned_docs/version-2.8/getting-started/quick-start-guides/deploy-workloads/workload-ingress.md
+++ b/versioned_docs/version-2.8/getting-started/quick-start-guides/deploy-workloads/workload-ingress.md
@@ -73,4 +73,5 @@ When you're done using your sandbox, destroy the Rancher Server and your cluster
 
 - [Amazon AWS: Destroying the Environment](../deploy-rancher-manager/aws.md#destroying-the-environment)
 - [DigitalOcean: Destroying the Environment](../deploy-rancher-manager/digitalocean.md#destroying-the-environment)
+- [Linode: Destroying the Environment](../deploy-rancher-manager/linode.md#destroying-the-environment)
 - [Vagrant: Destroying the Environment](../deploy-rancher-manager/vagrant.md#destroying-the-environment)

--- a/versioned_sidebars/version-2.6-sidebars.json
+++ b/versioned_sidebars/version-2.6-sidebars.json
@@ -28,6 +28,7 @@
                 "getting-started/quick-start-guides/deploy-rancher-manager/digitalocean",
                 "getting-started/quick-start-guides/deploy-rancher-manager/gcp",
                 "getting-started/quick-start-guides/deploy-rancher-manager/hetzner-cloud",
+                "getting-started/quick-start-guides/deploy-rancher-manager/linode",
                 "getting-started/quick-start-guides/deploy-rancher-manager/vagrant",
                 "getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal",
                 "getting-started/quick-start-guides/deploy-rancher-manager/outscale-qs",

--- a/versioned_sidebars/version-2.7-sidebars.json
+++ b/versioned_sidebars/version-2.7-sidebars.json
@@ -28,6 +28,7 @@
                 "getting-started/quick-start-guides/deploy-rancher-manager/digitalocean",
                 "getting-started/quick-start-guides/deploy-rancher-manager/gcp",
                 "getting-started/quick-start-guides/deploy-rancher-manager/hetzner-cloud",
+                "getting-started/quick-start-guides/deploy-rancher-manager/linode",
                 "getting-started/quick-start-guides/deploy-rancher-manager/vagrant",
                 "getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal",
                 "getting-started/quick-start-guides/deploy-rancher-manager/outscale-qs",

--- a/versioned_sidebars/version-2.8-sidebars.json
+++ b/versioned_sidebars/version-2.8-sidebars.json
@@ -28,6 +28,7 @@
                 "getting-started/quick-start-guides/deploy-rancher-manager/digitalocean",
                 "getting-started/quick-start-guides/deploy-rancher-manager/gcp",
                 "getting-started/quick-start-guides/deploy-rancher-manager/hetzner-cloud",
+                "getting-started/quick-start-guides/deploy-rancher-manager/linode",
                 "getting-started/quick-start-guides/deploy-rancher-manager/vagrant",
                 "getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal",
                 "getting-started/quick-start-guides/deploy-rancher-manager/outscale-qs",


### PR DESCRIPTION
## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

This pull request adds a short guide for using the [Linode quickstart Terraform configuration](https://github.com/rancher/quickstart/tree/master/rancher/linode). The quickstart has existed for a while but did not seem to have any accompanying documentation.

Given the Linode quickstart configuration is Rancher version-agnostic I've added the guide to the documentation for Rancher v2.6, v2.7, and v2.8. Let me know if this needs changing.
