### PR TITLE
[2.7] Move PAYG pages-for-subheader

### DIFF
--- a/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration/aws-marketplace-payg-integration.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration/aws-marketplace-payg-integration.md
@@ -19,8 +19,8 @@ Rancher Prime integrates with the [AWS Marketplace](https://aws.amazon.com/marke
 
 ## How to Use
 
-1. Complete the [prerequisite steps](../integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration/prerequisites.md).
-2. [Install the Rancher Prime PAYG offering on the AWS Marketplace](../integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration/installing-rancher-prime.md).
+1. Complete the [prerequisite steps](prerequisites.md).
+2. [Install the Rancher Prime PAYG offering on the AWS Marketplace](installing-rancher-prime.md).
 
 ## FAQ
 
@@ -316,7 +316,7 @@ While it is not possible to transact/bill Rancher Prime in China, it is possible
 
 #### Can I still deploy Rancher using the "Rancher Setup" listing from the AWS Marketplace?
 
-"Rancher Setup" is no longer available via AWS Marketplace. Customers should deploy an EKS Cluster to host Rancher. Follow the steps in this [guide](../getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md) except for the Rancher installation. The Rancher product installation should be carried out as per [installing the Rancher Prime PAYG offering on Amazon's AWS Marketplace](../integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration/installing-rancher-prime.md).
+"Rancher Setup" is no longer available via AWS Marketplace. Customers should deploy an EKS Cluster to host Rancher. Follow the steps in this [guide](../../../getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.md) except for the Rancher installation. The Rancher product installation should be carried out as per [installing the Rancher Prime PAYG offering on Amazon's AWS Marketplace](installing-rancher-prime.md).
 
 ### Billing
 
@@ -362,7 +362,7 @@ Rancher Prime has different pricing tiers when purchasing via the AWS Marketplac
 
 If using the Rancher Prime listing in the AWS Marketplace, billing will commence from the time of deployment.
 
-Rancher can be deployed manually using the standard documentation and repositories. When ready to benefit from a supported platform and have this billed via the AWS Marketplace, follow the available [documentation](../getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.md) to deploy Rancher Prime from the AWS Marketplace and migrate.
+Rancher can be deployed manually using the standard documentation and repositories. When ready to benefit from a supported platform and have this billed via the AWS Marketplace, follow the available [documentation](../../../getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.md) to deploy Rancher Prime from the AWS Marketplace and migrate.
 
 #### How does SUSE calculate the ‘average number of managed nodes’ to bill for?
 
@@ -468,7 +468,7 @@ Yes. Simply deploy the AWS Marketplace listing for Rancher Prime.
 
 In order to benefit from monthly billing via the AWS Marketplace, the primary Rancher cluster needs to be deployed from the listing, it is then possible to migrate the existing Rancher configuration to the new deployment.
 
-Please follow the [documentation](../getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.md) and be sure to back up the existing Rancher configuration.
+Please follow the [documentation](../../../getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.md) and be sure to back up the existing Rancher configuration.
 
 ### Technical (Product)
 
@@ -476,7 +476,7 @@ Please follow the [documentation](../getting-started/installation-and-upgrade/in
 
 It is very simple to [open a support case](https://scc.suse.com/cloudsupport) with SUSE for Rancher Prime. Create a ‘supportconfig’ via the Rancher UI and upload the output to the SUSE Customer Center. The support config bundle can be exported from the Rancher console using the ‘Get Support’ button at the bottom of the page. For deployments when Rancher is managing multiple downstream clusters, export the support config bundle from the primary cluster only.
 
-If the billing mechanism on the primary cluster is active, a support case will be opened. Further details can be found in the [documentation](../integrations-in-rancher/cloud-marketplace/supportconfig.md).
+If the billing mechanism on the primary cluster is active, a support case will be opened. Further details can be found in the [documentation](../supportconfig.md).
 
 #### What are the resource requirements for installing Rancher on EKS?
 
@@ -506,4 +506,4 @@ Yes. Nodes can run anywhere. SUSE Rancher will count the total number of nodes m
 
 #### How do I get fixes and updates for Rancher?
 
-To update to the latest version of the Rancher Prime PAYG offering supported in the marketplace listing, please see [upgrading Rancher Prime PAYG cluster in AWS](../integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration/upgrading-rancher-payg-cluster.md).
+To update to the latest version of the Rancher Prime PAYG offering supported in the marketplace listing, please see [upgrading Rancher Prime PAYG cluster in AWS](upgrading-rancher-payg-cluster.md).

--- a/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration/aws-marketplace-payg-integration.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration/aws-marketplace-payg-integration.md
@@ -3,7 +3,7 @@ title: AWS Marketplace Pay-as-you-go (PAYG) Integration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/aws-marketplace-payg-integration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration/aws-marketplace-payg-integration"/>
 </head>
 
 ## Overview

--- a/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration/azure-marketplace-payg-integration.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration/azure-marketplace-payg-integration.md
@@ -19,8 +19,8 @@ Rancher Prime integrates with the [Azure Marketplace](https://azuremarketplace.m
 
 ## How to Use
 
-1. Complete the [prerequisite steps](../integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration/prerequisites.md).
-2. [Install the Rancher Prime PAYG offering on the Azure Marketplace](../integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration/installing-rancher-prime.md).
+1. Complete the [prerequisite steps](prerequisites.md).
+2. [Install the Rancher Prime PAYG offering on the Azure Marketplace](installing-rancher-prime.md).
 
 ## FAQ
 
@@ -202,7 +202,7 @@ No. You need to deploy Rancher Prime with the Azure Marketplace listing and migr
 
 #### How do I get support?
 
-It is very simple to [open a support case](https://scc.suse.com/cloudsupport) with SUSE for Rancher Prime. Create a ‘supportconfig’ via the Rancher UI (click Get Support under the hamburger menu and follow instructions), then upload the ‘supportconfig’ output to the SUSE Customer Center. If the billing mechanism is active, a support case will be opened. See Supportconfig bundle in the Rancher [documentation](../integrations-in-rancher/cloud-marketplace/supportconfig.md) for more details.
+It is very simple to [open a support case](https://scc.suse.com/cloudsupport) with SUSE for Rancher Prime. Create a ‘supportconfig’ via the Rancher UI (click Get Support under the hamburger menu and follow instructions), then upload the ‘supportconfig’ output to the SUSE Customer Center. If the billing mechanism is active, a support case will be opened. See Supportconfig bundle in the Rancher [documentation](../supportconfig.md) for more details.
 
 :::note
 
@@ -212,7 +212,7 @@ For deployments where Rancher Prime is managing multiple downstream clusters, be
 
 #### What are the resource requirements for installing Rancher on AKS?
 
-Check the documentation for [best practices](../pages-for-subheaders/installation-requirements.md#hosted-kubernetes).
+Check the documentation for [best practices](../../../pages-for-subheaders/installation-requirements.md#hosted-kubernetes).
 
 #### Is there any difference between Rancher Prime from Azure Marketplace and the versions I can run in my own data center?
 
@@ -232,4 +232,4 @@ If the Racher Prime cluster is offline or disconnected from the Azure billing fr
 
 #### How do I get fixes and updates for Rancher?
 
-To update to the latest version of the Rancher Prime PAYG offering supported in the marketplace listing, please see [upgrading Rancher Prime PAYG cluster in Azure](../integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration/upgrading-rancher-payg-cluster.md).
+To update to the latest version of the Rancher Prime PAYG offering supported in the marketplace listing, please see [upgrading Rancher Prime PAYG cluster in Azure](upgrading-rancher-payg-cluster.md).

--- a/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration/azure-marketplace-payg-integration.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration/azure-marketplace-payg-integration.md
@@ -3,7 +3,7 @@ title: Azure Marketplace Pay-as-you-go (PAYG) Integration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/azure-marketplace-payg-integration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration/azure-marketplace-payg-integration"/>
 </head>
 
 ## Overview

--- a/versioned_sidebars/version-2.7-sidebars.json
+++ b/versioned_sidebars/version-2.7-sidebars.json
@@ -1114,7 +1114,7 @@
               "label": "AWS Marketplace Pay-as-you-go (PAYG)",
               "link": {
                 "type": "doc",
-                "id": "pages-for-subheaders/aws-marketplace-payg-integration"
+                "id": "integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration/aws-marketplace-payg-integration"
               },
               "items": [
                   "integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration/prerequisites",
@@ -1130,7 +1130,7 @@
               "label": "Azure Marketplace Pay-as-you-go (PAYG)",
               "link": {
                 "type": "doc",
-                "id": "pages-for-subheaders/azure-marketplace-payg-integration"
+                "id": "integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration/azure-marketplace-payg-integration"
               },
               "items": [
                   "integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration/prerequisites",


### PR DESCRIPTION
## Description

This removes the pages added to the pages-for-subheader directory in https://github.com/rancher/rancher-docs/pull/1008.  Due to the timing of the PRs, this was not resolved as part of https://github.com/rancher/rancher-docs/pull/1060.
