### PR TITLE
Update canonical links

### DIFF
--- a/docs/api/quickstart.md
+++ b/docs/api/quickstart.md
@@ -2,6 +2,10 @@
 title: API Quick Start Guide
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/api/quickstart"/>
+</head>
+
 You can access Rancher's resources through the Kubernetes API. This guide will help you get started on using this API as a Rancher user.
 
 1. In the upper left corner, click **☰ > Global Settings**.

--- a/docs/api/workflows/projects.md
+++ b/docs/api/workflows/projects.md
@@ -2,6 +2,10 @@
 title: Projects
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/api/workflows/projects"/>
+</head>
+
 ## Creating a Project
 
 Project resources may only be created on the management cluster. See below for [creating namespaces under projects in a managed cluster](#creating-a-namespace-in-a-project).

--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/install-upgrade-on-a-kubernetes-cluster.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/install-upgrade-on-a-kubernetes-cluster.md
@@ -4,7 +4,7 @@ description: Learn how to install Rancher in development and production environm
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster"/>
 </head>
 
 In this section, you'll learn how to deploy Rancher on a Kubernetes cluster using the Helm CLI.

--- a/docs/getting-started/installation-and-upgrade/installation-and-upgrade.md
+++ b/docs/getting-started/installation-and-upgrade/installation-and-upgrade.md
@@ -4,7 +4,7 @@ description: Learn how to install Rancher in development and production environm
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-and-upgrade"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade"/>
 </head>
 
 This section provides an overview of the architecture options of installing Rancher, describing advantages of each option.

--- a/docs/getting-started/installation-and-upgrade/installation-references/installation-references.md
+++ b/docs/getting-started/installation-and-upgrade/installation-references/installation-references.md
@@ -3,7 +3,7 @@ title: Installation References
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-references"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references"/>
 </head>
 
 Please see the following reference guides for other installation resources: [Rancher Helm chart options](helm-chart-options.md), [TLS settings](tls-settings.md), and [feature flags](feature-flags.md).

--- a/docs/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
+++ b/docs/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
@@ -4,7 +4,7 @@ description: Learn the node requirements for each node running Rancher server wh
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-requirements"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-requirements"/>
 </head>
 
 This page describes the software, hardware, and networking requirements for the nodes where the Rancher server will be installed. The Rancher server can be installed on a single node or a high-availability Kubernetes cluster.

--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/air-gapped-helm-cli-install.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/air-gapped-helm-cli-install.md
@@ -3,7 +3,7 @@ title: Air-Gapped Helm CLI Install
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/air-gapped-helm-cli-install"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install"/>
 </head>
 
 This section is about using the Helm CLI to install the Rancher server in an air gapped environment. An air gapped environment could be where Rancher server will be installed offline, behind a firewall, or behind a proxy.

--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/other-installation-methods.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/other-installation-methods.md
@@ -3,7 +3,7 @@ title: Other Installation Methods
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/other-installation-methods"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods"/>
 </head>
 
 ### Air Gapped Installations

--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/rancher-behind-an-http-proxy.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/rancher-behind-an-http-proxy.md
@@ -3,7 +3,7 @@ title: Installing Rancher behind an HTTP Proxy
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-behind-an-http-proxy"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy"/>
 </head>
 
 In a lot of enterprise environments, servers or VMs running on premise do not have direct Internet access, but must connect to external services through a HTTP(S) proxy for security reasons. This tutorial shows step by step how to set up a highly available Rancher installation in such an environment.

--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
@@ -4,7 +4,7 @@ description: For development and testing environments only, use a Docker install
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-on-a-single-node-with-docker"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker"/>
 </head>
 
 Rancher can be installed by running a single Docker container.

--- a/docs/getting-started/installation-and-upgrade/resources/resources.md
+++ b/docs/getting-started/installation-and-upgrade/resources/resources.md
@@ -3,7 +3,7 @@ title: Resources
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/resources"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/resources"/>
 </head>
 
 ### Docker Installations

--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
@@ -3,7 +3,7 @@ title: Deploying Rancher Server
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-rancher-manager"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager"/>
 </head>
 
 Use one of the following guides to deploy and provision Rancher and a Kubernetes cluster in the provider of your choice.

--- a/docs/getting-started/quick-start-guides/deploy-workloads/deploy-workloads.md
+++ b/docs/getting-started/quick-start-guides/deploy-workloads/deploy-workloads.md
@@ -3,7 +3,7 @@ title: Deploying Workloads
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-rancher-workloads"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-workloads"/>
 </head>
 
 These guides walk you through the deployment of an application, including how to expose the application for use outside of the cluster.

--- a/docs/getting-started/quick-start-guides/quick-start-guides.md
+++ b/docs/getting-started/quick-start-guides/quick-start-guides.md
@@ -3,7 +3,7 @@ title: Rancher Deployment Quick Start Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/quick-start-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides"/>
 </head>
 
 :::caution

--- a/docs/how-to-guides/advanced-user-guides/advanced-user-guides.md
+++ b/docs/how-to-guides/advanced-user-guides/advanced-user-guides.md
@@ -3,7 +3,7 @@ title: Advanced User Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/advanced-user-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides"/>
 </head>
 
 Advanced user guides are "problem-oriented" docs in which users learn how to answer questions or solve problems. The major difference between these and the new user guides is that these guides are geared toward more experienced or advanced users who have more technical needs from their documentation. These users already have an understanding of Rancher and its functions. They know what they need to accomplish; they just need additional guidance to complete some more complex task they they have encountered while working.

--- a/docs/how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md
+++ b/docs/how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md
@@ -3,7 +3,7 @@ title: CIS Scan Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scan-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides"/>
 </head>
 
 - [Install rancher-cis-benchmark](install-rancher-cis-benchmark.md)

--- a/docs/how-to-guides/advanced-user-guides/enable-experimental-features/enable-experimental-features.md
+++ b/docs/how-to-guides/advanced-user-guides/enable-experimental-features/enable-experimental-features.md
@@ -3,7 +3,7 @@ title: Enabling Experimental Features
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/enable-experimental-features"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/enable-experimental-features"/>
 </head>
 
 Rancher includes some features that are experimental and disabled by default. You might want to enable these features, for example, if you decide that the benefits of using an [unsupported storage type](unsupported-storage-drivers.md) outweighs the risk of using an untested feature. Feature flags were introduced to allow you to try these features that are not enabled by default.

--- a/docs/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
+++ b/docs/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
@@ -3,7 +3,7 @@ title: Setup Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/istio-setup-guide"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide"/>
 </head>
 
 This section describes how to enable Istio and start using it in your projects.

--- a/docs/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/manage-project-resource-quotas.md
+++ b/docs/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/manage-project-resource-quotas.md
@@ -3,7 +3,7 @@ title: Project Resource Quotas
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-project-resource-quotas"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas"/>
 </head>
 
 In situations where several teams share a cluster, one team may overconsume the resources available: CPU, memory, storage, services, Kubernetes objects like pods or secrets, and so on.  To prevent this overconsumption, you can apply a _resource quota_, which is a Rancher feature that limits the resources available to a project or namespace.

--- a/docs/how-to-guides/advanced-user-guides/manage-projects/manage-projects.md
+++ b/docs/how-to-guides/advanced-user-guides/manage-projects/manage-projects.md
@@ -3,7 +3,7 @@ title: Project Administration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-projects"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/manage-projects"/>
 </head>
 
 _Projects_ are objects introduced in Rancher that help organize namespaces in your Kubernetes cluster. You can use projects to create multi-tenant clusters, which allows a group of users to share the same underlying resources without interacting with each other's applications.

--- a/docs/how-to-guides/advanced-user-guides/monitoring-alerting-guides/monitoring-alerting-guides.md
+++ b/docs/how-to-guides/advanced-user-guides/monitoring-alerting-guides/monitoring-alerting-guides.md
@@ -3,7 +3,7 @@ title: Monitoring/Alerting Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-alerting-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-alerting-guides"/>
 </head>
 
 - [Enable monitoring](enable-monitoring.md)

--- a/docs/how-to-guides/advanced-user-guides/monitoring-alerting-guides/prometheus-federator-guides/prometheus-federator-guides.md
+++ b/docs/how-to-guides/advanced-user-guides/monitoring-alerting-guides/prometheus-federator-guides/prometheus-federator-guides.md
@@ -3,7 +3,7 @@ title: Prometheus Federator Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/prometheus-federator-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-alerting-guides/prometheus-federator-guides"/>
 </head>
 
 - [Enable Prometheus Operator](enable-prometheus-federator.md)

--- a/docs/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/advanced-configuration.md
+++ b/docs/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/advanced-configuration.md
@@ -3,7 +3,7 @@ title: Advanced Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/advanced-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration"/>
 </head>
 
 ### Alertmanager

--- a/docs/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/monitoring-v2-configuration-guides.md
+++ b/docs/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/monitoring-v2-configuration-guides.md
@@ -3,7 +3,7 @@ title: Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-v2-configuration-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides"/>
 </head>
 
 This page captures some of the most important options for configuring Monitoring V2 in the Rancher UI.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/about-provisioning-drivers.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/about-provisioning-drivers.md
@@ -3,7 +3,7 @@ title: About Provisioning Drivers
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/about-provisioning-drivers"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers"/>
 </head>
 
 Drivers in Rancher allow you to manage which providers can be used to deploy [hosted Kubernetes clusters](../../kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md) or [nodes in an infrastructure provider](../../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider.md) to allow Rancher to deploy and manage Kubernetes.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/about-rke1-templates.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/about-rke1-templates.md
@@ -3,7 +3,7 @@ title: RKE Templates
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/about-rke1-templates"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates"/>
 </head>
 
 RKE templates are designed to allow DevOps and security teams to standardize and simplify the creation of Kubernetes clusters.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
@@ -4,7 +4,7 @@ weight: 10
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/authentication-config"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config"/>
 </head>
 
 One of the key features that Rancher adds to Kubernetes is centralized user authentication. This feature allows your users to use one set of credentials to authenticate with any of your Kubernetes clusters.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-permissions-and-global-configuration.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-permissions-and-global-configuration.md
@@ -3,7 +3,7 @@ title: Authentication, Permissions and Global Settings
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/authentication-permissions-and-global-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration"/>
 </head>
 
 After installation, the [system administrator](manage-role-based-access-control-rbac/global-permissions.md) should configure Rancher to configure authentication, authorization, security, default settings, security policies, drivers and global DNS entries.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml/configure-microsoft-ad-federation-service-saml.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml/configure-microsoft-ad-federation-service-saml.md
@@ -3,7 +3,7 @@ title: Configuring Microsoft Active Directory Federation Service (SAML)
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configure-microsoft-ad-federation-service-saml"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml"/>
 </head>
 
 If your organization uses Microsoft Active Directory Federation Services (AD FS) for user authentication, you can configure Rancher to allow your users to log in using their AD FS credentials.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap/configure-openldap.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap/configure-openldap.md
@@ -3,7 +3,7 @@ title: Configuring OpenLDAP
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configure-openldap"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap"/>
 </head>
 
 If your organization uses LDAP for user authentication, you can configure Rancher to communicate with an OpenLDAP server to authenticate users. This allows Rancher admins to control access to clusters and projects based on users and groups managed externally in the organisation's central user repository, while allowing end-users to authenticate with their LDAP credentials when logging in to the Rancher UI.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml/configure-shibboleth-saml.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml/configure-shibboleth-saml.md
@@ -3,7 +3,7 @@ title: Configuring Shibboleth (SAML)
 ---
 
 <head> 
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configure-shibboleth-saml"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml"/>
 </head>
 
 If your organization uses Shibboleth Identity Provider (IdP) for user authentication, you can configure Rancher to allow your users to log in to Rancher using their Shibboleth credentials.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.md
@@ -3,7 +3,7 @@ title: Managing Role-Based Access Control (RBAC)
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-role-based-access-control-rbac"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac"/>
 </head>
 
 Within Rancher, each person authenticates as a _user_, which is a login that grants you access to Rancher. As mentioned in [Authentication](../authentication-config/authentication-config.md), users can either be local or external.

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
@@ -4,7 +4,7 @@ keywords: [rancher backup restore, rancher backup and restore, backup restore ra
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/backup-restore-and-disaster-recovery"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery"/>
 </head>
 
 In this section, you'll learn how to create backups of Rancher, how to restore Rancher from backup, and how to migrate Rancher to a new Kubernetes cluster.

--- a/docs/how-to-guides/new-user-guides/deploy-apps-across-clusters/deploy-apps-across-clusters.md
+++ b/docs/how-to-guides/new-user-guides/deploy-apps-across-clusters/deploy-apps-across-clusters.md
@@ -3,7 +3,7 @@ title: Deploying Applications across Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-apps-across-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters"/>
 </head>
 
 Rancher offers several ways to deploy applications across clusters, depending on version.

--- a/docs/how-to-guides/new-user-guides/helm-charts-in-rancher/helm-charts-in-rancher.md
+++ b/docs/how-to-guides/new-user-guides/helm-charts-in-rancher/helm-charts-in-rancher.md
@@ -3,7 +3,7 @@ title: Helm Charts in Rancher
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/helm-charts-in-rancher"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/helm-charts-in-rancher"/>
 </head>
 
 In this section, you'll learn how to manage Helm chart repositories and applications in Rancher. Helm chart repositories are managed using **Apps**. It uses a catalog-like system to import bundles of charts from repositories and then uses those charts to either deploy custom Helm applications or Rancher's tools such as Monitoring or Istio. Rancher tools come as pre-loaded repositories which deploy as standalone Helm charts. Any additional repositories are only added to the current cluster.

--- a/docs/how-to-guides/new-user-guides/infrastructure-setup/infrastructure-setup.md
+++ b/docs/how-to-guides/new-user-guides/infrastructure-setup/infrastructure-setup.md
@@ -3,7 +3,7 @@ title: Don't have infrastructure for your Kubernetes cluster? Try one of these t
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/infrastructure-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/infrastructure-setup"/>
 </head>
 
 To set up infrastructure for a high-availability K3s Kubernetes cluster with an external DB, refer to [this page.](ha-k3s-kubernetes-cluster.md)

--- a/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/kubernetes-cluster-setup.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/kubernetes-cluster-setup.md
@@ -3,7 +3,7 @@ title: "Don't have a Kubernetes cluster? Try one of these tutorials."
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-cluster-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup"/>
 </head>
 
 This section contains information on how to install a Kubernetes cluster that the Rancher server can be installed on.

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/checklist-for-production-ready-clusters.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/checklist-for-production-ready-clusters.md
@@ -3,7 +3,7 @@ title: Checklist for Production-Ready Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/checklist-for-production-ready-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters"/>
 </head>
 
 In this section, we recommend best practices for creating the production-ready Kubernetes clusters that will run your apps and services.

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/kubernetes-clusters-in-rancher-setup.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/kubernetes-clusters-in-rancher-setup.md
@@ -4,7 +4,7 @@ description: Provisioning Kubernetes Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-clusters-in-rancher-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup"/>
 </head>
 
 Rancher simplifies the creation of clusters by allowing you to create them through the Rancher UI rather than more complex alternatives. Rancher provides multiple options for launching a cluster. Use the option that best fits your use case.

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/set-up-cloud-providers.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/set-up-cloud-providers.md
@@ -3,7 +3,7 @@ title: Setting up Cloud Providers
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/set-up-cloud-providers"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers"/>
 </head>
 
 A _cloud provider_ is a module in Kubernetes that provides an interface for managing nodes, load balancers, and networking routes.

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md
@@ -3,7 +3,7 @@ title: Setting up Clusters from Hosted Kubernetes Providers
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/set-up-clusters-from-hosted-kubernetes-providers"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers"/>
 </head>
 
 In this scenario, Rancher does not provision Kubernetes because it is installed by providers such as Google Kubernetes Engine (GKE), Amazon Elastic Container Service for Kubernetes, or Azure Kubernetes Service.

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/use-windows-clusters.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/use-windows-clusters.md
@@ -3,7 +3,7 @@ title: Launching Kubernetes on Windows Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/use-windows-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters"/>
 </head>
 
 When provisioning a [custom cluster](../../../../reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md) using Rancher, Rancher uses RKE (the Rancher Kubernetes Engine) to install Kubernetes on your existing nodes.

--- a/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/horizontal-pod-autoscaler.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/horizontal-pod-autoscaler.md
@@ -4,7 +4,7 @@ description: Learn about the horizontal pod autoscaler (HPA). How to manage HPAs
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/horizontal-pod-autoscaler"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler"/>
 </head>
 
 The [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) (HPA) is a Kubernetes feature that allows you to configure your cluster to automatically scale the services it's running up or down.

--- a/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-resources-setup.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-resources-setup.md
@@ -3,7 +3,7 @@ title: Kubernetes Resources
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-resources-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup"/>
 </head>
 
 You can view and manipulate all of the custom resources and CRDs in a Kubernetes cluster from the Rancher UI.

--- a/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.md
@@ -4,7 +4,7 @@ description: Learn how you can set up load balancers and ingress controllers to 
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/load-balancer-and-ingress-controller"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller"/>
 </head>
 
 Within Rancher, you can set up load balancers and ingress controllers to redirect service requests.

--- a/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/workloads-and-pods.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/workloads-and-pods.md
@@ -4,7 +4,7 @@ description: "Learn about the two constructs with which you can build any comple
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/workloads-and-pods"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods"/>
 </head>
 
 You can build any complex containerized application in Kubernetes using two basic constructs: pods and workloads. Once you build an application, you can expose it for access either within the same cluster or on the Internet using a third construct: services.

--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md
@@ -3,7 +3,7 @@ title: Launching Kubernetes with Rancher
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher"/>
 </head>
 
 You can have Rancher launch a Kubernetes cluster using any nodes you want. When Rancher deploys Kubernetes onto these nodes, you can choose between [Rancher Kubernetes Engine](https://rancher.com/docs/rke/latest/en/) (RKE) or [RKE2](https://docs.rke2.io) distributions. Rancher can launch Kubernetes on any computers, including:

--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/nutanix.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/nutanix.md
@@ -4,7 +4,7 @@ description: Use Rancher to create a Nutanix AOS (AHV) cluster. It may consist o
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/nutanix"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix"/>
 </head>
 
 [Nutanix Acropolis Operating System](https://www.nutanix.com/products/acropolis) (Nutanix AOS) is an operating system for the Nutanix hyper-converged infrastructure platform. AOS comes with a built-in hypervisor called [Acropolis Hypervisor](https://www.nutanix.com/products/ahv), or AHV. By using Rancher with Nutanix AOS (AHV), you can bring cloud operations on-premises.

--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider.md
@@ -3,7 +3,7 @@ title: Launching Kubernetes on New Nodes in an Infrastructure Provider
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/use-new-nodes-in-an-infra-provider"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider"/>
 </head>
 
 When you create an RKE or RKE2 cluster using a node template in Rancher, each resulting node pool is shown in a new **Machine Pools** tab. You can see the machine pools by doing the following:

--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
@@ -4,7 +4,7 @@ description: Use Rancher to create a vSphere cluster. It may consist of groups o
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/vsphere"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere"/>
 </head>
 
 import YouTube from '@site/src/components/YouTube'

--- a/docs/how-to-guides/new-user-guides/manage-clusters/access-clusters/access-clusters.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/access-clusters/access-clusters.md
@@ -3,7 +3,7 @@ title: Cluster Access
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/access-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters"/>
 </head>
 
 This section is about what tools can be used to access clusters managed by Rancher.

--- a/docs/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/create-kubernetes-persistent-storage.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/create-kubernetes-persistent-storage.md
@@ -4,7 +4,7 @@ description: "Learn about the two ways with which you can create persistent stor
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/create-kubernetes-persistent-storage"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage"/>
 </head>
 
 When deploying an application that needs to retain data, you'll need to create persistent storage. Persistent storage allows you to store application data external from the pod running your application. This storage practice allows you to maintain application data, even if the application's pod fails.

--- a/docs/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/install-cluster-autoscaler.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/install-cluster-autoscaler.md
@@ -3,7 +3,7 @@ title: Cluster Autoscaler
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/install-cluster-autoscaler"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler"/>
 </head>
 
 In this section, you'll learn how to install and use the [Kubernetes cluster-autoscaler](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/) on Rancher custom clusters using AWS EC2 Auto Scaling Groups.

--- a/docs/how-to-guides/new-user-guides/manage-clusters/manage-clusters.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/manage-clusters.md
@@ -3,7 +3,7 @@ title: Cluster Administration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters"/>
 </head>
 
 After you provision a cluster in Rancher, you can begin using powerful Kubernetes features to deploy and scale your containerized applications in development, testing, or production environments.

--- a/docs/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/provisioning-storage-examples.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/provisioning-storage-examples.md
@@ -3,7 +3,7 @@ title: Provisioning Storage Examples
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/provisioning-storage-examples"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples"/>
 </head>
 
 Rancher supports persistent storage with a variety of volume plugins. However, before you use any of these plugins to bind persistent storage to your workloads, you have to configure the storage itself, whether its a cloud-based solution from a service-provider or an on-prem solution that you manage yourself.

--- a/docs/how-to-guides/new-user-guides/new-user-guides.md
+++ b/docs/how-to-guides/new-user-guides/new-user-guides.md
@@ -3,7 +3,7 @@ title: New User Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/new-user-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides"/>
 </head>
 
 New user guides, also known as **tutorials**, describe practical steps for users to follow in order to complete some concrete action. These docs are known as "learning-oriented" docs in which users learn by "doing".

--- a/docs/integrations-in-rancher/cis-scans/cis-scans.md
+++ b/docs/integrations-in-rancher/cis-scans/cis-scans.md
@@ -3,7 +3,7 @@ title: CIS Scans
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scans"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cis-scans"/>
 </head>
 
 Rancher can run a security scan to check whether Kubernetes is deployed according to security best practices as defined in the CIS Kubernetes Benchmark. The CIS scans can run on any Kubernetes cluster, including hosted Kubernetes providers such as EKS, AKS, and GKE.

--- a/docs/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/aws-cloud-marketplace.md
+++ b/docs/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/aws-cloud-marketplace.md
@@ -3,7 +3,7 @@ title: AWS Marketplace Integration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/aws-cloud-marketplace"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace"/>
 </head>
 
 ## Overview

--- a/docs/integrations-in-rancher/cloud-marketplace/cloud-marketplace.md
+++ b/docs/integrations-in-rancher/cloud-marketplace/cloud-marketplace.md
@@ -3,7 +3,7 @@ title: Cloud Marketplace Integration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cloud-marketplace"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cloud-marketplace"/>
 </head>
 
 Rancher offers integration with cloud marketplaces to easily purchase support for installations hosted on certain cloud providers. In addition, this integration also provides the ability to generate a supportconfig bundle which can be provided to rancher support.

--- a/docs/integrations-in-rancher/elemental/elemental.md
+++ b/docs/integrations-in-rancher/elemental/elemental.md
@@ -2,6 +2,10 @@
 title: Operating System Management with Elemental
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/elemental"/>
+</head>
+
 Elemental enables cloud-native host management. Elemental allows you to onboard any machine in any location, whether its in a datacenter or on the edge, and integrate them seamlessly into Kubernetes while managing your workflows (e.g., OS updates). 
 
 ## Elemental with Rancher 

--- a/docs/integrations-in-rancher/fleet/architecture.md
+++ b/docs/integrations-in-rancher/fleet/architecture.md
@@ -2,6 +2,10 @@
 title: Architecture
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/architecture"/>
+</head>
+
 Fleet can manage deployments from git of raw Kubernetes YAML, Helm charts, or Kustomize or any combination of the three. Regardless of the source, all resources are dynamically turned into Helm charts, and Helm is used as the engine to deploy everything in the cluster. This gives you a high degree of control, consistency, and auditability. Fleet focuses not only on the ability to scale, but to give one a high degree of control and visibility to exactly what is installed on the cluster.
 
 ![Architecture](/img/fleet-architecture.svg)

--- a/docs/integrations-in-rancher/fleet/fleet.md
+++ b/docs/integrations-in-rancher/fleet/fleet.md
@@ -2,6 +2,10 @@
 title: Continuous Delivery with Fleet
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet"/>
+</head>
+
 Fleet orchestrates and manages the continuous delivery of applications through the supply chain for fleets of clusters. Fleet organizes the supply chain to help teams deliver with confidence and trust in a timely manner using GitOps as a safe operating model. 
 
 ## Fleet with Rancher

--- a/docs/integrations-in-rancher/fleet/overview.md
+++ b/docs/integrations-in-rancher/fleet/overview.md
@@ -2,6 +2,10 @@
 title: Overview
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview"/>
+</head>
+
 Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/installation#configuration-for-multi-cluster). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
 
 Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.

--- a/docs/integrations-in-rancher/fleet/use-fleet-behind-a-proxy.md
+++ b/docs/integrations-in-rancher/fleet/use-fleet-behind-a-proxy.md
@@ -2,6 +2,10 @@
 title: Using Fleet Behind a Proxy
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/use-fleet-behind-a-proxy"/>
+</head>
+
 In this section, you'll learn how to enable Fleet in a setup that has a Rancher server with a public IP a Kubernetes cluster that has no public IP, but is configured to use a proxy.
 
 Rancher does not establish connections with registered downstream clusters. The Rancher agent deployed on the downstream cluster must be able to establish the connection with Rancher.

--- a/docs/integrations-in-rancher/fleet/windows-support.md
+++ b/docs/integrations-in-rancher/fleet/windows-support.md
@@ -2,6 +2,10 @@
 title: Windows Support
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/windows-support"/>
+</head>
+
 Prior to Rancher v2.5.6, the `agent` did not have native Windows manifests on downstream clusters with Windows nodes. This would result in a failing `agent` pod for the cluster.
 
 If you are upgrading from an older version of Rancher to v2.5.6+, you can deploy a working `agent` with the following workflow *in the downstream cluster*:

--- a/docs/integrations-in-rancher/harvester/harvester.md
+++ b/docs/integrations-in-rancher/harvester/harvester.md
@@ -2,6 +2,10 @@
 title: Virtualization on Kubernetes with Harvester
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester"/>
+</head>
+
 ## Harvester
 
 Introduced in Rancher v2.6.1, Harvester is an open-source hyper-converged infrastructure (HCI) software built on Kubernetes. Harvester installs on bare metal servers and provides integrated virtualization and distributed storage capabilities. Although Harvester operates using Kubernetes, it does not require knowledge of Kubernetes concepts, making it more user-friendly.

--- a/docs/integrations-in-rancher/harvester/overview.md
+++ b/docs/integrations-in-rancher/harvester/overview.md
@@ -2,6 +2,10 @@
 title: Overview
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester/overview"/>
+</head>
+
 Introduced in Rancher v2.6.1, [Harvester](https://docs.harvesterhci.io/) is an open-source hyper-converged infrastructure (HCI) software built on Kubernetes. Harvester installs on bare metal servers and provides integrated virtualization and distributed storage capabilities. Although Harvester operates using Kubernetes, it does not require users to know Kubernetes concepts, making it a more user-friendly application.
 
 ### Feature Flag

--- a/docs/integrations-in-rancher/istio/configuration-options/configuration-options.md
+++ b/docs/integrations-in-rancher/istio/configuration-options/configuration-options.md
@@ -3,7 +3,7 @@ title: Configuration Options
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configuration-options"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/configuration-options"/>
 </head>
 
 ### Egress Support

--- a/docs/integrations-in-rancher/istio/istio.md
+++ b/docs/integrations-in-rancher/istio/istio.md
@@ -3,7 +3,7 @@ title: Istio
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/istio"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio"/>
 </head>
 
 [Istio](https://istio.io/) is an open-source tool that makes it easier for DevOps teams to observe, secure, control, and troubleshoot the traffic within a complex network of microservices.

--- a/docs/integrations-in-rancher/kubernetes-distributions/kubernetes-distributions.md
+++ b/docs/integrations-in-rancher/kubernetes-distributions/kubernetes-distributions.md
@@ -2,6 +2,10 @@
 title: Kubernetes Distributions
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/kubernetes-distributions"/>
+</head>
+
 ## K3s
 
 K3s is a lightweight, fully compliant Kubernetes distribution designed for a range of use cases, including edge computing, IoT, CI/CD, development and embedding Kubernetes into applications. It simplifies Kubernetes management by packaging the system as a single binary, using sqlite3 as the default storage, and offering a user-friendly launcher. K3s includes essential features like local storage and load balancing, Helm chart controller and the Traefik CNI. It minimizes external dependencies and provides a streamlined Kubernetes experience. K3s was donated to the CNCF as a Sandbox Project in June 2020.

--- a/docs/integrations-in-rancher/logging/custom-resource-configuration/custom-resource-configuration.md
+++ b/docs/integrations-in-rancher/logging/custom-resource-configuration/custom-resource-configuration.md
@@ -3,7 +3,7 @@ title: Custom Resource Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/custom-resource-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/logging/custom-resource-configuration"/>
 </head>
 
 The following Custom Resource Definitions are used to configure logging:

--- a/docs/integrations-in-rancher/logging/logging.md
+++ b/docs/integrations-in-rancher/logging/logging.md
@@ -4,7 +4,7 @@ description: Rancher integrates with popular logging services. Learn the require
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/logging"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/logging"/>
 </head>
 
 The [Logging operator](https://kube-logging.github.io/docs/) now powers Rancher's logging solution in place of the former, in-house solution.

--- a/docs/integrations-in-rancher/monitoring-and-alerting/monitoring-and-alerting.md
+++ b/docs/integrations-in-rancher/monitoring-and-alerting/monitoring-and-alerting.md
@@ -4,7 +4,7 @@ description: Prometheus lets you view metrics from your different Rancher and Ku
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-and-alerting"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/monitoring-and-alerting"/>
 </head>
 
 The `rancher-monitoring` application can quickly deploy leading open-source monitoring and alerting solutions onto your cluster.

--- a/docs/reference-guides/about-the-api/about-the-api.md
+++ b/docs/reference-guides/about-the-api/about-the-api.md
@@ -3,7 +3,7 @@ title: API
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/about-the-api"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/about-the-api"/>
 </head>
 
 ## How to use the API

--- a/docs/reference-guides/backup-restore-configuration/backup-restore-configuration.md
+++ b/docs/reference-guides/backup-restore-configuration/backup-restore-configuration.md
@@ -3,7 +3,7 @@ title: Rancher Backup Configuration Reference
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/backup-restore-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/backup-restore-configuration"/>
 </head>
 
 - [Backup configuration](backup-configuration.md)

--- a/docs/reference-guides/best-practices/best-practices.md
+++ b/docs/reference-guides/best-practices/best-practices.md
@@ -3,7 +3,7 @@ title: Best Practices Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/best-practices"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/best-practices"/>
 </head>
 
 The purpose of this section is to consolidate best practices for Rancher implementations. This also includes recommendations for related technologies, such as Kubernetes, Docker, containers, and more. The objective is to improve the outcome of a Rancher implementation using the operational experience of Rancher and its customers.

--- a/docs/reference-guides/best-practices/rancher-managed-clusters/rancher-managed-clusters.md
+++ b/docs/reference-guides/best-practices/rancher-managed-clusters/rancher-managed-clusters.md
@@ -3,7 +3,7 @@ title: Best Practices for Rancher Managed Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-managed-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/best-practices/rancher-managed-clusters"/>
 </head>
 
 ### Logging

--- a/docs/reference-guides/best-practices/rancher-server/rancher-server.md
+++ b/docs/reference-guides/best-practices/rancher-server/rancher-server.md
@@ -3,7 +3,7 @@ title: Best Practices for the Rancher Server
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-server"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/best-practices/rancher-server"/>
 </head>
 
 This guide contains our recommendations for running the Rancher server, and is intended to be used in situations in which Rancher manages downstream Kubernetes clusters.

--- a/docs/reference-guides/cli-with-rancher/cli-with-rancher.md
+++ b/docs/reference-guides/cli-with-rancher/cli-with-rancher.md
@@ -3,7 +3,7 @@ title: CLI with Rancher
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cli-with-rancher"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cli-with-rancher"/>
 </head>
 
 Interact with Rancher using command line interface (CLI) tools from your workstation. The following docs will describe the [Rancher CLI](rancher-cli.md) and [kubectl Utility](kubectl-utility.md).

--- a/docs/reference-guides/cluster-configuration/cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/cluster-configuration.md
@@ -3,7 +3,7 @@ title: Cluster Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cluster-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration"/>
 </head>
 
 After you provision a Kubernetes cluster using Rancher, you can still edit options and settings for the cluster.

--- a/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/downstream-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/downstream-cluster-configuration.md
@@ -3,7 +3,7 @@ title: Downstream Cluster Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/downstream-cluster-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/downstream-cluster-configuration"/>
 </head>
 
 The following docs will discuss [node template configuration](node-template-configuration/node-template-configuration.md) and [machine configuration](machine-configuration/machine-configuration.md).

--- a/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/machine-configuration.md
+++ b/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/machine-configuration.md
@@ -3,7 +3,7 @@ title: Machine Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/machine-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration"/>
 </head>
 
 Machine configuration is the arrangement of resources assigned to a virtual machine. Please see the docs for [Amazon EC2](amazon-ec2.md), [DigitalOcean](digitalocean.md), and [Azure](azure.md) to learn more.

--- a/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/node-template-configuration.md
+++ b/docs/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/node-template-configuration.md
@@ -3,7 +3,7 @@ title: Node Template Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/node-template-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration"/>
 </head>
 
 To learn about node template config, refer to [EC2 Node Template Configuration](amazon-ec2.md), [DigitalOcean Node Template Configuration](digitalocean.md), [Azure Node Template Configuration](azure.md), [vSphere Node Template Configuration](vsphere.md), and [Nutanix Node Template Configuration](nutanix.md).

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
@@ -3,7 +3,7 @@ title: GKE Cluster Configuration Reference
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/gke-cluster-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration"/>
 </head>
 
 ## Changes in Rancher v2.6

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/rancher-server-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/rancher-server-configuration.md
@@ -3,7 +3,7 @@ title: Rancher Server Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-server-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration"/>
 </head>
 
 - [RKE1 Cluster Configuration](rke1-cluster-configuration.md)

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md
@@ -4,7 +4,7 @@ description: To create a cluster with custom nodes, you’ll need to access serv
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/use-existing-nodes"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes"/>
 </head>
 
 When you create a custom cluster, Rancher uses RKE (the Rancher Kubernetes Engine) to create a Kubernetes cluster in on-prem bare-metal servers, on-prem virtual machines, or in any node hosted by an infrastructure provider.

--- a/docs/reference-guides/monitoring-v2-configuration/monitoring-v2-configuration.md
+++ b/docs/reference-guides/monitoring-v2-configuration/monitoring-v2-configuration.md
@@ -3,7 +3,7 @@ title: Monitoring V2 Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-v2-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/monitoring-v2-configuration"/>
 </head>
 
 The following sections will explain important options essential to configuring Monitoring V2 in Rancher:

--- a/docs/reference-guides/prometheus-federator/prometheus-federator.md
+++ b/docs/reference-guides/prometheus-federator/prometheus-federator.md
@@ -3,7 +3,7 @@ title: Prometheus Federator
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/prometheus-federator"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/prometheus-federator"/>
 </head>
 
 Prometheus Federator, also referred to as Project Monitoring v2, deploys a Helm Project Operator (based on the [rancher/helm-project-operator](https://github.com/rancher/helm-project-operator)), an operator that manages deploying Helm charts each containing a Project Monitoring Stack, where each stack contains:

--- a/docs/reference-guides/rancher-manager-architecture/rancher-manager-architecture.md
+++ b/docs/reference-guides/rancher-manager-architecture/rancher-manager-architecture.md
@@ -3,7 +3,7 @@ title: Architecture
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-manager-architecture"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-manager-architecture"/>
 </head>
 
 This section focuses on the [Rancher server and its components](rancher-server-and-components.md) and how [Rancher communicates with downstream Kubernetes clusters](communicating-with-downstream-user-clusters.md).

--- a/docs/reference-guides/rancher-security/hardening-guides/hardening-guides.md
+++ b/docs/reference-guides/rancher-security/hardening-guides/hardening-guides.md
@@ -3,7 +3,7 @@ title: Self-Assessment and Hardening Guides for Rancher
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-hardening-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/hardening-guides"/>
 </head>
 
 Rancher provides specific security hardening guides for each supported Rancher version's Kubernetes distributions.

--- a/docs/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-hardening-guide.md
+++ b/docs/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-hardening-guide.md
@@ -3,7 +3,7 @@ title: K3s Hardening Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/k3s-hardening-guide"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide"/>
 </head>
 
 This document provides prescriptive guidance for how to harden a K3s cluster intended for production, before provisioning it with Rancher. It outlines the configurations and controls required for Center for Information Security (CIS) Kubernetes benchmark controls.

--- a/docs/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-hardening-guide.md
+++ b/docs/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-hardening-guide.md
@@ -3,7 +3,7 @@ title: RKE Hardening Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rke1-hardening-guide"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide"/>
 </head>
 
 This document provides prescriptive guidance for how to harden an RKE cluster intended for production, before provisioning it with Rancher. It outlines the configurations and controls required for Center for Information Security (CIS) Kubernetes benchmark controls.

--- a/docs/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-hardening-guide.md
+++ b/docs/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-hardening-guide.md
@@ -3,7 +3,7 @@ title: RKE2 Hardening Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rke2-hardening-guide"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide"/>
 </head>
 
 This document provides prescriptive guidance for how to harden an RKE2 cluster intended for production, before provisioning it with Rancher. It outlines the configurations and controls required for Center for Information Security (CIS) Kubernetes benchmark controls.

--- a/docs/reference-guides/rancher-security/rancher-security.md
+++ b/docs/reference-guides/rancher-security/rancher-security.md
@@ -3,7 +3,7 @@ title: Security
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-security"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security"/>
 </head>
 
 <table width="100%">

--- a/docs/reference-guides/rancher-security/rancher-webhook-hardening.md
+++ b/docs/reference-guides/rancher-security/rancher-webhook-hardening.md
@@ -2,6 +2,10 @@
 title: Hardening the Rancher Webhook
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/rancher-webhook-hardening"/>
+</head>
+
 Rancher Webhook is an important component within Rancher, playing a role in enforcing security requirements for Rancher and its workloads. To decrease its attack surface, access to it should be limited to the only valid caller it has: the Kubernetes API server. This can be done by using network policies and authentication independently or in conjunction with each other to harden the webhook against attacks.
 
 ## Block External Traffic Using Network Policies

--- a/docs/reference-guides/rancher-security/selinux-rpm/selinux-rpm.md
+++ b/docs/reference-guides/rancher-security/selinux-rpm/selinux-rpm.md
@@ -3,7 +3,7 @@ title: SELinux RPM
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/selinux-rpm"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/selinux-rpm"/>
 </head>
 
 [Security-Enhanced Linux (SELinux)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) is a security enhancement to Linux.

--- a/docs/reference-guides/single-node-rancher-in-docker/single-node-rancher-in-docker.md
+++ b/docs/reference-guides/single-node-rancher-in-docker/single-node-rancher-in-docker.md
@@ -3,7 +3,7 @@ title: Single Node Rancher in Docker
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/single-node-rancher-in-docker"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/single-node-rancher-in-docker"/>
 </head>
 
 The following docs will discuss [HTTP proxy configuration](http-proxy-configuration.md) and [advanced options](advanced-options.md) for Docker installs.

--- a/docs/reference-guides/user-settings/user-settings.md
+++ b/docs/reference-guides/user-settings/user-settings.md
@@ -3,7 +3,7 @@ title: User Settings
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/user-settings"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/user-settings"/>
 </head>
 
 Within Rancher, each user has a number of settings associated with their login: personal preferences, API keys, etc. You can configure these settings by choosing from the **User Settings** menu. You can open this menu by clicking your avatar, located within the main menu.

--- a/docs/security/security-scan/security-scan.md
+++ b/docs/security/security-scan/security-scan.md
@@ -3,7 +3,7 @@ title: Security Scans
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scan-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/security/security-scan"/>
 </head>
 
 The documentation about CIS security scans has moved [here.](../../how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md)

--- a/docs/troubleshooting/kubernetes-components/kubernetes-components.md
+++ b/docs/troubleshooting/kubernetes-components/kubernetes-components.md
@@ -3,7 +3,7 @@ title: Kubernetes Components
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-components"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components"/>
 </head>
 
 The commands and steps listed in this section apply to the core Kubernetes components on [Rancher Launched Kubernetes](../../how-to-guides/new-user-guides/launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md) clusters.

--- a/versioned_docs/version-2.0-2.4/explanations/integrations-in-rancher/cis-scans/cis-scans.md
+++ b/versioned_docs/version-2.0-2.4/explanations/integrations-in-rancher/cis-scans/cis-scans.md
@@ -3,7 +3,7 @@ title: CIS Scans
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scans"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cis-scans"/>
 </head>
 
 _Available as of v2.4.0_

--- a/versioned_docs/version-2.0-2.4/explanations/integrations-in-rancher/istio/istio.md
+++ b/versioned_docs/version-2.0-2.4/explanations/integrations-in-rancher/istio/istio.md
@@ -3,7 +3,7 @@ title: Istio
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/istio"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio"/>
 </head>
 
 _Available as of v2.3.0_

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/install-upgrade-on-a-kubernetes-cluster.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/install-upgrade-on-a-kubernetes-cluster.md
@@ -4,7 +4,7 @@ description: Learn how to install Rancher in development and production environm
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster"/>
 </head>
 
 ## Prerequisite

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/installation-and-upgrade.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/installation-and-upgrade.md
@@ -4,7 +4,7 @@ description: Learn how to install Rancher in development and production environm
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-and-upgrade"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade"/>
 </head>
 
 This section provides an overview of the architecture options of installing Rancher, describing advantages of each option.

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
@@ -4,7 +4,7 @@ description: Learn the node requirements for each node running Rancher server wh
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-requirements"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-requirements"/>
 </head>
 
 This page describes the software, hardware, and networking requirements for the nodes where the Rancher server will be installed. The Rancher server can be installed on a single node or a high-availability Kubernetes cluster.

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/air-gapped-helm-cli-install.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/air-gapped-helm-cli-install.md
@@ -3,7 +3,7 @@ title: Air Gapped Helm CLI Install
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/air-gapped-helm-cli-install"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install"/>
 </head>
 
 This section is about using the Helm CLI to install the Rancher server in an air gapped environment. An air gapped environment could be where Rancher server will be installed offline, behind a firewall, or behind a proxy.

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/rancher-behind-an-http-proxy.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/rancher-behind-an-http-proxy.md
@@ -3,7 +3,7 @@ title: Installing Rancher behind an HTTP Proxy
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-behind-an-http-proxy"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy"/>
 </head>
 
 In a lot of enterprise environments, servers or VMs running on premise do not have direct Internet access, but must connect to external services through a HTTP(S) proxy for security reasons. This tutorial shows step by step how to set up a highly available Rancher installation in such an environment.

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
@@ -4,7 +4,7 @@ description: For development and testing environments only, use a Docker install
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-on-a-single-node-with-docker"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker"/>
 </head>
 
 Rancher can be installed by running a single Docker container.

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/resources/resources.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/resources/resources.md
@@ -3,7 +3,7 @@ title: Resources
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/resources"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/resources"/>
 </head>
 
 ### Docker Installations

--- a/versioned_docs/version-2.0-2.4/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
@@ -3,7 +3,7 @@ title: Deploying Rancher Server
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-rancher-manager"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com"/>
 </head>
 
 Use one of the following guides to deploy and provision Rancher and a Kubernetes cluster in the provider of your choice.

--- a/versioned_docs/version-2.0-2.4/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli.md
@@ -2,6 +2,10 @@
 title: Manual Quick Start
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli"/>
+</head>
+
 Howdy Partner! This tutorial walks you through:
 
 - Installation of Rancher 2.x

--- a/versioned_docs/version-2.0-2.4/getting-started/quick-start-guides/deploy-workloads/deploy-workloads.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/quick-start-guides/deploy-workloads/deploy-workloads.md
@@ -3,7 +3,7 @@ title: Deploying Workloads
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-rancher-workloads"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-workloads"/>
 </head>
 
 These guides walk you through the deployment of an application, including how to expose the application for use outside of the cluster.

--- a/versioned_docs/version-2.0-2.4/getting-started/quick-start-guides/quick-start-guides.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/quick-start-guides/quick-start-guides.md
@@ -3,7 +3,7 @@ title: Rancher Deployment Quick Start Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/quick-start-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides"/>
 </head>
 
 >**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation](../installation-and-upgrade/installation-and-upgrade.md).

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/advanced-user-guides.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/advanced-user-guides.md
@@ -3,7 +3,7 @@ title: Advanced User Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/advanced-user-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides"/>
 </head>
 
 Advanced user guides are "problem-oriented" docs in which users learn how to answer questions or solve problems. The major difference between these and the new user guides is that these guides are geared toward more experienced or advanced users who have more technical needs from their documentation. These users already have an understanding of Rancher and its functions. They know what they need to accomplish; they just need additional guidance to complete some more complex task they they have encountered while working.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md
@@ -3,7 +3,7 @@ title: CIS Scan Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scan-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides"/>
 </head>
 
 - [Run a Scan](run-a-scan.md)

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
@@ -3,7 +3,7 @@ title: Setup Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/istio-setup-guide"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide"/>
 </head>
 
 This section describes how to enable Istio and start using it in your projects.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/manage-project-resource-quotas.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/manage-project-resource-quotas.md
@@ -3,7 +3,7 @@ title: Project Resource Quotas
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-project-resource-quotas"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas"/>
 </head>
 
 _Available as of v2.1.0_

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/manage-projects/manage-projects.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/manage-projects/manage-projects.md
@@ -3,7 +3,7 @@ title: Project Administration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-projects"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/manage-projects"/>
 </head>
 
 _Projects_ are objects introduced in Rancher that help organize namespaces in your Kubernetes cluster. You can use projects to create multi-tenant clusters, which allows a group of users to share the same underlying resources without interacting with each other's applications.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher-launched-kubernetes-clusters.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher-launched-kubernetes-clusters.md
@@ -2,6 +2,10 @@
 title: Backing up Rancher Installed on an RKE Kubernetes Cluster
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher-launched-kubernetes-clusters"/>
+</head>
+
 This section describes how to create backups of your high-availability Rancher install.
 
 In an RKE installation, the cluster data is replicated on each of three etcd nodes in the cluster, providing redundancy and data duplication in case one of the nodes fails.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
@@ -4,7 +4,7 @@ keywords: [rancher v2.0-v2.4 backup restore, rancher v2.0-v2.4 backup and restor
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/backup-restore-and-disaster-recovery"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery"/>
 </head>
 
 This section is devoted to protecting your data in a disaster scenario.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/restore-rancher-launched-kubernetes-clusters-from-backup.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/restore-rancher-launched-kubernetes-clusters-from-backup.md
@@ -2,6 +2,10 @@
 title: Restoring Backups—Kubernetes installs
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/restore-rancher-launched-kubernetes-clusters-from-backup"/>
+</head>
+
 This procedure describes how to use RKE to restore a snapshot of the Rancher Kubernetes cluster.
 This will restore the Kubernetes configuration and the Rancher database and state.
 

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/helm-charts-in-rancher/helm-charts-in-rancher.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/helm-charts-in-rancher/helm-charts-in-rancher.md
@@ -4,7 +4,7 @@ description: Rancher enables the use of catalogs to repeatedly deploy applicatio
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/helm-charts-in-rancher"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/helm-charts-in-rancher"/>
 </head>
 
 Rancher provides the ability to use a catalog of Helm charts that make it easy to repeatedly deploy applications.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/infrastructure-setup/infrastructure-setup.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/infrastructure-setup/infrastructure-setup.md
@@ -3,7 +3,7 @@ title: Don't have infrastructure for your Kubernetes cluster? Try one of these t
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/infrastructure-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/infrastructure-setup"/>
 </head>
 
 To set up infrastructure for a high-availability K3s Kubernetes cluster with an external DB, refer to [this page.](ha-k3s-kubernetes-cluster.md)

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-cluster-setup/kubernetes-cluster-setup.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-cluster-setup/kubernetes-cluster-setup.md
@@ -3,7 +3,7 @@ title: "Don't have a Kubernetes cluster? Try one of these tutorials."
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-cluster-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup"/>
 </head>
 
 This section contains information on how to install a Kubernetes cluster that the Rancher server can be installed on.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/checklist-for-production-ready-clusters.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/checklist-for-production-ready-clusters.md
@@ -3,7 +3,7 @@ title: Checklist for Production-Ready Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/checklist-for-production-ready-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters"/>
 </head>
 
 In this section, we recommend best practices for creating the production-ready Kubernetes clusters that will run your apps and services.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/kubernetes-clusters-in-rancher-setup.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/kubernetes-clusters-in-rancher-setup.md
@@ -4,7 +4,7 @@ description: Provisioning Kubernetes Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-clusters-in-rancher-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup"/>
 </head>
 
 Rancher simplifies the creation of clusters by allowing you to create them through the Rancher UI rather than more complex alternatives. Rancher provides multiple options for launching a cluster. Use the option that best fits your use case.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md
@@ -3,7 +3,7 @@ title: Setting up Clusters from Hosted Kubernetes Providers
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/set-up-clusters-from-hosted-kubernetes-providers"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers"/>
 </head>
 
 In this scenario, Rancher does not provision Kubernetes because it is installed by providers such as Google Kubernetes Engine (GKE), Amazon Elastic Container Service for Kubernetes, or Azure Kubernetes Service.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/horizontal-pod-autoscaler.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/horizontal-pod-autoscaler.md
@@ -4,7 +4,7 @@ description: Learn about the horizontal pod autoscaler (HPA). How to manage HPAs
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/horizontal-pod-autoscaler"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler"/>
 </head>
 
 The [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) (HPA) is a Kubernetes feature that allows you to configure your cluster to automatically scale the services it's running up or down.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-resources-setup.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-resources-setup.md
@@ -3,7 +3,7 @@ title: Kubernetes Resources
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-resources-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup"/>
 </head>
 
 ## Workloads

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.md
@@ -4,7 +4,7 @@ description: Learn how you can set up load balancers and ingress controllers to 
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/load-balancer-and-ingress-controller"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller"/>
 </head>
 
 Within Rancher, you can set up load balancers and ingress controllers to redirect service requests.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/workloads-and-pods.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/workloads-and-pods.md
@@ -4,7 +4,7 @@ description: "Learn about the two constructs with which you can build any comple
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/workloads-and-pods"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods"/>
 </head>
 
 You can build any complex containerized application in Kubernetes using two basic constructs: pods and workloads. Once you build an application, you can expose it for access either within the same cluster or on the Internet using a third construct: services.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/new-user-guides.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/new-user-guides.md
@@ -3,7 +3,7 @@ title: New User Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/new-user-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides"/>
 </head>
 
 New user guides, also known as **tutorials**, describe practical steps for users to follow in order to complete some concrete action. These docs are known as "learning-oriented" docs in which users learn by "doing".

--- a/versioned_docs/version-2.0-2.4/rancher-manager.md
+++ b/versioned_docs/version-2.0-2.4/rancher-manager.md
@@ -3,6 +3,10 @@ title: "Rancher 2.0-2.4"
 description: "Rancher adds significant value on top of Kubernetes: managing hundreds of clusters from one interface, centralizing RBAC, enabling monitoring and alerting. Read more."
 slug: /
 ---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com"/>
+</head>
 Rancher was originally built to work with multiple orchestrators, and it included its own orchestrator called Cattle. With the rise of Kubernetes in the marketplace, Rancher 2.x exclusively deploys and manages Kubernetes clusters running anywhere, on any provider.
 
 Rancher can provision Kubernetes from a hosted provider, provision compute nodes and then install Kubernetes onto them, or import existing Kubernetes clusters running anywhere.

--- a/versioned_docs/version-2.0-2.4/reference-guides/about-the-api/about-the-api.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/about-the-api/about-the-api.md
@@ -3,7 +3,7 @@ title: API
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/about-the-api"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/about-the-api"/>
 </head>
 
 ## How to use the API

--- a/versioned_docs/version-2.0-2.4/reference-guides/best-practices/best-practices.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/best-practices/best-practices.md
@@ -3,7 +3,7 @@ title: Best Practices Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/best-practices"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/best-practices"/>
 </head>
 
 The purpose of this section is to consolidate best practices for Rancher implementations. This also includes recommendations for related technologies, such as Kubernetes, Docker, containers, and more. The objective is to improve the outcome of a Rancher implementation using the operational experience of Rancher and its customers.

--- a/versioned_docs/version-2.0-2.4/reference-guides/cli-with-rancher/cli-with-rancher.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/cli-with-rancher/cli-with-rancher.md
@@ -3,7 +3,7 @@ title: CLI with Rancher
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cli-with-rancher"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cli-with-rancher"/>
 </head>
 
 Interact with Rancher using command line interface (CLI) tools from your workstation. The following docs will describe the [Rancher CLI](rancher-cli.md) and [kubectl Utility](kubectl-utility.md).

--- a/versioned_docs/version-2.0-2.4/reference-guides/cluster-configuration/cluster-configuration.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/cluster-configuration/cluster-configuration.md
@@ -3,7 +3,7 @@ title: Cluster Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cluster-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration"/>
 </head>
 
 After you provision a Kubernetes cluster using Rancher, you can still edit options and settings for the cluster.

--- a/versioned_docs/version-2.0-2.4/reference-guides/cluster-configuration/downstream-cluster-configuration/downstream-cluster-configuration.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/cluster-configuration/downstream-cluster-configuration/downstream-cluster-configuration.md
@@ -3,7 +3,7 @@ title: Downstream Cluster Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/downstream-cluster-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/downstream-cluster-configuration"/>
 </head>
 
 The following docs will discuss [node template configuration](node-template-configuration/node-template-configuration.md).

--- a/versioned_docs/version-2.0-2.4/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/node-template-configuration.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/node-template-configuration.md
@@ -3,7 +3,7 @@ title: Node Template Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/node-template-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration"/>
 </head>
 
 To learn about node template config, refer to [EC2 Node Template Configuration](amazon-ec2.md), [DigitalOcean Node Template Configuration](digitalocean.md), [Azure Node Template Configuration](azure.md), and [vSphere Node Template Configuration](vsphere/vsphere.md).

--- a/versioned_docs/version-2.0-2.4/reference-guides/cluster-configuration/rancher-server-configuration/rancher-server-configuration.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/cluster-configuration/rancher-server-configuration/rancher-server-configuration.md
@@ -3,7 +3,7 @@ title: Rancher Server Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-server-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration"/>
 </head>
 
 - [RKE1 Cluster Configuration](rke1-cluster-configuration.md)

--- a/versioned_docs/version-2.0-2.4/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md
@@ -4,7 +4,7 @@ description: To create a cluster with custom nodes, you’ll need to access serv
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/use-existing-nodes"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes"/>
 </head>
 
 When you create a custom cluster, Rancher uses RKE (the Rancher Kubernetes Engine) to create a Kubernetes cluster in on-prem bare-metal servers, on-prem virtual machines, or in any node hosted by an infrastructure provider.

--- a/versioned_docs/version-2.0-2.4/reference-guides/rancher-manager-architecture/rancher-manager-architecture.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/rancher-manager-architecture/rancher-manager-architecture.md
@@ -3,7 +3,7 @@ title: Architecture
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-manager-architecture"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-manager-architecture"/>
 </head>
 
 This section focuses on the [Rancher server and its components](rancher-server-and-components.md) and how [Rancher communicates with downstream Kubernetes clusters](communicating-with-downstream-user-clusters.md).

--- a/versioned_docs/version-2.0-2.4/reference-guides/rancher-security/rancher-security.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/rancher-security/rancher-security.md
@@ -3,7 +3,7 @@ title: Security
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-security"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security"/>
 </head>
 
 <table width="100%">

--- a/versioned_docs/version-2.0-2.4/reference-guides/single-node-rancher-in-docker/single-node-rancher-in-docker.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/single-node-rancher-in-docker/single-node-rancher-in-docker.md
@@ -3,7 +3,7 @@ title: Single Node Rancher in Docker
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/single-node-rancher-in-docker"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/single-node-rancher-in-docker"/>
 </head>
 
 The following docs will discuss [HTTP proxy configuration](http-proxy-configuration.md) and [advanced options](advanced-options.md) for Docker installs.

--- a/versioned_docs/version-2.0-2.4/reference-guides/user-settings/user-settings.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/user-settings/user-settings.md
@@ -3,7 +3,7 @@ title: User Settings
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/user-settings"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/user-settings"/>
 </head>
 
 Within Rancher, each user has a number of settings associated with their login: personal preferences, API keys, etc. You can configure these settings by choosing from the **User Settings** menu. You can open this menu by clicking your avatar, located within the main menu.

--- a/versioned_docs/version-2.0-2.4/security/security-scan/security-scan.md
+++ b/versioned_docs/version-2.0-2.4/security/security-scan/security-scan.md
@@ -3,7 +3,7 @@ title: Security Scans
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scan-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/security/security-scan"/>
 </head>
 
 The documentation about CIS security scans has moved [here.](../../how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md)

--- a/versioned_docs/version-2.0-2.4/troubleshooting/kubernetes-components/kubernetes-components.md
+++ b/versioned_docs/version-2.0-2.4/troubleshooting/kubernetes-components/kubernetes-components.md
@@ -3,7 +3,7 @@ title: Kubernetes Components
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-components"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components"/>
 </head>
 
 The commands and steps listed in this section apply to the core Kubernetes components on [Rancher Launched Kubernetes](../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md) clusters.

--- a/versioned_docs/version-2.5/explanations/integrations-in-rancher/cis-scans/cis-scans.md
+++ b/versioned_docs/version-2.5/explanations/integrations-in-rancher/cis-scans/cis-scans.md
@@ -3,7 +3,7 @@ title: CIS Scans
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scans"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cis-scans"/>
 </head>
 
 Rancher can run a security scan to check whether Kubernetes is deployed according to security best practices as defined in the CIS Kubernetes Benchmark.

--- a/versioned_docs/version-2.5/explanations/integrations-in-rancher/istio/configuration-options/configuration-options.md
+++ b/versioned_docs/version-2.5/explanations/integrations-in-rancher/istio/configuration-options/configuration-options.md
@@ -3,7 +3,7 @@ title: Configuration Options
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configuration-options"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/configuration-options"/>
 </head>
 
 ### Egress Support

--- a/versioned_docs/version-2.5/explanations/integrations-in-rancher/istio/istio.md
+++ b/versioned_docs/version-2.5/explanations/integrations-in-rancher/istio/istio.md
@@ -3,7 +3,7 @@ title: Istio
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/istio"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio"/>
 </head>
 
 [Istio](https://istio.io/) is an open-source tool that makes it easier for DevOps teams to observe, secure, control, and troubleshoot the traffic within a complex network of microservices.

--- a/versioned_docs/version-2.5/explanations/integrations-in-rancher/logging/custom-resource-configuration/custom-resource-configuration.md
+++ b/versioned_docs/version-2.5/explanations/integrations-in-rancher/logging/custom-resource-configuration/custom-resource-configuration.md
@@ -3,7 +3,7 @@ title: Custom Resource Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/custom-resource-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/logging/custom-resource-configuration"/>
 </head>
 
 The following Custom Resource Definitions are used to configure logging:

--- a/versioned_docs/version-2.5/explanations/integrations-in-rancher/logging/logging.md
+++ b/versioned_docs/version-2.5/explanations/integrations-in-rancher/logging/logging.md
@@ -4,7 +4,7 @@ description: Rancher integrates with popular logging services. Learn the require
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/logging"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/logging"/>
 </head>
 
 The [Logging operator](https://kube-logging.github.io/docs/) now powers Rancher's logging solution in place of the former, in-house solution.

--- a/versioned_docs/version-2.5/explanations/integrations-in-rancher/monitoring-and-alerting/monitoring-and-alerting.md
+++ b/versioned_docs/version-2.5/explanations/integrations-in-rancher/monitoring-and-alerting/monitoring-and-alerting.md
@@ -4,7 +4,7 @@ description: Prometheus lets you view metrics from your different Rancher and Ku
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-and-alerting"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/monitoring-and-alerting"/>
 </head>
 
 Using the `rancher-monitoring` application, you can quickly deploy leading open-source monitoring and alerting solutions onto your cluster.

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/install-upgrade-on-a-kubernetes-cluster.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/install-upgrade-on-a-kubernetes-cluster.md
@@ -4,7 +4,7 @@ description: Learn how to install Rancher in development and production environm
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster"/>
 </head>
 
 In this section, you'll learn how to deploy Rancher on a Kubernetes cluster using the Helm CLI.

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/installation-and-upgrade.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/installation-and-upgrade.md
@@ -4,7 +4,7 @@ description: Learn how to install Rancher in development and production environm
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-and-upgrade"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade"/>
 </head>
 
 This section provides an overview of the architecture options of installing Rancher, describing advantages of each option.

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
@@ -4,7 +4,7 @@ description: Learn the node requirements for each node running Rancher server wh
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-requirements"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-requirements"/>
 </head>
 
 This page describes the software, hardware, and networking requirements for the nodes where the Rancher server will be installed. The Rancher server can be installed on a single node or a high-availability Kubernetes cluster.

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/air-gapped-helm-cli-install.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/air-gapped-helm-cli-install.md
@@ -3,7 +3,7 @@ title: Air Gapped Helm CLI Install
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/air-gapped-helm-cli-install"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install"/>
 </head>
 
 This section is about using the Helm CLI to install the Rancher server in an air gapped environment. An air gapped environment could be where Rancher server will be installed offline, behind a firewall, or behind a proxy.

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/other-installation-methods.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/other-installation-methods.md
@@ -3,7 +3,7 @@ title: Other Installation Methods
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/other-installation-methods"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods"/>
 </head>
 
 ### Air Gapped Installations

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/rancher-behind-an-http-proxy.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/rancher-behind-an-http-proxy.md
@@ -3,7 +3,7 @@ title: Installing Rancher behind an HTTP Proxy
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-behind-an-http-proxy"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy"/>
 </head>
 
 In a lot of enterprise environments, servers or VMs running on premise do not have direct Internet access, but must connect to external services through a HTTP(S) proxy for security reasons. This tutorial shows step by step how to set up a highly available Rancher installation in such an environment.

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
@@ -4,7 +4,7 @@ description: For development and testing environments only, use a Docker install
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-on-a-single-node-with-docker"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker"/>
 </head>
 
 Rancher can be installed by running a single Docker container.

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/resources/resources.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/resources/resources.md
@@ -3,7 +3,7 @@ title: Resources
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/resources"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/resources"/>
 </head>
 
 ### Docker Installations

--- a/versioned_docs/version-2.5/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
+++ b/versioned_docs/version-2.5/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
@@ -3,7 +3,7 @@ title: Deploying Rancher Server
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-rancher-manager"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com"/>
 </head>
 
 Use one of the following guides to deploy and provision Rancher and a Kubernetes cluster in the provider of your choice.

--- a/versioned_docs/version-2.5/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli.md
+++ b/versioned_docs/version-2.5/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli.md
@@ -2,6 +2,10 @@
 title: Manual Quick Start
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli"/>
+</head>
+
 Howdy Partner! This tutorial walks you through:
 
 - Installation of Rancher 2.x

--- a/versioned_docs/version-2.5/getting-started/quick-start-guides/deploy-workloads/deploy-workloads.md
+++ b/versioned_docs/version-2.5/getting-started/quick-start-guides/deploy-workloads/deploy-workloads.md
@@ -3,7 +3,7 @@ title: Deploying Workloads
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-rancher-workloads"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-workloads"/>
 </head>
 
 These guides walk you through the deployment of an application, including how to expose the application for use outside of the cluster.

--- a/versioned_docs/version-2.5/getting-started/quick-start-guides/quick-start-guides.md
+++ b/versioned_docs/version-2.5/getting-started/quick-start-guides/quick-start-guides.md
@@ -3,7 +3,7 @@ title: Rancher Deployment Quick Start Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/quick-start-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides"/>
 </head>
 
 >**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation](../installation-and-upgrade/installation-and-upgrade.md).

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/advanced-user-guides.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/advanced-user-guides.md
@@ -3,7 +3,7 @@ title: Advanced User Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/advanced-user-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides"/>
 </head>
 
 Advanced user guides are "problem-oriented" docs in which users learn how to answer questions or solve problems. The major difference between these and the new user guides is that these guides are geared toward more experienced or advanced users who have more technical needs from their documentation. These users already have an understanding of Rancher and its functions. They know what they need to accomplish; they just need additional guidance to complete some more complex task they they have encountered while working.

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md
@@ -3,7 +3,7 @@ title: CIS Scan Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scan-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides"/>
 </head>
 
 - [Install rancher-cis-benchmark](install-rancher-cis-benchmark.md)

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
@@ -3,7 +3,7 @@ title: Setup Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/istio-setup-guide"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide"/>
 </head>
 
 This section describes how to enable Istio and start using it in your projects.

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/manage-project-resource-quotas.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/manage-project-resource-quotas.md
@@ -3,7 +3,7 @@ title: Project Resource Quotas
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-project-resource-quotas"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas"/>
 </head>
 
 In situations where several teams share a cluster, one team may overconsume the resources available: CPU, memory, storage, services, Kubernetes objects like pods or secrets, and so on.  To prevent this overconsumption, you can apply a _resource quota_, which is a Rancher feature that limits the resources available to a project or namespace.

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/manage-projects/manage-projects.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/manage-projects/manage-projects.md
@@ -3,7 +3,7 @@ title: Project Administration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-projects"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/manage-projects"/>
 </head>
 
 _Projects_ are objects introduced in Rancher that help organize namespaces in your Kubernetes cluster. You can use projects to create multi-tenant clusters, which allows a group of users to share the same underlying resources without interacting with each other's applications.

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/monitoring-alerting-guides/monitoring-alerting-guides.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/monitoring-alerting-guides/monitoring-alerting-guides.md
@@ -3,7 +3,7 @@ title: Monitoring/Alerting Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-alerting-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-alerting-guides"/>
 </head>
 
 - [Enable monitoring](enable-monitoring.md)

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/advanced-configuration.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/advanced-configuration.md
@@ -3,7 +3,7 @@ title: Advanced Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/advanced-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration"/>
 </head>
 
 ### Alertmanager

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/monitoring-v2-configuration-guides.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/monitoring-v2-configuration-guides.md
@@ -3,7 +3,7 @@ title: Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-v2-configuration-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides"/>
 </head>
 
 This page captures some of the most important options for configuring Monitoring V2 in the Rancher UI.

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
@@ -4,7 +4,7 @@ keywords: [rancher v2.5 backup restore, rancher v2.5 backup and restore, backup 
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/backup-restore-and-disaster-recovery"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery"/>
 </head>
 
 In this section, you'll learn how to create backups of Rancher, how to restore Rancher from backup, and how to migrate Rancher to a new Kubernetes cluster.

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/deploy-apps-across-clusters/deploy-apps-across-clusters.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/deploy-apps-across-clusters/deploy-apps-across-clusters.md
@@ -3,7 +3,7 @@ title: Deploying Applications across Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-apps-across-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters"/>
 </head>
 
 Rancher offers several ways to deploy applications across clusters, depending on version.

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
@@ -2,6 +2,10 @@
 title: Fleet - GitOps at Scale
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet"/>
+</head>
+
 _Available as of Rancher v2.5_
 
 Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It's also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale.](https://fleet.rancher.io/installation#configuration-for-multi-cluster) By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/infrastructure-setup/infrastructure-setup.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/infrastructure-setup/infrastructure-setup.md
@@ -3,7 +3,7 @@ title: Don't have infrastructure for your Kubernetes cluster? Try one of these t
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/infrastructure-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/infrastructure-setup"/>
 </head>
 
 To set up infrastructure for a high-availability K3s Kubernetes cluster with an external DB, refer to [this page.](ha-k3s-kubernetes-cluster.md)

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-cluster-setup/kubernetes-cluster-setup.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-cluster-setup/kubernetes-cluster-setup.md
@@ -3,7 +3,7 @@ title: "Don't have a Kubernetes cluster? Try one of these tutorials."
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-cluster-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup"/>
 </head>
 
 This section contains information on how to install a Kubernetes cluster that the Rancher server can be installed on.

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/checklist-for-production-ready-clusters.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/checklist-for-production-ready-clusters.md
@@ -3,7 +3,7 @@ title: Checklist for Production-Ready Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/checklist-for-production-ready-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters"/>
 </head>
 
 In this section, we recommend best practices for creating the production-ready Kubernetes clusters that will run your apps and services.

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/kubernetes-clusters-in-rancher-setup.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/kubernetes-clusters-in-rancher-setup.md
@@ -4,7 +4,7 @@ description: Provisioning Kubernetes Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-clusters-in-rancher-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup"/>
 </head>
 
 Rancher simplifies the creation of clusters by allowing you to create them through the Rancher UI rather than more complex alternatives. Rancher provides multiple options for launching a cluster. Use the option that best fits your use case.

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md
@@ -3,7 +3,7 @@ title: Setting up Clusters from Hosted Kubernetes Providers
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/set-up-clusters-from-hosted-kubernetes-providers"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers"/>
 </head>
 
 In this scenario, Rancher does not provision Kubernetes because it is installed by providers such as Google Kubernetes Engine (GKE), Amazon Elastic Container Service for Kubernetes, or Azure Kubernetes Service.

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/horizontal-pod-autoscaler.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/horizontal-pod-autoscaler.md
@@ -4,7 +4,7 @@ description: Learn about the horizontal pod autoscaler (HPA). How to manage HPAs
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/horizontal-pod-autoscaler"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler"/>
 </head>
 
 The [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) (HPA) is a Kubernetes feature that allows you to configure your cluster to automatically scale the services it's running up or down.

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-resources-setup.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-resources-setup.md
@@ -3,7 +3,7 @@ title: Kubernetes Resources
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-resources-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup"/>
 </head>
 
 > The <b>Cluster Explorer</b> is a new feature in Rancher v2.5 that allows you to view and manipulate all of the custom resources and CRDs in a Kubernetes cluster from the Rancher UI. This section will be updated to reflect the way that Kubernetes resources are handled in Rancher v2.5.

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.md
@@ -4,7 +4,7 @@ description: Learn how you can set up load balancers and ingress controllers to 
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/load-balancer-and-ingress-controller"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller"/>
 </head>
 
 Within Rancher, you can set up load balancers and ingress controllers to redirect service requests.

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/workloads-and-pods.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/workloads-and-pods.md
@@ -4,7 +4,7 @@ description: "Learn about the two constructs with which you can build any comple
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/workloads-and-pods"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods"/>
 </head>
 
 You can build any complex containerized application in Kubernetes using two basic constructs: pods and workloads. Once you build an application, you can expose it for access either within the same cluster or on the Internet using a third construct: services.

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/new-user-guides.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/new-user-guides.md
@@ -3,7 +3,7 @@ title: New User Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/new-user-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides"/>
 </head>
 
 New user guides, also known as **tutorials**, describe practical steps for users to follow in order to complete some concrete action. These docs are known as "learning-oriented" docs in which users learn by "doing".

--- a/versioned_docs/version-2.5/rancher-manager.md
+++ b/versioned_docs/version-2.5/rancher-manager.md
@@ -3,6 +3,10 @@ title: "Rancher 2.5"
 description: "Rancher adds significant value on top of Kubernetes: managing hundreds of clusters from one interface, centralizing RBAC, enabling monitoring and alerting. Read more."
 slug: /
 ---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com"/>
+</head>
 Rancher was originally built to work with multiple orchestrators, and it included its own orchestrator called Cattle. With the rise of Kubernetes in the marketplace, Rancher 2 exclusively deploys and manages Kubernetes clusters running anywhere, on any provider.
 
 Rancher can provision Kubernetes from a hosted provider, provision compute nodes and then install Kubernetes onto them, or import existing Kubernetes clusters running anywhere.

--- a/versioned_docs/version-2.5/reference-guides/about-the-api/about-the-api.md
+++ b/versioned_docs/version-2.5/reference-guides/about-the-api/about-the-api.md
@@ -3,7 +3,7 @@ title: API
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/about-the-api"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/about-the-api"/>
 </head>
 
 ## How to use the API

--- a/versioned_docs/version-2.5/reference-guides/backup-restore-configuration/backup-restore-configuration.md
+++ b/versioned_docs/version-2.5/reference-guides/backup-restore-configuration/backup-restore-configuration.md
@@ -3,7 +3,7 @@ title: Rancher Backup Configuration Reference
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/backup-restore-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/backup-restore-configuration"/>
 </head>
 
 - [Backup configuration](backup-configuration.md)

--- a/versioned_docs/version-2.5/reference-guides/best-practices/best-practices.md
+++ b/versioned_docs/version-2.5/reference-guides/best-practices/best-practices.md
@@ -3,7 +3,7 @@ title: Best Practices Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/best-practices"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/best-practices"/>
 </head>
 
 The purpose of this section is to consolidate best practices for Rancher implementations. This also includes recommendations for related technologies, such as Kubernetes, Docker, containers, and more. The objective is to improve the outcome of a Rancher implementation using the operational experience of Rancher and its customers.

--- a/versioned_docs/version-2.5/reference-guides/best-practices/rancher-managed-clusters/rancher-managed-clusters.md
+++ b/versioned_docs/version-2.5/reference-guides/best-practices/rancher-managed-clusters/rancher-managed-clusters.md
@@ -3,7 +3,7 @@ title: Best Practices for Rancher Managed Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-managed-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/best-practices/rancher-managed-clusters"/>
 </head>
 
 ### Logging

--- a/versioned_docs/version-2.5/reference-guides/best-practices/rancher-server/rancher-server.md
+++ b/versioned_docs/version-2.5/reference-guides/best-practices/rancher-server/rancher-server.md
@@ -3,7 +3,7 @@ title: Best Practices for the Rancher Server
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-server"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/best-practices/rancher-server"/>
 </head>
 
 This guide contains our recommendations for running the Rancher server, and is intended to be used in situations in which Rancher manages downstream Kubernetes clusters.

--- a/versioned_docs/version-2.5/reference-guides/cli-with-rancher/cli-with-rancher.md
+++ b/versioned_docs/version-2.5/reference-guides/cli-with-rancher/cli-with-rancher.md
@@ -3,7 +3,7 @@ title: CLI with Rancher
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cli-with-rancher"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cli-with-rancher"/>
 </head>
 
 Interact with Rancher using command line interface (CLI) tools from your workstation. The following docs will describe the [Rancher CLI](rancher-cli.md) and [kubectl Utility](kubectl-utility.md).

--- a/versioned_docs/version-2.5/reference-guides/cluster-configuration/cluster-configuration.md
+++ b/versioned_docs/version-2.5/reference-guides/cluster-configuration/cluster-configuration.md
@@ -3,7 +3,7 @@ title: Cluster Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cluster-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration"/>
 </head>
 
 After you provision a Kubernetes cluster using Rancher, you can still edit options and settings for the cluster.

--- a/versioned_docs/version-2.5/reference-guides/cluster-configuration/downstream-cluster-configuration/downstream-cluster-configuration.md
+++ b/versioned_docs/version-2.5/reference-guides/cluster-configuration/downstream-cluster-configuration/downstream-cluster-configuration.md
@@ -3,7 +3,7 @@ title: Downstream Cluster Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/downstream-cluster-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/downstream-cluster-configuration"/>
 </head>
 
 The following docs will discuss [node template configuration](node-template-configuration/node-template-configuration.md).

--- a/versioned_docs/version-2.5/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/node-template-configuration.md
+++ b/versioned_docs/version-2.5/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/node-template-configuration.md
@@ -3,7 +3,7 @@ title: Node Template Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/node-template-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration"/>
 </head>
 
 To learn about node template config, refer to [EC2 Node Template Configuration](amazon-ec2.md), [DigitalOcean Node Template Configuration](digitalocean.md), [Azure Node Template Configuration](azure.md), and [vSphere Node Template Configuration](vsphere.md).

--- a/versioned_docs/version-2.5/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
+++ b/versioned_docs/version-2.5/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
@@ -3,7 +3,7 @@ title: GKE Cluster Configuration Reference
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/gke-cluster-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration"/>
 </head>
 
 <Tabs>

--- a/versioned_docs/version-2.5/reference-guides/cluster-configuration/rancher-server-configuration/rancher-server-configuration.md
+++ b/versioned_docs/version-2.5/reference-guides/cluster-configuration/rancher-server-configuration/rancher-server-configuration.md
@@ -3,7 +3,7 @@ title: Rancher Server Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-server-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration"/>
 </head>
 
 - [RKE1 Cluster Configuration](rke1-cluster-configuration.md)

--- a/versioned_docs/version-2.5/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md
+++ b/versioned_docs/version-2.5/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md
@@ -4,7 +4,7 @@ description: To create a cluster with custom nodes, you’ll need to access serv
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/use-existing-nodes"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes"/>
 </head>
 
 When you create a custom cluster, Rancher uses RKE (the Rancher Kubernetes Engine) to create a Kubernetes cluster in on-prem bare-metal servers, on-prem virtual machines, or in any node hosted by an infrastructure provider.

--- a/versioned_docs/version-2.5/reference-guides/monitoring-v2-configuration/monitoring-v2-configuration.md
+++ b/versioned_docs/version-2.5/reference-guides/monitoring-v2-configuration/monitoring-v2-configuration.md
@@ -3,7 +3,7 @@ title: Monitoring V2 Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-v2-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/monitoring-v2-configuration"/>
 </head>
 
 The following sections will explain important options essential to configuring Monitoring V2 in Rancher:

--- a/versioned_docs/version-2.5/reference-guides/rancher-manager-architecture/rancher-manager-architecture.md
+++ b/versioned_docs/version-2.5/reference-guides/rancher-manager-architecture/rancher-manager-architecture.md
@@ -3,7 +3,7 @@ title: Architecture
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-manager-architecture"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-manager-architecture"/>
 </head>
 
 This section focuses on the [Rancher server and its components](rancher-server-and-components.md) and how [Rancher communicates with downstream Kubernetes clusters](communicating-with-downstream-user-clusters.md).

--- a/versioned_docs/version-2.5/reference-guides/rancher-security/rancher-security.md
+++ b/versioned_docs/version-2.5/reference-guides/rancher-security/rancher-security.md
@@ -3,7 +3,7 @@ title: Security
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-security"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security"/>
 </head>
 
 <table width="100%">

--- a/versioned_docs/version-2.5/reference-guides/rancher-security/selinux-rpm/selinux-rpm.md
+++ b/versioned_docs/version-2.5/reference-guides/rancher-security/selinux-rpm/selinux-rpm.md
@@ -3,7 +3,7 @@ title: SELinux RPM
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/selinux-rpm"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/selinux-rpm"/>
 </head>
 
 _Available as of v2.5.8_

--- a/versioned_docs/version-2.5/reference-guides/single-node-rancher-in-docker/single-node-rancher-in-docker.md
+++ b/versioned_docs/version-2.5/reference-guides/single-node-rancher-in-docker/single-node-rancher-in-docker.md
@@ -3,7 +3,7 @@ title: Single Node Rancher in Docker
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/single-node-rancher-in-docker"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/single-node-rancher-in-docker"/>
 </head>
 
 The following docs will discuss [HTTP proxy configuration](http-proxy-configuration.md) and [advanced options](advanced-options.md) for Docker installs.

--- a/versioned_docs/version-2.5/reference-guides/user-settings/user-settings.md
+++ b/versioned_docs/version-2.5/reference-guides/user-settings/user-settings.md
@@ -3,7 +3,7 @@ title: User Settings
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/user-settings"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/user-settings"/>
 </head>
 
 Within Rancher, each user has a number of settings associated with their login: personal preferences, API keys, etc. You can configure these settings by choosing from the **User Settings** menu. You can open this menu by clicking your avatar, located within the main menu.

--- a/versioned_docs/version-2.5/security/security-scan/security-scan.md
+++ b/versioned_docs/version-2.5/security/security-scan/security-scan.md
@@ -3,7 +3,7 @@ title: Security Scans
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scan-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/security/security-scan"/>
 </head>
 
 The documentation about CIS security scans has moved [here.](../../how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md)

--- a/versioned_docs/version-2.5/troubleshooting/kubernetes-components/kubernetes-components.md
+++ b/versioned_docs/version-2.5/troubleshooting/kubernetes-components/kubernetes-components.md
@@ -3,7 +3,7 @@ title: Kubernetes Components
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-components"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components"/>
 </head>
 
 The commands and steps listed in this section apply to the core Kubernetes components on [Rancher Launched Kubernetes](../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md) clusters.

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/install-upgrade-on-a-kubernetes-cluster.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/install-upgrade-on-a-kubernetes-cluster.md
@@ -4,7 +4,7 @@ description: Learn how to install Rancher in development and production environm
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster"/>
 </head>
 
 In this section, you'll learn how to deploy Rancher on a Kubernetes cluster using the Helm CLI.

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/installation-and-upgrade.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/installation-and-upgrade.md
@@ -4,7 +4,7 @@ description: Learn how to install Rancher in development and production environm
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-and-upgrade"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade"/>
 </head>
 
 This section provides an overview of the architecture options of installing Rancher, describing advantages of each option.

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/installation-references/installation-references.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/installation-references/installation-references.md
@@ -3,7 +3,7 @@ title: Installation References
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-references"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references"/>
 </head>
 
 Please see the following reference guides for other installation resources: [Rancher Helm chart options](helm-chart-options.md), [TLS settings](tls-settings.md), and [feature flags](feature-flags.md).

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
@@ -4,7 +4,7 @@ description: Learn the node requirements for each node running Rancher server wh
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-requirements"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-requirements"/>
 </head>
 
 This page describes the software, hardware, and networking requirements for the nodes where the Rancher server will be installed. The Rancher server can be installed on a single node or a high-availability Kubernetes cluster.

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/air-gapped-helm-cli-install.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/air-gapped-helm-cli-install.md
@@ -3,7 +3,7 @@ title: Air-Gapped Helm CLI Install
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/air-gapped-helm-cli-install"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install"/>
 </head>
 
 This section is about using the Helm CLI to install the Rancher server in an air gapped environment. An air gapped environment could be where Rancher server will be installed offline, behind a firewall, or behind a proxy.

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/other-installation-methods.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/other-installation-methods.md
@@ -3,7 +3,7 @@ title: Other Installation Methods
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/other-installation-methods"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods"/>
 </head>
 
 ### Air Gapped Installations

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/rancher-behind-an-http-proxy.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/rancher-behind-an-http-proxy.md
@@ -3,7 +3,7 @@ title: Installing Rancher behind an HTTP Proxy
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-behind-an-http-proxy"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy"/>
 </head>
 
 In a lot of enterprise environments, servers or VMs running on premise do not have direct Internet access, but must connect to external services through a HTTP(S) proxy for security reasons. This tutorial shows step by step how to set up a highly available Rancher installation in such an environment.

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
@@ -4,7 +4,7 @@ description: For development and testing environments only, use a Docker install
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-on-a-single-node-with-docker"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker"/>
 </head>
 
 Rancher can be installed by running a single Docker container.

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/resources/resources.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/resources/resources.md
@@ -3,7 +3,7 @@ title: Resources
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/resources"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/resources"/>
 </head>
 
 ### Docker Installations

--- a/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
+++ b/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
@@ -3,7 +3,7 @@ title: Deploying Rancher Server
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-rancher-manager"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com"/>
 </head>
 
 Use one of the following guides to deploy and provision Rancher and a Kubernetes cluster in the provider of your choice.

--- a/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-workloads/deploy-workloads.md
+++ b/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-workloads/deploy-workloads.md
@@ -3,7 +3,7 @@ title: Deploying Workloads
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-rancher-workloads"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-workloads"/>
 </head>
 
 These guides walk you through the deployment of an application, including how to expose the application for use outside of the cluster.

--- a/versioned_docs/version-2.6/getting-started/quick-start-guides/quick-start-guides.md
+++ b/versioned_docs/version-2.6/getting-started/quick-start-guides/quick-start-guides.md
@@ -3,7 +3,7 @@ title: Rancher Deployment Quick Start Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/quick-start-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides"/>
 </head>
 
 :::caution

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/advanced-user-guides.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/advanced-user-guides.md
@@ -3,7 +3,7 @@ title: Advanced User Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/advanced-user-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides"/>
 </head>
 
 Advanced user guides are "problem-oriented" docs in which users learn how to answer questions or solve problems. The major difference between these and the new user guides is that these guides are geared toward more experienced or advanced users who have more technical needs from their documentation. These users already have an understanding of Rancher and its functions. They know what they need to accomplish; they just need additional guidance to complete some more complex task they they have encountered while working.

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md
@@ -3,7 +3,7 @@ title: CIS Scan Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scan-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides"/>
 </head>
 
 - [Install rancher-cis-benchmark](install-rancher-cis-benchmark.md)

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/enable-experimental-features/enable-experimental-features.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/enable-experimental-features/enable-experimental-features.md
@@ -3,7 +3,7 @@ title: Enabling Experimental Features
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/enable-experimental-features"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/enable-experimental-features"/>
 </head>
 
 Rancher includes some features that are experimental and disabled by default. You might want to enable these features, for example, if you decide that the benefits of using an [unsupported storage type](unsupported-storage-drivers.md) outweighs the risk of using an untested feature. Feature flags were introduced to allow you to try these features that are not enabled by default.

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
@@ -3,7 +3,7 @@ title: Setup Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/istio-setup-guide"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide"/>
 </head>
 
 This section describes how to enable Istio and start using it in your projects.

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/manage-project-resource-quotas.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/manage-project-resource-quotas.md
@@ -3,7 +3,7 @@ title: Project Resource Quotas
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-project-resource-quotas"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas"/>
 </head>
 
 In situations where several teams share a cluster, one team may overconsume the resources available: CPU, memory, storage, services, Kubernetes objects like pods or secrets, and so on.  To prevent this overconsumption, you can apply a _resource quota_, which is a Rancher feature that limits the resources available to a project or namespace.

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/manage-projects/manage-projects.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/manage-projects/manage-projects.md
@@ -3,7 +3,7 @@ title: Project Administration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-projects"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/manage-projects"/>
 </head>
 
 _Projects_ are objects introduced in Rancher that help organize namespaces in your Kubernetes cluster. You can use projects to create multi-tenant clusters, which allows a group of users to share the same underlying resources without interacting with each other's applications.

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/monitoring-alerting-guides.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/monitoring-alerting-guides.md
@@ -3,7 +3,7 @@ title: Monitoring/Alerting Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-alerting-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-alerting-guides"/>
 </head>
 
 - [Enable monitoring](enable-monitoring.md)

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/prometheus-federator-guides/prometheus-federator-guides.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/prometheus-federator-guides/prometheus-federator-guides.md
@@ -3,7 +3,7 @@ title: Prometheus Federator Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/prometheus-federator-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-alerting-guides/prometheus-federator-guides"/>
 </head>
 
 - [Enable Prometheus Operator](enable-prometheus-federator.md)

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/advanced-configuration.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/advanced-configuration.md
@@ -3,7 +3,7 @@ title: Advanced Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/advanced-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration"/>
 </head>
 
 ### Alertmanager

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/monitoring-v2-configuration-guides.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/monitoring-v2-configuration-guides.md
@@ -3,7 +3,7 @@ title: Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-v2-configuration-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides"/>
 </head>
 
 This page captures some of the most important options for configuring Monitoring V2 in the Rancher UI.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/about-provisioning-drivers.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/about-provisioning-drivers.md
@@ -3,7 +3,7 @@ title: About Provisioning Drivers
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/about-provisioning-drivers"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers"/>
 </head>
 
 Drivers in Rancher allow you to manage which providers can be used to deploy [hosted Kubernetes clusters](../../kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md) or [nodes in an infrastructure provider](../../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider.md) to allow Rancher to deploy and manage Kubernetes.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/about-rke1-templates.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/about-rke1-templates.md
@@ -3,7 +3,7 @@ title: RKE Templates
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/about-rke1-templates"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates"/>
 </head>
 
 RKE templates are designed to allow DevOps and security teams to standardize and simplify the creation of Kubernetes clusters.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
@@ -4,7 +4,7 @@ weight: 10
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/authentication-config"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config"/>
 </head>
 
 One of the key features that Rancher adds to Kubernetes is centralized user authentication. This feature allows your users to use one set of credentials to authenticate with any of your Kubernetes clusters.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-permissions-and-global-configuration.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-permissions-and-global-configuration.md
@@ -3,7 +3,7 @@ title: Authentication, Permissions and Global Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/authentication-permissions-and-global-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration"/>
 </head>
 
 After installation, the [system administrator](manage-role-based-access-control-rbac/global-permissions.md) should configure Rancher to configure authentication, authorization, security, default settings, security policies, drivers and global DNS entries.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml/configure-microsoft-ad-federation-service-saml.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml/configure-microsoft-ad-federation-service-saml.md
@@ -3,7 +3,7 @@ title: Configuring Microsoft Active Directory Federation Service (SAML)
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configure-microsoft-ad-federation-service-saml"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml"/>
 </head>
 
 If your organization uses Microsoft Active Directory Federation Services (AD FS) for user authentication, you can configure Rancher to allow your users to log in using their AD FS credentials.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap/configure-openldap.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap/configure-openldap.md
@@ -3,7 +3,7 @@ title: Configuring OpenLDAP
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configure-openldap"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap"/>
 </head>
 
 If your organization uses LDAP for user authentication, you can configure Rancher to communicate with an OpenLDAP server to authenticate users. This allows Rancher admins to control access to clusters and projects based on users and groups managed externally in the organisation's central user repository, while allowing end-users to authenticate with their LDAP credentials when logging in to the Rancher UI.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml/configure-shibboleth-saml.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml/configure-shibboleth-saml.md
@@ -2,6 +2,10 @@
 title: Configuring Shibboleth (SAML)
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml"/>
+</head>
+
 If your organization uses Shibboleth Identity Provider (IdP) for user authentication, you can configure Rancher to allow your users to log in to Rancher using their Shibboleth credentials.
 
 In this configuration, when Rancher users log in, they will be redirected to the Shibboleth IdP to enter their credentials. After authentication, they will be redirected back to the Rancher UI.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.md
@@ -3,7 +3,7 @@ title: Managing Role-Based Access Control (RBAC)
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-role-based-access-control-rbac"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac"/>
 </head>
 
 Within Rancher, each person authenticates as a _user_, which is a login that grants you access to Rancher. As mentioned in [Authentication](../authentication-config/authentication-config.md), users can either be local or external.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
@@ -4,7 +4,7 @@ keywords: [rancher v2.6 backup restore, rancher v2.6 backup and restore, backup 
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/backup-restore-and-disaster-recovery"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery"/>
 </head>
 
 In this section, you'll learn how to create backups of Rancher, how to restore Rancher from backup, and how to migrate Rancher to a new Kubernetes cluster.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/deploy-apps-across-clusters/deploy-apps-across-clusters.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/deploy-apps-across-clusters/deploy-apps-across-clusters.md
@@ -3,7 +3,7 @@ title: Deploying Applications across Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-apps-across-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters"/>
 </head>
 
 Rancher offers several ways to deploy applications across clusters, depending on version.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/helm-charts-in-rancher/helm-charts-in-rancher.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/helm-charts-in-rancher/helm-charts-in-rancher.md
@@ -3,7 +3,7 @@ title: Helm Charts in Rancher
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/helm-charts-in-rancher"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/helm-charts-in-rancher"/>
 </head>
 
 In this section, you'll learn how to manage Helm chart repositories and applications in Rancher. Helm chart repositories are managed using **Apps & Marketplace** (Rancher before v2.6.5) or **Apps** (Rancher v2.6.5+). It uses a catalog-like system to import bundles of charts from repositories and then uses those charts to either deploy custom Helm applications or Rancher's tools such as Monitoring or Istio. Rancher tools come as pre-loaded repositories which deploy as standalone Helm charts. Any additional repositories are only added to the current cluster.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/infrastructure-setup/infrastructure-setup.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/infrastructure-setup/infrastructure-setup.md
@@ -3,7 +3,7 @@ title: Don't have infrastructure for your Kubernetes cluster? Try one of these t
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/infrastructure-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/infrastructure-setup"/>
 </head>
 
 To set up infrastructure for a high-availability K3s Kubernetes cluster with an external DB, refer to [this page.](ha-k3s-kubernetes-cluster.md)

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/kubernetes-cluster-setup.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/kubernetes-cluster-setup.md
@@ -3,7 +3,7 @@ title: "Don't have a Kubernetes cluster? Try one of these tutorials."
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-cluster-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup"/>
 </head>
 
 This section contains information on how to install a Kubernetes cluster that the Rancher server can be installed on.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/checklist-for-production-ready-clusters.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/checklist-for-production-ready-clusters.md
@@ -3,7 +3,7 @@ title: Checklist for Production-Ready Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/checklist-for-production-ready-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters"/>
 </head>
 
 In this section, we recommend best practices for creating the production-ready Kubernetes clusters that will run your apps and services.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/kubernetes-clusters-in-rancher-setup.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/kubernetes-clusters-in-rancher-setup.md
@@ -4,7 +4,7 @@ description: Provisioning Kubernetes Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-clusters-in-rancher-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup"/>
 </head>
 
 Rancher simplifies the creation of clusters by allowing you to create them through the Rancher UI rather than more complex alternatives. Rancher provides multiple options for launching a cluster. Use the option that best fits your use case.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/set-up-cloud-providers.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/set-up-cloud-providers.md
@@ -3,7 +3,7 @@ title: Setting up Cloud Providers
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/set-up-cloud-providers"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers"/>
 </head>
 
 A _cloud provider_ is a module in Kubernetes that provides an interface for managing nodes, load balancers, and networking routes.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md
@@ -3,7 +3,7 @@ title: Setting up Clusters from Hosted Kubernetes Providers
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/set-up-clusters-from-hosted-kubernetes-providers"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers"/>
 </head>
 
 In this scenario, Rancher does not provision Kubernetes because it is installed by providers such as Google Kubernetes Engine (GKE), Amazon Elastic Container Service for Kubernetes, or Azure Kubernetes Service.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/use-windows-clusters.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/use-windows-clusters.md
@@ -3,7 +3,7 @@ title: Launching Kubernetes on Windows Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/use-windows-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters"/>
 </head>
 
 When provisioning a [custom cluster](../../../../reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md) using Rancher, Rancher uses RKE (the Rancher Kubernetes Engine) to install Kubernetes on your existing nodes.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/horizontal-pod-autoscaler.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/horizontal-pod-autoscaler.md
@@ -4,7 +4,7 @@ description: Learn about the horizontal pod autoscaler (HPA). How to manage HPAs
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/horizontal-pod-autoscaler"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler"/>
 </head>
 
 The [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) (HPA) is a Kubernetes feature that allows you to configure your cluster to automatically scale the services it's running up or down.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-resources-setup.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-resources-setup.md
@@ -3,7 +3,7 @@ title: Kubernetes Resources
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-resources-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup"/>
 </head>
 
 You can view and manipulate all of the custom resources and CRDs in a Kubernetes cluster from the Rancher UI.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.md
@@ -4,7 +4,7 @@ description: Learn how you can set up load balancers and ingress controllers to 
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/load-balancer-and-ingress-controller"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller"/>
 </head>
 
 Within Rancher, you can set up load balancers and ingress controllers to redirect service requests.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/workloads-and-pods.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/workloads-and-pods.md
@@ -4,7 +4,7 @@ description: "Learn about the two constructs with which you can build any comple
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/workloads-and-pods"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods"/>
 </head>
 
 You can build any complex containerized application in Kubernetes using two basic constructs: pods and workloads. Once you build an application, you can expose it for access either within the same cluster or on the Internet using a third construct: services.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md
@@ -3,7 +3,7 @@ title: Launching Kubernetes with Rancher
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher"/>
 </head>
 
 You can have Rancher launch a Kubernetes cluster using any nodes you want. When Rancher deploys Kubernetes onto these nodes, you can choose between [Rancher Kubernetes Engine](https://rancher.com/docs/rke/latest/en/) (RKE) or [RKE2](https://docs.rke2.io) distributions. Rancher can launch Kubernetes on any computers, including:

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/nutanix.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/nutanix.md
@@ -4,7 +4,7 @@ description: Use Rancher to create a Nutanix AOS (AHV) cluster. It may consist o
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/nutanix"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix"/>
 </head>
 
 [Nutanix Acropolis Operating System](https://www.nutanix.com/products/acropolis) (Nutanix AOS) is an operating system for the Nutanix hyper-converged infrastructure platform. AOS comes with a built-in hypervisor called [Acropolis Hypervisor](https://www.nutanix.com/products/ahv), or AHV. By using Rancher with Nutanix AOS (AHV), you can bring cloud operations on-premises.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider.md
@@ -3,7 +3,7 @@ title: Launching Kubernetes on New Nodes in an Infrastructure Provider
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/use-new-nodes-in-an-infra-provider"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider"/>
 </head>
 
 When you create an RKE or RKE2 cluster using a node template in Rancher, each resulting node pool is shown in a new **Machine Pools** tab. You can see the machine pools by doing the following:

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
@@ -4,7 +4,7 @@ description: Use Rancher to create a vSphere cluster. It may consist of groups o
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/vsphere"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere"/>
 </head>
 
 import YouTube from '@site/src/components/YouTube'

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/access-clusters/access-clusters.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/access-clusters/access-clusters.md
@@ -3,7 +3,7 @@ title: Cluster Access
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/access-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters"/>
 </head>
 
 This section is about what tools can be used to access clusters managed by Rancher.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/create-kubernetes-persistent-storage.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/create-kubernetes-persistent-storage.md
@@ -4,7 +4,7 @@ description: "Learn about the two ways with which you can create persistent stor
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/create-kubernetes-persistent-storage"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage"/>
 </head>
 
 When deploying an application that needs to retain data, you'll need to create persistent storage. Persistent storage allows you to store application data external from the pod running your application. This storage practice allows you to maintain application data, even if the application's pod fails.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/install-cluster-autoscaler.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/install-cluster-autoscaler.md
@@ -3,7 +3,7 @@ title: Cluster Autoscaler
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/install-cluster-autoscaler"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler"/>
 </head>
 
 In this section, you'll learn how to install and use the [Kubernetes cluster-autoscaler](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/) on Rancher custom clusters using AWS EC2 Auto Scaling Groups.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/manage-clusters.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/manage-clusters.md
@@ -3,7 +3,7 @@ title: Cluster Administration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters"/>
 </head>
 
 After you provision a cluster in Rancher, you can begin using powerful Kubernetes features to deploy and scale your containerized applications in development, testing, or production environments.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/provisioning-storage-examples.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/provisioning-storage-examples.md
@@ -3,7 +3,7 @@ title: Provisioning Storage Examples
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/provisioning-storage-examples"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples"/>
 </head>
 
 Rancher supports persistent storage with a variety of volume plugins. However, before you use any of these plugins to bind persistent storage to your workloads, you have to configure the storage itself, whether its a cloud-based solution from a service-provider or an on-prem solution that you manage yourself.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/new-user-guides.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/new-user-guides.md
@@ -3,7 +3,7 @@ title: New User Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/new-user-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides"/>
 </head>
 
 New user guides, also known as **tutorials**, describe practical steps for users to follow in order to complete some concrete action. These docs are known as "learning-oriented" docs in which users learn by "doing".

--- a/versioned_docs/version-2.6/integrations-in-rancher/cis-scans/cis-scans.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/cis-scans/cis-scans.md
@@ -3,7 +3,7 @@ title: CIS Scans
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scans"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cis-scans"/>
 </head>
 
 Rancher can run a security scan to check whether Kubernetes is deployed according to security best practices as defined in the CIS Kubernetes Benchmark. The CIS scans can run on any Kubernetes cluster, including hosted Kubernetes providers such as EKS, AKS, and GKE.

--- a/versioned_docs/version-2.6/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/aws-cloud-marketplace.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/aws-cloud-marketplace.md
@@ -3,7 +3,7 @@ title: AWS Marketplace Integration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/aws-cloud-marketplace"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace"/>
 </head>
 
 ## Overview

--- a/versioned_docs/version-2.6/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/install-adapter.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/install-adapter.md
@@ -2,6 +2,10 @@
 title: Installing the Adapter
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/install-adapter"/>
+</head>
+
 > **Important:** If you are attempting to re-install the adapter, you may experience errant out-of-compliance messages for up to an hour.
 
 ### Rancher vs. Adapter Compatibility Matrix

--- a/versioned_docs/version-2.6/integrations-in-rancher/cloud-marketplace/cloud-marketplace.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/cloud-marketplace/cloud-marketplace.md
@@ -3,7 +3,7 @@ title: Cloud Marketplace Integration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cloud-marketplace"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cloud-marketplace"/>
 </head>
 
 Rancher offers integration with cloud marketplaces to easily purchase support for installations hosted on certain cloud providers. In addition, this integration also provides the ability to generate a supportconfig bundle which can be provided to rancher support.

--- a/versioned_docs/version-2.6/integrations-in-rancher/istio/configuration-options/configuration-options.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/istio/configuration-options/configuration-options.md
@@ -3,7 +3,7 @@ title: Configuration Options
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configuration-options"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/configuration-options"/>
 </head>
 
 ### Egress Support

--- a/versioned_docs/version-2.6/integrations-in-rancher/istio/istio.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/istio/istio.md
@@ -3,7 +3,7 @@ title: Istio
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/istio"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio"/>
 </head>
 
 [Istio](https://istio.io/) is an open-source tool that makes it easier for DevOps teams to observe, secure, control, and troubleshoot the traffic within a complex network of microservices.

--- a/versioned_docs/version-2.6/integrations-in-rancher/logging/custom-resource-configuration/custom-resource-configuration.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/logging/custom-resource-configuration/custom-resource-configuration.md
@@ -3,7 +3,7 @@ title: Custom Resource Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/custom-resource-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/logging/custom-resource-configuration"/>
 </head>
 
 The following Custom Resource Definitions are used to configure logging:

--- a/versioned_docs/version-2.6/integrations-in-rancher/logging/logging.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/logging/logging.md
@@ -4,7 +4,7 @@ description: Rancher integrates with popular logging services. Learn the require
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/logging"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/logging"/>
 </head>
 
 The [Logging operator](https://kube-logging.github.io/docs/) now powers Rancher's logging solution in place of the former, in-house solution.

--- a/versioned_docs/version-2.6/integrations-in-rancher/monitoring-and-alerting/monitoring-and-alerting.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/monitoring-and-alerting/monitoring-and-alerting.md
@@ -4,7 +4,7 @@ description: Prometheus lets you view metrics from your different Rancher and Ku
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-and-alerting"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/monitoring-and-alerting"/>
 </head>
 
 Using the `rancher-monitoring` application, you can quickly deploy leading open-source monitoring and alerting solutions onto your cluster.

--- a/versioned_docs/version-2.6/reference-guides/about-the-api/about-the-api.md
+++ b/versioned_docs/version-2.6/reference-guides/about-the-api/about-the-api.md
@@ -3,7 +3,7 @@ title: API
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/about-the-api"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/about-the-api"/>
 </head>
 
 ## How to use the API

--- a/versioned_docs/version-2.6/reference-guides/backup-restore-configuration/backup-restore-configuration.md
+++ b/versioned_docs/version-2.6/reference-guides/backup-restore-configuration/backup-restore-configuration.md
@@ -3,7 +3,7 @@ title: Rancher Backup Configuration Reference
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/backup-restore-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/backup-restore-configuration"/>
 </head>
 
 - [Backup configuration](backup-configuration.md)

--- a/versioned_docs/version-2.6/reference-guides/best-practices/best-practices.md
+++ b/versioned_docs/version-2.6/reference-guides/best-practices/best-practices.md
@@ -3,7 +3,7 @@ title: Best Practices Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/best-practices"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/best-practices"/>
 </head>
 
 The purpose of this section is to consolidate best practices for Rancher implementations. This also includes recommendations for related technologies, such as Kubernetes, Docker, containers, and more. The objective is to improve the outcome of a Rancher implementation using the operational experience of Rancher and its customers.

--- a/versioned_docs/version-2.6/reference-guides/best-practices/rancher-managed-clusters/rancher-managed-clusters.md
+++ b/versioned_docs/version-2.6/reference-guides/best-practices/rancher-managed-clusters/rancher-managed-clusters.md
@@ -3,7 +3,7 @@ title: Best Practices for Rancher Managed Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-managed-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/best-practices/rancher-managed-clusters"/>
 </head>
 
 ### Logging

--- a/versioned_docs/version-2.6/reference-guides/best-practices/rancher-server/rancher-server.md
+++ b/versioned_docs/version-2.6/reference-guides/best-practices/rancher-server/rancher-server.md
@@ -3,7 +3,7 @@ title: Best Practices for the Rancher Server
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-server"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/best-practices/rancher-server"/>
 </head>
 
 This guide contains our recommendations for running the Rancher server, and is intended to be used in situations in which Rancher manages downstream Kubernetes clusters.

--- a/versioned_docs/version-2.6/reference-guides/cli-with-rancher/cli-with-rancher.md
+++ b/versioned_docs/version-2.6/reference-guides/cli-with-rancher/cli-with-rancher.md
@@ -3,7 +3,7 @@ title: CLI with Rancher
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cli-with-rancher"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cli-with-rancher"/>
 </head>
 
 Interact with Rancher using command line interface (CLI) tools from your workstation. The following docs will describe the [Rancher CLI](rancher-cli.md) and [kubectl Utility](kubectl-utility.md).

--- a/versioned_docs/version-2.6/reference-guides/cluster-configuration/cluster-configuration.md
+++ b/versioned_docs/version-2.6/reference-guides/cluster-configuration/cluster-configuration.md
@@ -3,7 +3,7 @@ title: Cluster Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cluster-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration"/>
 </head>
 
 After you provision a Kubernetes cluster using Rancher, you can still edit options and settings for the cluster.

--- a/versioned_docs/version-2.6/reference-guides/cluster-configuration/downstream-cluster-configuration/downstream-cluster-configuration.md
+++ b/versioned_docs/version-2.6/reference-guides/cluster-configuration/downstream-cluster-configuration/downstream-cluster-configuration.md
@@ -3,7 +3,7 @@ title: Downstream Cluster Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/downstream-cluster-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/downstream-cluster-configuration"/>
 </head>
 
 The following docs will discuss [node template configuration](node-template-configuration/node-template-configuration.md) and [machine configuration](machine-configuration/machine-configuration.md).

--- a/versioned_docs/version-2.6/reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/machine-configuration.md
+++ b/versioned_docs/version-2.6/reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/machine-configuration.md
@@ -3,7 +3,7 @@ title: Machine Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/machine-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration"/>
 </head>
 
 Machine configuration is the arrangement of resources assigned to a virtual machine. Please see the docs for [Amazon EC2](amazon-ec2.md), [DigitalOcean](digitalocean.md), and [Azure](azure.md) to learn more.

--- a/versioned_docs/version-2.6/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/node-template-configuration.md
+++ b/versioned_docs/version-2.6/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/node-template-configuration.md
@@ -3,7 +3,7 @@ title: Node Template Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/node-template-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration"/>
 </head>
 
 To learn about node template config, refer to [EC2 Node Template Configuration](amazon-ec2.md), [DigitalOcean Node Template Configuration](digitalocean.md), [Azure Node Template Configuration](azure.md), [vSphere Node Template Configuration](vsphere.md), and [Nutanix Node Template Configuration](nutanix.md).

--- a/versioned_docs/version-2.6/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
+++ b/versioned_docs/version-2.6/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
@@ -3,7 +3,7 @@ title: GKE Cluster Configuration Reference
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/gke-cluster-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration"/>
 </head>
 
 ## Changes in Rancher v2.6

--- a/versioned_docs/version-2.6/reference-guides/cluster-configuration/rancher-server-configuration/rancher-server-configuration.md
+++ b/versioned_docs/version-2.6/reference-guides/cluster-configuration/rancher-server-configuration/rancher-server-configuration.md
@@ -3,7 +3,7 @@ title: Rancher Server Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-server-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration"/>
 </head>
 
 - [RKE1 Cluster Configuration](rke1-cluster-configuration.md)

--- a/versioned_docs/version-2.6/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md
+++ b/versioned_docs/version-2.6/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md
@@ -4,7 +4,7 @@ description: To create a cluster with custom nodes, you’ll need to access serv
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/use-existing-nodes"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes"/>
 </head>
 
 When you create a custom cluster, Rancher uses RKE (the Rancher Kubernetes Engine) to create a Kubernetes cluster in on-prem bare-metal servers, on-prem virtual machines, or in any node hosted by an infrastructure provider.

--- a/versioned_docs/version-2.6/reference-guides/monitoring-v2-configuration/monitoring-v2-configuration.md
+++ b/versioned_docs/version-2.6/reference-guides/monitoring-v2-configuration/monitoring-v2-configuration.md
@@ -3,7 +3,7 @@ title: Monitoring V2 Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-v2-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/monitoring-v2-configuration"/>
 </head>
 
 The following sections will explain important options essential to configuring Monitoring V2 in Rancher:

--- a/versioned_docs/version-2.6/reference-guides/prometheus-federator/prometheus-federator.md
+++ b/versioned_docs/version-2.6/reference-guides/prometheus-federator/prometheus-federator.md
@@ -3,7 +3,7 @@ title: Prometheus Federator
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/prometheus-federator"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/prometheus-federator"/>
 </head>
 
 Prometheus Federator, also referred to as Project Monitoring v2, deploys a Helm Project Operator (based on the [rancher/helm-project-operator](https://github.com/rancher/helm-project-operator)), an operator that manages deploying Helm charts each containing a Project Monitoring Stack, where each stack contains:

--- a/versioned_docs/version-2.6/reference-guides/rancher-manager-architecture/rancher-manager-architecture.md
+++ b/versioned_docs/version-2.6/reference-guides/rancher-manager-architecture/rancher-manager-architecture.md
@@ -3,7 +3,7 @@ title: Architecture
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-manager-architecture"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-manager-architecture"/>
 </head>
 
 This section focuses on the [Rancher server and its components](rancher-server-and-components.md) and how [Rancher communicates with downstream Kubernetes clusters](communicating-with-downstream-user-clusters.md).

--- a/versioned_docs/version-2.6/reference-guides/rancher-security/rancher-security.md
+++ b/versioned_docs/version-2.6/reference-guides/rancher-security/rancher-security.md
@@ -3,7 +3,7 @@ title: Security
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-security"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security"/>
 </head>
 
 <table width="100%">

--- a/versioned_docs/version-2.6/reference-guides/rancher-security/selinux-rpm/selinux-rpm.md
+++ b/versioned_docs/version-2.6/reference-guides/rancher-security/selinux-rpm/selinux-rpm.md
@@ -3,7 +3,7 @@ title: SELinux RPM
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/selinux-rpm"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/selinux-rpm"/>
 </head>
 
 [Security-Enhanced Linux (SELinux)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) is a security enhancement to Linux.

--- a/versioned_docs/version-2.6/reference-guides/single-node-rancher-in-docker/single-node-rancher-in-docker.md
+++ b/versioned_docs/version-2.6/reference-guides/single-node-rancher-in-docker/single-node-rancher-in-docker.md
@@ -3,7 +3,7 @@ title: Single Node Rancher in Docker
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/single-node-rancher-in-docker"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/single-node-rancher-in-docker"/>
 </head>
 
 The following docs will discuss [HTTP proxy configuration](http-proxy-configuration.md) and [advanced options](advanced-options.md) for Docker installs.

--- a/versioned_docs/version-2.6/reference-guides/user-settings/user-settings.md
+++ b/versioned_docs/version-2.6/reference-guides/user-settings/user-settings.md
@@ -3,7 +3,7 @@ title: User Settings
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/user-settings"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/user-settings"/>
 </head>
 
 Within Rancher, each user has a number of settings associated with their login: personal preferences, API keys, etc. You can configure these settings by choosing from the **User Settings** menu. You can open this menu by clicking your avatar, located within the main menu.

--- a/versioned_docs/version-2.6/security/security-scan/security-scan.md
+++ b/versioned_docs/version-2.6/security/security-scan/security-scan.md
@@ -3,7 +3,7 @@ title: Security Scans
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scan-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/security/security-scan"/>
 </head>
 
 The documentation about CIS security scans has moved [here.](../../how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md)

--- a/versioned_docs/version-2.6/troubleshooting/kubernetes-components/kubernetes-components.md
+++ b/versioned_docs/version-2.6/troubleshooting/kubernetes-components/kubernetes-components.md
@@ -3,7 +3,7 @@ title: Kubernetes Components
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-components"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components"/>
 </head>
 
 The commands and steps listed in this section apply to the core Kubernetes components on [Rancher Launched Kubernetes](../../how-to-guides/new-user-guides/launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md) clusters.

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/install-upgrade-on-a-kubernetes-cluster.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/install-upgrade-on-a-kubernetes-cluster.md
@@ -4,7 +4,7 @@ description: Learn how to install Rancher in development and production environm
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster"/>
 </head>
 
 In this section, you'll learn how to deploy Rancher on a Kubernetes cluster using the Helm CLI.

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/installation-and-upgrade.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/installation-and-upgrade.md
@@ -4,7 +4,7 @@ description: Learn how to install Rancher in development and production environm
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-and-upgrade"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade"/>
 </head>
 
 This section provides an overview of the architecture options of installing Rancher, describing advantages of each option.

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/installation-references/installation-references.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/installation-references/installation-references.md
@@ -3,7 +3,7 @@ title: Installation References
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-references"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references"/>
 </head>
 
 Please see the following reference guides for other installation resources: [Rancher Helm chart options](helm-chart-options.md), [TLS settings](tls-settings.md), and [feature flags](feature-flags.md).

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
@@ -4,7 +4,7 @@ description: Learn the node requirements for each node running Rancher server wh
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-requirements"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-requirements"/>
 </head>
 
 This page describes the software, hardware, and networking requirements for the nodes where the Rancher server will be installed. The Rancher server can be installed on a single node or a high-availability Kubernetes cluster.

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/air-gapped-helm-cli-install.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/air-gapped-helm-cli-install.md
@@ -3,7 +3,7 @@ title: Air-Gapped Helm CLI Install
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/air-gapped-helm-cli-install"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install"/>
 </head>
 
 This section is about using the Helm CLI to install the Rancher server in an air gapped environment. An air gapped environment could be where Rancher server will be installed offline, behind a firewall, or behind a proxy.

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/other-installation-methods.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/other-installation-methods.md
@@ -3,7 +3,7 @@ title: Other Installation Methods
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/other-installation-methods"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods"/>
 </head>
 
 ### Air Gapped Installations

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/rancher-behind-an-http-proxy.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/rancher-behind-an-http-proxy.md
@@ -3,7 +3,7 @@ title: Installing Rancher behind an HTTP Proxy
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-behind-an-http-proxy"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy"/>
 </head>
 
 In a lot of enterprise environments, servers or VMs running on premise do not have direct Internet access, but must connect to external services through a HTTP(S) proxy for security reasons. This tutorial shows step by step how to set up a highly available Rancher installation in such an environment.

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
@@ -4,7 +4,7 @@ description: For development and testing environments only, use a Docker install
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-on-a-single-node-with-docker"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker"/>
 </head>
 
 Rancher can be installed by running a single Docker container.

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/resources/resources.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/resources/resources.md
@@ -3,7 +3,7 @@ title: Resources
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/resources"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/resources"/>
 </head>
 
 ### Docker Installations

--- a/versioned_docs/version-2.7/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
+++ b/versioned_docs/version-2.7/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
@@ -3,7 +3,7 @@ title: Deploying Rancher Server
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-rancher-manager"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com"/>
 </head>
 
 Use one of the following guides to deploy and provision Rancher and a Kubernetes cluster in the provider of your choice.

--- a/versioned_docs/version-2.7/getting-started/quick-start-guides/deploy-workloads/deploy-workloads.md
+++ b/versioned_docs/version-2.7/getting-started/quick-start-guides/deploy-workloads/deploy-workloads.md
@@ -3,7 +3,7 @@ title: Deploying Workloads
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-rancher-workloads"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-workloads"/>
 </head>
 
 These guides walk you through the deployment of an application, including how to expose the application for use outside of the cluster.

--- a/versioned_docs/version-2.7/getting-started/quick-start-guides/quick-start-guides.md
+++ b/versioned_docs/version-2.7/getting-started/quick-start-guides/quick-start-guides.md
@@ -3,7 +3,7 @@ title: Rancher Deployment Quick Start Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/quick-start-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides"/>
 </head>
 
 :::caution

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/advanced-user-guides.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/advanced-user-guides.md
@@ -3,7 +3,7 @@ title: Advanced User Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/advanced-user-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides"/>
 </head>
 
 Advanced user guides are "problem-oriented" docs in which users learn how to answer questions or solve problems. The major difference between these and the new user guides is that these guides are geared toward more experienced or advanced users who have more technical needs from their documentation. These users already have an understanding of Rancher and its functions. They know what they need to accomplish; they just need additional guidance to complete some more complex task they they have encountered while working.

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md
@@ -3,7 +3,7 @@ title: CIS Scan Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scan-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides"/>
 </head>
 
 - [Install rancher-cis-benchmark](install-rancher-cis-benchmark.md)

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/enable-experimental-features/enable-experimental-features.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/enable-experimental-features/enable-experimental-features.md
@@ -3,7 +3,7 @@ title: Enabling Experimental Features
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/enable-experimental-features"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/enable-experimental-features"/>
 </head>
 
 Rancher includes some features that are experimental and disabled by default. You might want to enable these features, for example, if you decide that the benefits of using an [unsupported storage type](unsupported-storage-drivers.md) outweighs the risk of using an untested feature. Feature flags were introduced to allow you to try these features that are not enabled by default.

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
@@ -3,7 +3,7 @@ title: Setup Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/istio-setup-guide"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide"/>
 </head>
 
 This section describes how to enable Istio and start using it in your projects.

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/manage-project-resource-quotas.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/manage-project-resource-quotas.md
@@ -3,7 +3,7 @@ title: Project Resource Quotas
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-project-resource-quotas"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas"/>
 </head>
 
 In situations where several teams share a cluster, one team may overconsume the resources available: CPU, memory, storage, services, Kubernetes objects like pods or secrets, and so on.  To prevent this overconsumption, you can apply a _resource quota_, which is a Rancher feature that limits the resources available to a project or namespace.

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/manage-projects/manage-projects.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/manage-projects/manage-projects.md
@@ -3,7 +3,7 @@ title: Project Administration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-projects"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/manage-projects"/>
 </head>
 
 _Projects_ are objects introduced in Rancher that help organize namespaces in your Kubernetes cluster. You can use projects to create multi-tenant clusters, which allows a group of users to share the same underlying resources without interacting with each other's applications.

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/monitoring-alerting-guides/monitoring-alerting-guides.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/monitoring-alerting-guides/monitoring-alerting-guides.md
@@ -3,7 +3,7 @@ title: Monitoring/Alerting Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-alerting-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-alerting-guides"/>
 </head>
 
 - [Enable monitoring](enable-monitoring.md)

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/monitoring-alerting-guides/prometheus-federator-guides/prometheus-federator-guides.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/monitoring-alerting-guides/prometheus-federator-guides/prometheus-federator-guides.md
@@ -3,7 +3,7 @@ title: Prometheus Federator Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/prometheus-federator-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-alerting-guides/prometheus-federator-guides"/>
 </head>
 
 - [Enable Prometheus Operator](enable-prometheus-federator.md)

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/advanced-configuration.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/advanced-configuration.md
@@ -3,7 +3,7 @@ title: Advanced Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/advanced-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration"/>
 </head>
 
 ### Alertmanager

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/monitoring-v2-configuration-guides.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/monitoring-v2-configuration-guides.md
@@ -3,7 +3,7 @@ title: Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-v2-configuration-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides"/>
 </head>
 
 This page captures some of the most important options for configuring Monitoring V2 in the Rancher UI.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/about-provisioning-drivers.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/about-provisioning-drivers.md
@@ -3,7 +3,7 @@ title: About Provisioning Drivers
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/about-provisioning-drivers"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers"/>
 </head>
 
 Drivers in Rancher allow you to manage which providers can be used to deploy [hosted Kubernetes clusters](../../kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md) or [nodes in an infrastructure provider](../../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider.md) to allow Rancher to deploy and manage Kubernetes.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/about-rke1-templates.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/about-rke1-templates.md
@@ -3,7 +3,7 @@ title: RKE Templates
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/about-rke1-templates"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates"/>
 </head>
 
 RKE templates are designed to allow DevOps and security teams to standardize and simplify the creation of Kubernetes clusters.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
@@ -4,7 +4,7 @@ weight: 10
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/authentication-config"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config"/>
 </head>
 
 One of the key features that Rancher adds to Kubernetes is centralized user authentication. This feature allows your users to use one set of credentials to authenticate with any of your Kubernetes clusters.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-permissions-and-global-configuration.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-permissions-and-global-configuration.md
@@ -3,7 +3,7 @@ title: Authentication, Permissions and Global Settings
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/authentication-permissions-and-global-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration"/>
 </head>
 
 After installation, the [system administrator](manage-role-based-access-control-rbac/global-permissions.md) should configure Rancher to configure authentication, authorization, security, default settings, security policies, drivers and global DNS entries.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml/configure-microsoft-ad-federation-service-saml.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml/configure-microsoft-ad-federation-service-saml.md
@@ -3,7 +3,7 @@ title: Configuring Microsoft Active Directory Federation Service (SAML)
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configure-microsoft-ad-federation-service-saml"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml"/>
 </head>
 
 If your organization uses Microsoft Active Directory Federation Services (AD FS) for user authentication, you can configure Rancher to allow your users to log in using their AD FS credentials.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap/configure-openldap.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap/configure-openldap.md
@@ -3,7 +3,7 @@ title: Configuring OpenLDAP
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configure-openldap"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap"/>
 </head>
 
 If your organization uses LDAP for user authentication, you can configure Rancher to communicate with an OpenLDAP server to authenticate users. This allows Rancher admins to control access to clusters and projects based on users and groups managed externally in the organisation's central user repository, while allowing end-users to authenticate with their LDAP credentials when logging in to the Rancher UI.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml/configure-shibboleth-saml.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml/configure-shibboleth-saml.md
@@ -3,7 +3,7 @@ title: Configuring Shibboleth (SAML)
 ---
 
 <head> 
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configure-shibboleth-saml"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml"/>
 </head>
 
 If your organization uses Shibboleth Identity Provider (IdP) for user authentication, you can configure Rancher to allow your users to log in to Rancher using their Shibboleth credentials.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.md
@@ -3,7 +3,7 @@ title: Managing Role-Based Access Control (RBAC)
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-role-based-access-control-rbac"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac"/>
 </head>
 
 Within Rancher, each person authenticates as a _user_, which is a login that grants you access to Rancher. As mentioned in [Authentication](../authentication-config/authentication-config.md), users can either be local or external.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
@@ -4,7 +4,7 @@ keywords: [rancher backup restore, rancher backup and restore, backup restore ra
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/backup-restore-and-disaster-recovery"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery"/>
 </head>
 
 In this section, you'll learn how to create backups of Rancher, how to restore Rancher from backup, and how to migrate Rancher to a new Kubernetes cluster.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/deploy-apps-across-clusters/deploy-apps-across-clusters.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/deploy-apps-across-clusters/deploy-apps-across-clusters.md
@@ -3,7 +3,7 @@ title: Deploying Applications across Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-apps-across-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters"/>
 </head>
 
 Rancher offers several ways to deploy applications across clusters, depending on version.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/helm-charts-in-rancher/helm-charts-in-rancher.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/helm-charts-in-rancher/helm-charts-in-rancher.md
@@ -3,7 +3,7 @@ title: Helm Charts in Rancher
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/helm-charts-in-rancher"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/helm-charts-in-rancher"/>
 </head>
 
 In this section, you'll learn how to manage Helm chart repositories and applications in Rancher. Helm chart repositories are managed using **Apps**. It uses a catalog-like system to import bundles of charts from repositories and then uses those charts to either deploy custom Helm applications or Rancher's tools such as Monitoring or Istio. Rancher tools come as pre-loaded repositories which deploy as standalone Helm charts. Any additional repositories are only added to the current cluster.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/infrastructure-setup/infrastructure-setup.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/infrastructure-setup/infrastructure-setup.md
@@ -3,7 +3,7 @@ title: Don't have infrastructure for your Kubernetes cluster? Try one of these t
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/infrastructure-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/infrastructure-setup"/>
 </head>
 
 To set up infrastructure for a high-availability K3s Kubernetes cluster with an external DB, refer to [this page.](ha-k3s-kubernetes-cluster.md)

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-cluster-setup/kubernetes-cluster-setup.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-cluster-setup/kubernetes-cluster-setup.md
@@ -3,7 +3,7 @@ title: "Don't have a Kubernetes cluster? Try one of these tutorials."
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-cluster-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup"/>
 </head>
 
 This section contains information on how to install a Kubernetes cluster that the Rancher server can be installed on.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/checklist-for-production-ready-clusters.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/checklist-for-production-ready-clusters.md
@@ -3,7 +3,7 @@ title: Checklist for Production-Ready Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/checklist-for-production-ready-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters"/>
 </head>
 
 In this section, we recommend best practices for creating the production-ready Kubernetes clusters that will run your apps and services.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/kubernetes-clusters-in-rancher-setup.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/kubernetes-clusters-in-rancher-setup.md
@@ -4,7 +4,7 @@ description: Provisioning Kubernetes Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-clusters-in-rancher-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup"/>
 </head>
 
 Rancher simplifies the creation of clusters by allowing you to create them through the Rancher UI rather than more complex alternatives. Rancher provides multiple options for launching a cluster. Use the option that best fits your use case.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/set-up-cloud-providers.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/set-up-cloud-providers.md
@@ -3,7 +3,7 @@ title: Setting up Cloud Providers
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/set-up-cloud-providers"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers"/>
 </head>
 
 A _cloud provider_ is a module in Kubernetes that provides an interface for managing nodes, load balancers, and networking routes.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md
@@ -3,7 +3,7 @@ title: Setting up Clusters from Hosted Kubernetes Providers
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/set-up-clusters-from-hosted-kubernetes-providers"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers"/>
 </head>
 
 In this scenario, Rancher does not provision Kubernetes because it is installed by providers such as Google Kubernetes Engine (GKE), Amazon Elastic Container Service for Kubernetes, or Azure Kubernetes Service.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/use-windows-clusters.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/use-windows-clusters.md
@@ -3,7 +3,7 @@ title: Launching Kubernetes on Windows Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/use-windows-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters"/>
 </head>
 
 When provisioning a [custom cluster](../../../../reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md) using Rancher, Rancher uses RKE (the Rancher Kubernetes Engine) to install Kubernetes on your existing nodes.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/horizontal-pod-autoscaler.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/horizontal-pod-autoscaler.md
@@ -4,7 +4,7 @@ description: Learn about the horizontal pod autoscaler (HPA). How to manage HPAs
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/horizontal-pod-autoscaler"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler"/>
 </head>
 
 The [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) (HPA) is a Kubernetes feature that allows you to configure your cluster to automatically scale the services it's running up or down.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-resources-setup.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-resources-setup.md
@@ -3,7 +3,7 @@ title: Kubernetes Resources
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-resources-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup"/>
 </head>
 
 You can view and manipulate all of the custom resources and CRDs in a Kubernetes cluster from the Rancher UI.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.md
@@ -4,7 +4,7 @@ description: Learn how you can set up load balancers and ingress controllers to 
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/load-balancer-and-ingress-controller"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller"/>
 </head>
 
 Within Rancher, you can set up load balancers and ingress controllers to redirect service requests.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/workloads-and-pods.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/workloads-and-pods.md
@@ -4,7 +4,7 @@ description: "Learn about the two constructs with which you can build any comple
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/workloads-and-pods"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods"/>
 </head>
 
 You can build any complex containerized application in Kubernetes using two basic constructs: pods and workloads. Once you build an application, you can expose it for access either within the same cluster or on the Internet using a third construct: services.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md
@@ -3,7 +3,7 @@ title: Launching Kubernetes with Rancher
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher"/>
 </head>
 
 You can have Rancher launch a Kubernetes cluster using any nodes you want. When Rancher deploys Kubernetes onto these nodes, you can choose between [Rancher Kubernetes Engine](https://rancher.com/docs/rke/latest/en/) (RKE) or [RKE2](https://docs.rke2.io) distributions. Rancher can launch Kubernetes on any computers, including:

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/nutanix.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/nutanix.md
@@ -4,7 +4,7 @@ description: Use Rancher to create a Nutanix AOS (AHV) cluster. It may consist o
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/nutanix"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix"/>
 </head>
 
 [Nutanix Acropolis Operating System](https://www.nutanix.com/products/acropolis) (Nutanix AOS) is an operating system for the Nutanix hyper-converged infrastructure platform. AOS comes with a built-in hypervisor called [Acropolis Hypervisor](https://www.nutanix.com/products/ahv), or AHV. By using Rancher with Nutanix AOS (AHV), you can bring cloud operations on-premises.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider.md
@@ -3,7 +3,7 @@ title: Launching Kubernetes on New Nodes in an Infrastructure Provider
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/use-new-nodes-in-an-infra-provider"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider"/>
 </head>
 
 When you create an RKE or RKE2 cluster using a node template in Rancher, each resulting node pool is shown in a new **Machine Pools** tab. You can see the machine pools by doing the following:

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
@@ -4,7 +4,7 @@ description: Use Rancher to create a vSphere cluster. It may consist of groups o
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/vsphere"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere"/>
 </head>
 
 import YouTube from '@site/src/components/YouTube'

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/manage-clusters/access-clusters/access-clusters.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/manage-clusters/access-clusters/access-clusters.md
@@ -3,7 +3,7 @@ title: Cluster Access
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/access-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters"/>
 </head>
 
 This section is about what tools can be used to access clusters managed by Rancher.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/create-kubernetes-persistent-storage.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/create-kubernetes-persistent-storage.md
@@ -4,7 +4,7 @@ description: "Learn about the two ways with which you can create persistent stor
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/create-kubernetes-persistent-storage"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage"/>
 </head>
 
 When deploying an application that needs to retain data, you'll need to create persistent storage. Persistent storage allows you to store application data external from the pod running your application. This storage practice allows you to maintain application data, even if the application's pod fails.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/install-cluster-autoscaler.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/install-cluster-autoscaler.md
@@ -3,7 +3,7 @@ title: Cluster Autoscaler
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/install-cluster-autoscaler"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler"/>
 </head>
 
 In this section, you'll learn how to install and use the [Kubernetes cluster-autoscaler](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/) on Rancher custom clusters using AWS EC2 Auto Scaling Groups.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/manage-clusters/manage-clusters.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/manage-clusters/manage-clusters.md
@@ -3,7 +3,7 @@ title: Cluster Administration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters"/>
 </head>
 
 After you provision a cluster in Rancher, you can begin using powerful Kubernetes features to deploy and scale your containerized applications in development, testing, or production environments.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/provisioning-storage-examples.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/provisioning-storage-examples.md
@@ -3,7 +3,7 @@ title: Provisioning Storage Examples
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/provisioning-storage-examples"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples"/>
 </head>
 
 Rancher supports persistent storage with a variety of volume plugins. However, before you use any of these plugins to bind persistent storage to your workloads, you have to configure the storage itself, whether its a cloud-based solution from a service-provider or an on-prem solution that you manage yourself.

--- a/versioned_docs/version-2.7/integrations-in-rancher/cis-scans/cis-scans.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cis-scans/cis-scans.md
@@ -3,7 +3,7 @@ title: CIS Scans
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scans"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cis-scans"/>
 </head>
 
 Rancher can run a security scan to check whether Kubernetes is deployed according to security best practices as defined in the CIS Kubernetes Benchmark. The CIS scans can run on any Kubernetes cluster, including hosted Kubernetes providers such as EKS, AKS, and GKE.

--- a/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/aws-cloud-marketplace.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/aws-cloud-marketplace.md
@@ -3,7 +3,7 @@ title: AWS Marketplace Integration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/aws-cloud-marketplace"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace"/>
 </head>
 
 ## Overview

--- a/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/cloud-marketplace.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/cloud-marketplace.md
@@ -3,7 +3,7 @@ title: Cloud Marketplace Integration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cloud-marketplace"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cloud-marketplace"/>
 </head>
 
 Rancher offers integration with cloud marketplaces to easily purchase support for installations hosted on certain cloud providers. In addition, this integration also provides the ability to generate a supportconfig bundle which can be provided to rancher support.

--- a/versioned_docs/version-2.7/integrations-in-rancher/istio/configuration-options/configuration-options.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/istio/configuration-options/configuration-options.md
@@ -3,7 +3,7 @@ title: Configuration Options
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configuration-options"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/configuration-options"/>
 </head>
 
 ### Egress Support

--- a/versioned_docs/version-2.7/integrations-in-rancher/istio/istio.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/istio/istio.md
@@ -3,7 +3,7 @@ title: Istio
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/istio"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio"/>
 </head>
 
 [Istio](https://istio.io/) is an open-source tool that makes it easier for DevOps teams to observe, secure, control, and troubleshoot the traffic within a complex network of microservices.

--- a/versioned_docs/version-2.7/integrations-in-rancher/logging/custom-resource-configuration/custom-resource-configuration.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/logging/custom-resource-configuration/custom-resource-configuration.md
@@ -3,7 +3,7 @@ title: Custom Resource Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/custom-resource-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/logging/custom-resource-configuration"/>
 </head>
 
 The following Custom Resource Definitions are used to configure logging:

--- a/versioned_docs/version-2.7/integrations-in-rancher/logging/logging.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/logging/logging.md
@@ -4,7 +4,7 @@ description: Rancher integrates with popular logging services. Learn the require
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/logging"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/logging"/>
 </head>
 
 The [Logging operator](https://kube-logging.github.io/docs/) now powers Rancher's logging solution in place of the former, in-house solution.

--- a/versioned_docs/version-2.7/integrations-in-rancher/monitoring-and-alerting/monitoring-and-alerting.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/monitoring-and-alerting/monitoring-and-alerting.md
@@ -4,7 +4,7 @@ description: Prometheus lets you view metrics from your different Rancher and Ku
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-and-alerting"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/monitoring-and-alerting"/>
 </head>
 
 The `rancher-monitoring` application can quickly deploy leading open-source monitoring and alerting solutions onto your cluster.

--- a/versioned_docs/version-2.7/reference-guides/about-the-api/about-the-api.md
+++ b/versioned_docs/version-2.7/reference-guides/about-the-api/about-the-api.md
@@ -3,7 +3,7 @@ title: API
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/about-the-api"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/about-the-api"/>
 </head>
 
 ## How to use the API

--- a/versioned_docs/version-2.7/reference-guides/backup-restore-configuration/backup-restore-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/backup-restore-configuration/backup-restore-configuration.md
@@ -3,7 +3,7 @@ title: Rancher Backup Configuration Reference
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/backup-restore-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/backup-restore-configuration"/>
 </head>
 
 - [Backup configuration](backup-configuration.md)

--- a/versioned_docs/version-2.7/reference-guides/best-practices/best-practices.md
+++ b/versioned_docs/version-2.7/reference-guides/best-practices/best-practices.md
@@ -3,7 +3,7 @@ title: Best Practices Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/best-practices"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/best-practices"/>
 </head>
 
 The purpose of this section is to consolidate best practices for Rancher implementations. This also includes recommendations for related technologies, such as Kubernetes, Docker, containers, and more. The objective is to improve the outcome of a Rancher implementation using the operational experience of Rancher and its customers.

--- a/versioned_docs/version-2.7/reference-guides/best-practices/rancher-managed-clusters/rancher-managed-clusters.md
+++ b/versioned_docs/version-2.7/reference-guides/best-practices/rancher-managed-clusters/rancher-managed-clusters.md
@@ -3,7 +3,7 @@ title: Best Practices for Rancher Managed Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-managed-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/best-practices/rancher-managed-clusters"/>
 </head>
 
 ### Logging

--- a/versioned_docs/version-2.7/reference-guides/best-practices/rancher-server/rancher-server.md
+++ b/versioned_docs/version-2.7/reference-guides/best-practices/rancher-server/rancher-server.md
@@ -3,7 +3,7 @@ title: Best Practices for the Rancher Server
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-server"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/best-practices/rancher-server"/>
 </head>
 
 This guide contains our recommendations for running the Rancher server, and is intended to be used in situations in which Rancher manages downstream Kubernetes clusters.

--- a/versioned_docs/version-2.7/reference-guides/cli-with-rancher/cli-with-rancher.md
+++ b/versioned_docs/version-2.7/reference-guides/cli-with-rancher/cli-with-rancher.md
@@ -3,7 +3,7 @@ title: CLI with Rancher
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cli-with-rancher"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cli-with-rancher"/>
 </head>
 
 Interact with Rancher using command line interface (CLI) tools from your workstation. The following docs will describe the [Rancher CLI](rancher-cli.md) and [kubectl Utility](kubectl-utility.md).

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/cluster-configuration.md
@@ -3,7 +3,7 @@ title: Cluster Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cluster-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration"/>
 </head>
 
 After you provision a Kubernetes cluster using Rancher, you can still edit options and settings for the cluster.

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/downstream-cluster-configuration/downstream-cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/downstream-cluster-configuration/downstream-cluster-configuration.md
@@ -3,7 +3,7 @@ title: Downstream Cluster Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/downstream-cluster-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/downstream-cluster-configuration"/>
 </head>
 
 The following docs will discuss [node template configuration](node-template-configuration/node-template-configuration.md) and [machine configuration](machine-configuration/machine-configuration.md).

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/machine-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/machine-configuration.md
@@ -3,7 +3,7 @@ title: Machine Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/machine-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration"/>
 </head>
 
 Machine configuration is the arrangement of resources assigned to a virtual machine. Please see the docs for [Amazon EC2](amazon-ec2.md), [DigitalOcean](digitalocean.md), and [Azure](azure.md) to learn more.

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/node-template-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/node-template-configuration.md
@@ -3,7 +3,7 @@ title: Node Template Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/node-template-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration"/>
 </head>
 
 To learn about node template config, refer to [EC2 Node Template Configuration](amazon-ec2.md), [DigitalOcean Node Template Configuration](digitalocean.md), [Azure Node Template Configuration](azure.md), [vSphere Node Template Configuration](vsphere.md), and [Nutanix Node Template Configuration](nutanix.md).

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
@@ -3,7 +3,7 @@ title: GKE Cluster Configuration Reference
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/gke-cluster-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration"/>
 </head>
 
 ## Changes in Rancher v2.6

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/rancher-server-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/rancher-server-configuration.md
@@ -3,7 +3,7 @@ title: Rancher Server Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-server-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration"/>
 </head>
 
 - [RKE1 Cluster Configuration](rke1-cluster-configuration.md)

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md
@@ -4,7 +4,7 @@ description: To create a cluster with custom nodes, you’ll need to access serv
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/use-existing-nodes"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes"/>
 </head>
 
 When you create a custom cluster, Rancher uses RKE (the Rancher Kubernetes Engine) to create a Kubernetes cluster in on-prem bare-metal servers, on-prem virtual machines, or in any node hosted by an infrastructure provider.

--- a/versioned_docs/version-2.7/reference-guides/monitoring-v2-configuration/monitoring-v2-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/monitoring-v2-configuration/monitoring-v2-configuration.md
@@ -3,7 +3,7 @@ title: Monitoring V2 Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-v2-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/monitoring-v2-configuration"/>
 </head>
 
 The following sections will explain important options essential to configuring Monitoring V2 in Rancher:

--- a/versioned_docs/version-2.7/reference-guides/prometheus-federator/prometheus-federator.md
+++ b/versioned_docs/version-2.7/reference-guides/prometheus-federator/prometheus-federator.md
@@ -3,7 +3,7 @@ title: Prometheus Federator
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/prometheus-federator"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/prometheus-federator"/>
 </head>
 
 Prometheus Federator, also referred to as Project Monitoring v2, deploys a Helm Project Operator (based on the [rancher/helm-project-operator](https://github.com/rancher/helm-project-operator)), an operator that manages deploying Helm charts each containing a Project Monitoring Stack, where each stack contains:

--- a/versioned_docs/version-2.7/reference-guides/rancher-manager-architecture/rancher-manager-architecture.md
+++ b/versioned_docs/version-2.7/reference-guides/rancher-manager-architecture/rancher-manager-architecture.md
@@ -3,7 +3,7 @@ title: Architecture
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-manager-architecture"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-manager-architecture"/>
 </head>
 
 This section focuses on the [Rancher server and its components](rancher-server-and-components.md) and how [Rancher communicates with downstream Kubernetes clusters](communicating-with-downstream-user-clusters.md).

--- a/versioned_docs/version-2.7/reference-guides/rancher-security/hardening-guides/hardening-guides.md
+++ b/versioned_docs/version-2.7/reference-guides/rancher-security/hardening-guides/hardening-guides.md
@@ -3,7 +3,7 @@ title: Self-Assessment and Hardening Guides for Rancher
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-hardening-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/hardening-guides"/>
 </head>
 
 Rancher provides specific security hardening guides for each supported Rancher version's Kubernetes distributions.

--- a/versioned_docs/version-2.7/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-hardening-guide.md
+++ b/versioned_docs/version-2.7/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-hardening-guide.md
@@ -3,7 +3,7 @@ title: K3s Hardening Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/k3s-hardening-guide"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide"/>
 </head>
 
 This document provides prescriptive guidance for how to harden a K3s cluster intended for production, before provisioning it with Rancher. It outlines the configurations and controls required for Center for Information Security (CIS) Kubernetes benchmark controls.

--- a/versioned_docs/version-2.7/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-hardening-guide.md
+++ b/versioned_docs/version-2.7/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-hardening-guide.md
@@ -3,7 +3,7 @@ title: RKE Hardening Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rke1-hardening-guide"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide"/>
 </head>
 
 This document provides prescriptive guidance for how to harden an RKE cluster intended for production, before provisioning it with Rancher. It outlines the configurations and controls required for Center for Information Security (CIS) Kubernetes benchmark controls.

--- a/versioned_docs/version-2.7/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-hardening-guide.md
+++ b/versioned_docs/version-2.7/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-hardening-guide.md
@@ -3,7 +3,7 @@ title: RKE2 Hardening Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rke2-hardening-guide"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide"/>
 </head>
 
 This document provides prescriptive guidance for how to harden an RKE2 cluster intended for production, before provisioning it with Rancher. It outlines the configurations and controls required for Center for Information Security (CIS) Kubernetes benchmark controls.

--- a/versioned_docs/version-2.7/reference-guides/rancher-security/rancher-security.md
+++ b/versioned_docs/version-2.7/reference-guides/rancher-security/rancher-security.md
@@ -3,7 +3,7 @@ title: Security
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-security"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security"/>
 </head>
 
 <table width="100%">

--- a/versioned_docs/version-2.7/reference-guides/rancher-security/selinux-rpm/selinux-rpm.md
+++ b/versioned_docs/version-2.7/reference-guides/rancher-security/selinux-rpm/selinux-rpm.md
@@ -3,7 +3,7 @@ title: SELinux RPM
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/selinux-rpm"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/selinux-rpm"/>
 </head>
 
 [Security-Enhanced Linux (SELinux)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) is a security enhancement to Linux.

--- a/versioned_docs/version-2.7/reference-guides/single-node-rancher-in-docker/single-node-rancher-in-docker.md
+++ b/versioned_docs/version-2.7/reference-guides/single-node-rancher-in-docker/single-node-rancher-in-docker.md
@@ -3,7 +3,7 @@ title: Single Node Rancher in Docker
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/single-node-rancher-in-docker"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/single-node-rancher-in-docker"/>
 </head>
 
 The following docs will discuss [HTTP proxy configuration](http-proxy-configuration.md) and [advanced options](advanced-options.md) for Docker installs.

--- a/versioned_docs/version-2.7/reference-guides/user-settings/user-settings.md
+++ b/versioned_docs/version-2.7/reference-guides/user-settings/user-settings.md
@@ -3,7 +3,7 @@ title: User Settings
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/user-settings"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/user-settings"/>
 </head>
 
 Within Rancher, each user has a number of settings associated with their login: personal preferences, API keys, etc. You can configure these settings by choosing from the **User Settings** menu. You can open this menu by clicking your avatar, located within the main menu.

--- a/versioned_docs/version-2.7/security/security-scan/security-scan.md
+++ b/versioned_docs/version-2.7/security/security-scan/security-scan.md
@@ -3,7 +3,7 @@ title: Security Scans
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scan-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/security/security-scan"/>
 </head>
 
 The documentation about CIS security scans has moved [here.](../../how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md)

--- a/versioned_docs/version-2.7/troubleshooting/kubernetes-components/kubernetes-components.md
+++ b/versioned_docs/version-2.7/troubleshooting/kubernetes-components/kubernetes-components.md
@@ -3,7 +3,7 @@ title: Kubernetes Components
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-components"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components"/>
 </head>
 
 The commands and steps listed in this section apply to the core Kubernetes components on [Rancher Launched Kubernetes](../../how-to-guides/new-user-guides/launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md) clusters.

--- a/versioned_docs/version-2.8/api/quickstart.md
+++ b/versioned_docs/version-2.8/api/quickstart.md
@@ -2,6 +2,10 @@
 title: API Quick Start Guide
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/api/quickstart"/>
+</head>
+
 You can access Rancher's resources through the Kubernetes API. This guide will help you get started on using this API as a Rancher user.
 
 1. In the upper left corner, click **☰ > Global Settings**.

--- a/versioned_docs/version-2.8/api/workflows/projects.md
+++ b/versioned_docs/version-2.8/api/workflows/projects.md
@@ -2,6 +2,10 @@
 title: Projects
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/api/workflows/projects"/>
+</head>
+
 ## Creating a Project
 
 Project resources may only be created on the management cluster. See below for [creating namespaces under projects in a managed cluster](#creating-a-namespace-in-a-project).

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/install-upgrade-on-a-kubernetes-cluster.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/install-upgrade-on-a-kubernetes-cluster.md
@@ -4,7 +4,7 @@ description: Learn how to install Rancher in development and production environm
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster"/>
 </head>
 
 In this section, you'll learn how to deploy Rancher on a Kubernetes cluster using the Helm CLI.

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/installation-and-upgrade.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/installation-and-upgrade.md
@@ -4,7 +4,7 @@ description: Learn how to install Rancher in development and production environm
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-and-upgrade"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade"/>
 </head>
 
 This section provides an overview of the architecture options of installing Rancher, describing advantages of each option.

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/installation-references/installation-references.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/installation-references/installation-references.md
@@ -3,7 +3,7 @@ title: Installation References
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-references"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references"/>
 </head>
 
 Please see the following reference guides for other installation resources: [Rancher Helm chart options](helm-chart-options.md), [TLS settings](tls-settings.md), and [feature flags](feature-flags.md).

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
@@ -4,7 +4,7 @@ description: Learn the node requirements for each node running Rancher server wh
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-requirements"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-requirements"/>
 </head>
 
 This page describes the software, hardware, and networking requirements for the nodes where the Rancher server will be installed. The Rancher server can be installed on a single node or a high-availability Kubernetes cluster.

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/air-gapped-helm-cli-install.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/air-gapped-helm-cli-install.md
@@ -3,7 +3,7 @@ title: Air-Gapped Helm CLI Install
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/air-gapped-helm-cli-install"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install"/>
 </head>
 
 This section is about using the Helm CLI to install the Rancher server in an air gapped environment. An air gapped environment could be where Rancher server will be installed offline, behind a firewall, or behind a proxy.

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/other-installation-methods.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/other-installation-methods.md
@@ -3,7 +3,7 @@ title: Other Installation Methods
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/other-installation-methods"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods"/>
 </head>
 
 ### Air Gapped Installations

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/rancher-behind-an-http-proxy.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/rancher-behind-an-http-proxy.md
@@ -3,7 +3,7 @@ title: Installing Rancher behind an HTTP Proxy
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-behind-an-http-proxy"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy"/>
 </head>
 
 In a lot of enterprise environments, servers or VMs running on premise do not have direct Internet access, but must connect to external services through a HTTP(S) proxy for security reasons. This tutorial shows step by step how to set up a highly available Rancher installation in such an environment.

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
@@ -4,7 +4,7 @@ description: For development and testing environments only, use a Docker install
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-on-a-single-node-with-docker"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker"/>
 </head>
 
 Rancher can be installed by running a single Docker container.

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/resources/resources.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/resources/resources.md
@@ -3,7 +3,7 @@ title: Resources
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/resources"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/resources"/>
 </head>
 
 ### Docker Installations

--- a/versioned_docs/version-2.8/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
+++ b/versioned_docs/version-2.8/getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager.md
@@ -3,7 +3,7 @@ title: Deploying Rancher Server
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-rancher-manager"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com"/>
 </head>
 
 Use one of the following guides to deploy and provision Rancher and a Kubernetes cluster in the provider of your choice.

--- a/versioned_docs/version-2.8/getting-started/quick-start-guides/deploy-workloads/deploy-workloads.md
+++ b/versioned_docs/version-2.8/getting-started/quick-start-guides/deploy-workloads/deploy-workloads.md
@@ -3,7 +3,7 @@ title: Deploying Workloads
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-rancher-workloads"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-workloads"/>
 </head>
 
 These guides walk you through the deployment of an application, including how to expose the application for use outside of the cluster.

--- a/versioned_docs/version-2.8/getting-started/quick-start-guides/quick-start-guides.md
+++ b/versioned_docs/version-2.8/getting-started/quick-start-guides/quick-start-guides.md
@@ -3,7 +3,7 @@ title: Rancher Deployment Quick Start Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/quick-start-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides"/>
 </head>
 
 :::caution

--- a/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/advanced-user-guides.md
+++ b/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/advanced-user-guides.md
@@ -3,7 +3,7 @@ title: Advanced User Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/advanced-user-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides"/>
 </head>
 
 Advanced user guides are "problem-oriented" docs in which users learn how to answer questions or solve problems. The major difference between these and the new user guides is that these guides are geared toward more experienced or advanced users who have more technical needs from their documentation. These users already have an understanding of Rancher and its functions. They know what they need to accomplish; they just need additional guidance to complete some more complex task they they have encountered while working.

--- a/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md
+++ b/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md
@@ -3,7 +3,7 @@ title: CIS Scan Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scan-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/cis-scan-guides"/>
 </head>
 
 - [Install rancher-cis-benchmark](install-rancher-cis-benchmark.md)

--- a/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/enable-experimental-features/enable-experimental-features.md
+++ b/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/enable-experimental-features/enable-experimental-features.md
@@ -3,7 +3,7 @@ title: Enabling Experimental Features
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/enable-experimental-features"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/enable-experimental-features"/>
 </head>
 
 Rancher includes some features that are experimental and disabled by default. You might want to enable these features, for example, if you decide that the benefits of using an [unsupported storage type](unsupported-storage-drivers.md) outweighs the risk of using an untested feature. Feature flags were introduced to allow you to try these features that are not enabled by default.

--- a/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
+++ b/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
@@ -3,7 +3,7 @@ title: Setup Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/istio-setup-guide"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide"/>
 </head>
 
 This section describes how to enable Istio and start using it in your projects.

--- a/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/manage-project-resource-quotas.md
+++ b/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/manage-project-resource-quotas.md
@@ -3,7 +3,7 @@ title: Project Resource Quotas
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-project-resource-quotas"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas"/>
 </head>
 
 In situations where several teams share a cluster, one team may overconsume the resources available: CPU, memory, storage, services, Kubernetes objects like pods or secrets, and so on.  To prevent this overconsumption, you can apply a _resource quota_, which is a Rancher feature that limits the resources available to a project or namespace.

--- a/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/manage-projects/manage-projects.md
+++ b/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/manage-projects/manage-projects.md
@@ -3,7 +3,7 @@ title: Project Administration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-projects"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/manage-projects"/>
 </head>
 
 _Projects_ are objects introduced in Rancher that help organize namespaces in your Kubernetes cluster. You can use projects to create multi-tenant clusters, which allows a group of users to share the same underlying resources without interacting with each other's applications.

--- a/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/monitoring-alerting-guides/monitoring-alerting-guides.md
+++ b/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/monitoring-alerting-guides/monitoring-alerting-guides.md
@@ -3,7 +3,7 @@ title: Monitoring/Alerting Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-alerting-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-alerting-guides"/>
 </head>
 
 - [Enable monitoring](enable-monitoring.md)

--- a/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/monitoring-alerting-guides/prometheus-federator-guides/prometheus-federator-guides.md
+++ b/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/monitoring-alerting-guides/prometheus-federator-guides/prometheus-federator-guides.md
@@ -3,7 +3,7 @@ title: Prometheus Federator Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/prometheus-federator-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-alerting-guides/prometheus-federator-guides"/>
 </head>
 
 - [Enable Prometheus Operator](enable-prometheus-federator.md)

--- a/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/advanced-configuration.md
+++ b/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/advanced-configuration.md
@@ -3,7 +3,7 @@ title: Advanced Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/advanced-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration"/>
 </head>
 
 ### Alertmanager

--- a/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/monitoring-v2-configuration-guides.md
+++ b/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/monitoring-v2-configuration-guides.md
@@ -3,7 +3,7 @@ title: Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-v2-configuration-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides"/>
 </head>
 
 This page captures some of the most important options for configuring Monitoring V2 in the Rancher UI.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/about-provisioning-drivers.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/about-provisioning-drivers.md
@@ -3,7 +3,7 @@ title: About Provisioning Drivers
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/about-provisioning-drivers"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers"/>
 </head>
 
 Drivers in Rancher allow you to manage which providers can be used to deploy [hosted Kubernetes clusters](../../kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md) or [nodes in an infrastructure provider](../../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider.md) to allow Rancher to deploy and manage Kubernetes.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/about-rke1-templates.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/about-rke1-templates.md
@@ -3,7 +3,7 @@ title: RKE Templates
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/about-rke1-templates"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates"/>
 </head>
 
 RKE templates are designed to allow DevOps and security teams to standardize and simplify the creation of Kubernetes clusters.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
@@ -4,7 +4,7 @@ weight: 10
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/authentication-config"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config"/>
 </head>
 
 One of the key features that Rancher adds to Kubernetes is centralized user authentication. This feature allows your users to use one set of credentials to authenticate with any of your Kubernetes clusters.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-permissions-and-global-configuration.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-permissions-and-global-configuration.md
@@ -3,7 +3,7 @@ title: Authentication, Permissions and Global Settings
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/authentication-permissions-and-global-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration"/>
 </head>
 
 After installation, the [system administrator](manage-role-based-access-control-rbac/global-permissions.md) should configure Rancher to configure authentication, authorization, security, default settings, security policies, drivers and global DNS entries.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml/configure-microsoft-ad-federation-service-saml.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml/configure-microsoft-ad-federation-service-saml.md
@@ -3,7 +3,7 @@ title: Configuring Microsoft Active Directory Federation Service (SAML)
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configure-microsoft-ad-federation-service-saml"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml"/>
 </head>
 
 If your organization uses Microsoft Active Directory Federation Services (AD FS) for user authentication, you can configure Rancher to allow your users to log in using their AD FS credentials.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap/configure-openldap.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap/configure-openldap.md
@@ -3,7 +3,7 @@ title: Configuring OpenLDAP
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configure-openldap"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap"/>
 </head>
 
 If your organization uses LDAP for user authentication, you can configure Rancher to communicate with an OpenLDAP server to authenticate users. This allows Rancher admins to control access to clusters and projects based on users and groups managed externally in the organisation's central user repository, while allowing end-users to authenticate with their LDAP credentials when logging in to the Rancher UI.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml/configure-shibboleth-saml.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml/configure-shibboleth-saml.md
@@ -3,7 +3,7 @@ title: Configuring Shibboleth (SAML)
 ---
 
 <head> 
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configure-shibboleth-saml"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml"/>
 </head>
 
 If your organization uses Shibboleth Identity Provider (IdP) for user authentication, you can configure Rancher to allow your users to log in to Rancher using their Shibboleth credentials.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.md
@@ -3,7 +3,7 @@ title: Managing Role-Based Access Control (RBAC)
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-role-based-access-control-rbac"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac"/>
 </head>
 
 Within Rancher, each person authenticates as a _user_, which is a login that grants you access to Rancher. As mentioned in [Authentication](../authentication-config/authentication-config.md), users can either be local or external.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
@@ -4,7 +4,7 @@ keywords: [rancher backup restore, rancher backup and restore, backup restore ra
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/backup-restore-and-disaster-recovery"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery"/>
 </head>
 
 In this section, you'll learn how to create backups of Rancher, how to restore Rancher from backup, and how to migrate Rancher to a new Kubernetes cluster.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/deploy-apps-across-clusters/deploy-apps-across-clusters.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/deploy-apps-across-clusters/deploy-apps-across-clusters.md
@@ -3,7 +3,7 @@ title: Deploying Applications across Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/deploy-apps-across-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters"/>
 </head>
 
 Rancher offers several ways to deploy applications across clusters, depending on version.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/helm-charts-in-rancher/helm-charts-in-rancher.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/helm-charts-in-rancher/helm-charts-in-rancher.md
@@ -3,7 +3,7 @@ title: Helm Charts in Rancher
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/helm-charts-in-rancher"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/helm-charts-in-rancher"/>
 </head>
 
 In this section, you'll learn how to manage Helm chart repositories and applications in Rancher. Helm chart repositories are managed using **Apps**. It uses a catalog-like system to import bundles of charts from repositories and then uses those charts to either deploy custom Helm applications or Rancher's tools such as Monitoring or Istio. Rancher tools come as pre-loaded repositories which deploy as standalone Helm charts. Any additional repositories are only added to the current cluster.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/infrastructure-setup/infrastructure-setup.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/infrastructure-setup/infrastructure-setup.md
@@ -3,7 +3,7 @@ title: Don't have infrastructure for your Kubernetes cluster? Try one of these t
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/infrastructure-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/infrastructure-setup"/>
 </head>
 
 To set up infrastructure for a high-availability K3s Kubernetes cluster with an external DB, refer to [this page.](ha-k3s-kubernetes-cluster.md)

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-cluster-setup/kubernetes-cluster-setup.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-cluster-setup/kubernetes-cluster-setup.md
@@ -3,7 +3,7 @@ title: "Don't have a Kubernetes cluster? Try one of these tutorials."
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-cluster-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-cluster-setup"/>
 </head>
 
 This section contains information on how to install a Kubernetes cluster that the Rancher server can be installed on.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/checklist-for-production-ready-clusters.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/checklist-for-production-ready-clusters.md
@@ -3,7 +3,7 @@ title: Checklist for Production-Ready Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/checklist-for-production-ready-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters"/>
 </head>
 
 In this section, we recommend best practices for creating the production-ready Kubernetes clusters that will run your apps and services.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/kubernetes-clusters-in-rancher-setup.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/kubernetes-clusters-in-rancher-setup.md
@@ -4,7 +4,7 @@ description: Provisioning Kubernetes Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-clusters-in-rancher-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup"/>
 </head>
 
 Rancher simplifies the creation of clusters by allowing you to create them through the Rancher UI rather than more complex alternatives. Rancher provides multiple options for launching a cluster. Use the option that best fits your use case.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/set-up-cloud-providers.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/set-up-cloud-providers.md
@@ -3,7 +3,7 @@ title: Setting up Cloud Providers
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/set-up-cloud-providers"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers"/>
 </head>
 
 A _cloud provider_ is a module in Kubernetes that provides an interface for managing nodes, load balancers, and networking routes.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md
@@ -3,7 +3,7 @@ title: Setting up Clusters from Hosted Kubernetes Providers
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/set-up-clusters-from-hosted-kubernetes-providers"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers"/>
 </head>
 
 In this scenario, Rancher does not provision Kubernetes because it is installed by providers such as Google Kubernetes Engine (GKE), Amazon Elastic Container Service for Kubernetes, or Azure Kubernetes Service.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/use-windows-clusters.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/use-windows-clusters.md
@@ -3,7 +3,7 @@ title: Launching Kubernetes on Windows Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/use-windows-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters"/>
 </head>
 
 When provisioning a [custom cluster](../../../../reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md) using Rancher, Rancher uses RKE (the Rancher Kubernetes Engine) to install Kubernetes on your existing nodes.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/horizontal-pod-autoscaler.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/horizontal-pod-autoscaler.md
@@ -4,7 +4,7 @@ description: Learn about the horizontal pod autoscaler (HPA). How to manage HPAs
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/horizontal-pod-autoscaler"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler"/>
 </head>
 
 The [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) (HPA) is a Kubernetes feature that allows you to configure your cluster to automatically scale the services it's running up or down.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-resources-setup.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-resources-setup.md
@@ -3,7 +3,7 @@ title: Kubernetes Resources
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-resources-setup"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup"/>
 </head>
 
 You can view and manipulate all of the custom resources and CRDs in a Kubernetes cluster from the Rancher UI.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.md
@@ -4,7 +4,7 @@ description: Learn how you can set up load balancers and ingress controllers to 
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/load-balancer-and-ingress-controller"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller"/>
 </head>
 
 Within Rancher, you can set up load balancers and ingress controllers to redirect service requests.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/workloads-and-pods.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/workloads-and-pods.md
@@ -4,7 +4,7 @@ description: "Learn about the two constructs with which you can build any comple
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/workloads-and-pods"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods"/>
 </head>
 
 You can build any complex containerized application in Kubernetes using two basic constructs: pods and workloads. Once you build an application, you can expose it for access either within the same cluster or on the Internet using a third construct: services.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md
@@ -3,7 +3,7 @@ title: Launching Kubernetes with Rancher
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher"/>
 </head>
 
 You can have Rancher launch a Kubernetes cluster using any nodes you want. When Rancher deploys Kubernetes onto these nodes, you can choose between [Rancher Kubernetes Engine](https://rancher.com/docs/rke/latest/en/) (RKE) or [RKE2](https://docs.rke2.io) distributions. Rancher can launch Kubernetes on any computers, including:

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/nutanix.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/nutanix.md
@@ -4,7 +4,7 @@ description: Use Rancher to create a Nutanix AOS (AHV) cluster. It may consist o
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/nutanix"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix"/>
 </head>
 
 [Nutanix Acropolis Operating System](https://www.nutanix.com/products/acropolis) (Nutanix AOS) is an operating system for the Nutanix hyper-converged infrastructure platform. AOS comes with a built-in hypervisor called [Acropolis Hypervisor](https://www.nutanix.com/products/ahv), or AHV. By using Rancher with Nutanix AOS (AHV), you can bring cloud operations on-premises.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider.md
@@ -3,7 +3,7 @@ title: Launching Kubernetes on New Nodes in an Infrastructure Provider
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/use-new-nodes-in-an-infra-provider"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider"/>
 </head>
 
 When you create an RKE or RKE2 cluster using a node template in Rancher, each resulting node pool is shown in a new **Machine Pools** tab. You can see the machine pools by doing the following:

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
@@ -4,7 +4,7 @@ description: Use Rancher to create a vSphere cluster. It may consist of groups o
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/vsphere"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere"/>
 </head>
 
 import YouTube from '@site/src/components/YouTube'

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/manage-clusters/access-clusters/access-clusters.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/manage-clusters/access-clusters/access-clusters.md
@@ -3,7 +3,7 @@ title: Cluster Access
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/access-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters"/>
 </head>
 
 This section is about what tools can be used to access clusters managed by Rancher.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/create-kubernetes-persistent-storage.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/create-kubernetes-persistent-storage.md
@@ -4,7 +4,7 @@ description: "Learn about the two ways with which you can create persistent stor
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/create-kubernetes-persistent-storage"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage"/>
 </head>
 
 When deploying an application that needs to retain data, you'll need to create persistent storage. Persistent storage allows you to store application data external from the pod running your application. This storage practice allows you to maintain application data, even if the application's pod fails.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/install-cluster-autoscaler.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/install-cluster-autoscaler.md
@@ -3,7 +3,7 @@ title: Cluster Autoscaler
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/install-cluster-autoscaler"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler"/>
 </head>
 
 In this section, you'll learn how to install and use the [Kubernetes cluster-autoscaler](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/) on Rancher custom clusters using AWS EC2 Auto Scaling Groups.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/manage-clusters/manage-clusters.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/manage-clusters/manage-clusters.md
@@ -3,7 +3,7 @@ title: Cluster Administration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/manage-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters"/>
 </head>
 
 After you provision a cluster in Rancher, you can begin using powerful Kubernetes features to deploy and scale your containerized applications in development, testing, or production environments.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/provisioning-storage-examples.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/provisioning-storage-examples.md
@@ -3,7 +3,7 @@ title: Provisioning Storage Examples
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/provisioning-storage-examples"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples"/>
 </head>
 
 Rancher supports persistent storage with a variety of volume plugins. However, before you use any of these plugins to bind persistent storage to your workloads, you have to configure the storage itself, whether its a cloud-based solution from a service-provider or an on-prem solution that you manage yourself.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/new-user-guides.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/new-user-guides.md
@@ -3,7 +3,7 @@ title: New User Guides
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/new-user-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides"/>
 </head>
 
 New user guides, also known as **tutorials**, describe practical steps for users to follow in order to complete some concrete action. These docs are known as "learning-oriented" docs in which users learn by "doing".

--- a/versioned_docs/version-2.8/integrations-in-rancher/cis-scans/cis-scans.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/cis-scans/cis-scans.md
@@ -3,7 +3,7 @@ title: CIS Scans
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scans"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cis-scans"/>
 </head>
 
 Rancher can run a security scan to check whether Kubernetes is deployed according to security best practices as defined in the CIS Kubernetes Benchmark. The CIS scans can run on any Kubernetes cluster, including hosted Kubernetes providers such as EKS, AKS, and GKE.

--- a/versioned_docs/version-2.8/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/aws-cloud-marketplace.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/aws-cloud-marketplace.md
@@ -3,7 +3,7 @@ title: AWS Marketplace Integration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/aws-cloud-marketplace"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace"/>
 </head>
 
 ## Overview

--- a/versioned_docs/version-2.8/integrations-in-rancher/cloud-marketplace/cloud-marketplace.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/cloud-marketplace/cloud-marketplace.md
@@ -3,7 +3,7 @@ title: Cloud Marketplace Integration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cloud-marketplace"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cloud-marketplace"/>
 </head>
 
 Rancher offers integration with cloud marketplaces to easily purchase support for installations hosted on certain cloud providers. In addition, this integration also provides the ability to generate a supportconfig bundle which can be provided to rancher support.

--- a/versioned_docs/version-2.8/integrations-in-rancher/elemental/elemental.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/elemental/elemental.md
@@ -2,6 +2,10 @@
 title: Operating System Management with Elemental
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/elemental"/>
+</head>
+
 Elemental enables cloud-native host management. Elemental allows you to onboard any machine in any location, whether its in a datacenter or on the edge, and integrate them seamlessly into Kubernetes while managing your workflows (e.g., OS updates). 
 
 ## Elemental with Rancher 

--- a/versioned_docs/version-2.8/integrations-in-rancher/fleet/architecture.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/fleet/architecture.md
@@ -2,6 +2,10 @@
 title: Architecture
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/architecture"/>
+</head>
+
 Fleet can manage deployments from git of raw Kubernetes YAML, Helm charts, or Kustomize or any combination of the three. Regardless of the source, all resources are dynamically turned into Helm charts, and Helm is used as the engine to deploy everything in the cluster. This gives you a high degree of control, consistency, and auditability. Fleet focuses not only on the ability to scale, but to give one a high degree of control and visibility to exactly what is installed on the cluster.
 
 ![Architecture](/img/fleet-architecture.svg)

--- a/versioned_docs/version-2.8/integrations-in-rancher/fleet/fleet.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/fleet/fleet.md
@@ -2,6 +2,10 @@
 title: Continuous Delivery with Fleet
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet"/>
+</head>
+
 Fleet orchestrates and manages the continuous delivery of applications through the supply chain for fleets of clusters. Fleet organizes the supply chain to help teams deliver with confidence and trust in a timely manner using GitOps as a safe operating model. 
 
 ## Fleet with Rancher

--- a/versioned_docs/version-2.8/integrations-in-rancher/fleet/overview.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/fleet/overview.md
@@ -2,6 +2,10 @@
 title: Overview
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview"/>
+</head>
+
 Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/installation#configuration-for-multi-cluster). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
 
 Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.

--- a/versioned_docs/version-2.8/integrations-in-rancher/fleet/use-fleet-behind-a-proxy.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/fleet/use-fleet-behind-a-proxy.md
@@ -2,6 +2,10 @@
 title: Using Fleet Behind a Proxy
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/use-fleet-behind-a-proxy"/>
+</head>
+
 In this section, you'll learn how to enable Fleet in a setup that has a Rancher server with a public IP a Kubernetes cluster that has no public IP, but is configured to use a proxy.
 
 Rancher does not establish connections with registered downstream clusters. The Rancher agent deployed on the downstream cluster must be able to establish the connection with Rancher.

--- a/versioned_docs/version-2.8/integrations-in-rancher/fleet/windows-support.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/fleet/windows-support.md
@@ -2,6 +2,10 @@
 title: Windows Support
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/windows-support"/>
+</head>
+
 Prior to Rancher v2.5.6, the `agent` did not have native Windows manifests on downstream clusters with Windows nodes. This would result in a failing `agent` pod for the cluster.
 
 If you are upgrading from an older version of Rancher to v2.5.6+, you can deploy a working `agent` with the following workflow *in the downstream cluster*:

--- a/versioned_docs/version-2.8/integrations-in-rancher/harvester/harvester.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/harvester/harvester.md
@@ -2,6 +2,10 @@
 title: Virtualization on Kubernetes with Harvester
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester"/>
+</head>
+
 ## Harvester
 
 Introduced in Rancher v2.6.1, Harvester is an open-source hyper-converged infrastructure (HCI) software built on Kubernetes. Harvester installs on bare metal servers and provides integrated virtualization and distributed storage capabilities. Although Harvester operates using Kubernetes, it does not require knowledge of Kubernetes concepts, making it more user-friendly.

--- a/versioned_docs/version-2.8/integrations-in-rancher/harvester/overview.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/harvester/overview.md
@@ -2,6 +2,10 @@
 title: Overview
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester/overview"/>
+</head>
+
 Introduced in Rancher v2.6.1, [Harvester](https://docs.harvesterhci.io/) is an open-source hyper-converged infrastructure (HCI) software built on Kubernetes. Harvester installs on bare metal servers and provides integrated virtualization and distributed storage capabilities. Although Harvester operates using Kubernetes, it does not require users to know Kubernetes concepts, making it a more user-friendly application.
 
 ### Feature Flag

--- a/versioned_docs/version-2.8/integrations-in-rancher/istio/configuration-options/configuration-options.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/istio/configuration-options/configuration-options.md
@@ -3,7 +3,7 @@ title: Configuration Options
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/configuration-options"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/configuration-options"/>
 </head>
 
 ### Egress Support

--- a/versioned_docs/version-2.8/integrations-in-rancher/istio/istio.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/istio/istio.md
@@ -3,7 +3,7 @@ title: Istio
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/istio"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio"/>
 </head>
 
 [Istio](https://istio.io/) is an open-source tool that makes it easier for DevOps teams to observe, secure, control, and troubleshoot the traffic within a complex network of microservices.

--- a/versioned_docs/version-2.8/integrations-in-rancher/kubernetes-distributions/kubernetes-distributions.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/kubernetes-distributions/kubernetes-distributions.md
@@ -2,6 +2,10 @@
 title: Kubernetes Distributions
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/kubernetes-distributions"/>
+</head>
+
 ## K3s
 
 K3s is a lightweight, fully compliant Kubernetes distribution designed for a range of use cases, including edge computing, IoT, CI/CD, development and embedding Kubernetes into applications. It simplifies Kubernetes management by packaging the system as a single binary, using sqlite3 as the default storage, and offering a user-friendly launcher. K3s includes essential features like local storage and load balancing, Helm chart controller and the Traefik CNI. It minimizes external dependencies and provides a streamlined Kubernetes experience. K3s was donated to the CNCF as a Sandbox Project in June 2020.

--- a/versioned_docs/version-2.8/integrations-in-rancher/logging/custom-resource-configuration/custom-resource-configuration.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/logging/custom-resource-configuration/custom-resource-configuration.md
@@ -3,7 +3,7 @@ title: Custom Resource Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/custom-resource-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/logging/custom-resource-configuration"/>
 </head>
 
 The following Custom Resource Definitions are used to configure logging:

--- a/versioned_docs/version-2.8/integrations-in-rancher/logging/logging.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/logging/logging.md
@@ -4,7 +4,7 @@ description: Rancher integrates with popular logging services. Learn the require
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/logging"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/logging"/>
 </head>
 
 The [Logging operator](https://kube-logging.github.io/docs/) now powers Rancher's logging solution in place of the former, in-house solution.

--- a/versioned_docs/version-2.8/integrations-in-rancher/monitoring-and-alerting/monitoring-and-alerting.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/monitoring-and-alerting/monitoring-and-alerting.md
@@ -4,7 +4,7 @@ description: Prometheus lets you view metrics from your different Rancher and Ku
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-and-alerting"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/monitoring-and-alerting"/>
 </head>
 
 The `rancher-monitoring` application can quickly deploy leading open-source monitoring and alerting solutions onto your cluster.

--- a/versioned_docs/version-2.8/reference-guides/about-the-api/about-the-api.md
+++ b/versioned_docs/version-2.8/reference-guides/about-the-api/about-the-api.md
@@ -3,7 +3,7 @@ title: API
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/about-the-api"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/about-the-api"/>
 </head>
 
 ## How to use the API

--- a/versioned_docs/version-2.8/reference-guides/backup-restore-configuration/backup-restore-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/backup-restore-configuration/backup-restore-configuration.md
@@ -3,7 +3,7 @@ title: Rancher Backup Configuration Reference
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/backup-restore-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/backup-restore-configuration"/>
 </head>
 
 - [Backup configuration](backup-configuration.md)

--- a/versioned_docs/version-2.8/reference-guides/best-practices/best-practices.md
+++ b/versioned_docs/version-2.8/reference-guides/best-practices/best-practices.md
@@ -3,7 +3,7 @@ title: Best Practices Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/best-practices"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/best-practices"/>
 </head>
 
 The purpose of this section is to consolidate best practices for Rancher implementations. This also includes recommendations for related technologies, such as Kubernetes, Docker, containers, and more. The objective is to improve the outcome of a Rancher implementation using the operational experience of Rancher and its customers.

--- a/versioned_docs/version-2.8/reference-guides/best-practices/rancher-managed-clusters/rancher-managed-clusters.md
+++ b/versioned_docs/version-2.8/reference-guides/best-practices/rancher-managed-clusters/rancher-managed-clusters.md
@@ -3,7 +3,7 @@ title: Best Practices for Rancher Managed Clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-managed-clusters"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/best-practices/rancher-managed-clusters"/>
 </head>
 
 ### Logging

--- a/versioned_docs/version-2.8/reference-guides/best-practices/rancher-server/rancher-server.md
+++ b/versioned_docs/version-2.8/reference-guides/best-practices/rancher-server/rancher-server.md
@@ -3,7 +3,7 @@ title: Best Practices for the Rancher Server
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-server"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/best-practices/rancher-server"/>
 </head>
 
 This guide contains our recommendations for running the Rancher server, and is intended to be used in situations in which Rancher manages downstream Kubernetes clusters.

--- a/versioned_docs/version-2.8/reference-guides/cli-with-rancher/cli-with-rancher.md
+++ b/versioned_docs/version-2.8/reference-guides/cli-with-rancher/cli-with-rancher.md
@@ -3,7 +3,7 @@ title: CLI with Rancher
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cli-with-rancher"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cli-with-rancher"/>
 </head>
 
 Interact with Rancher using command line interface (CLI) tools from your workstation. The following docs will describe the [Rancher CLI](rancher-cli.md) and [kubectl Utility](kubectl-utility.md).

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/cluster-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/cluster-configuration.md
@@ -3,7 +3,7 @@ title: Cluster Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cluster-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration"/>
 </head>
 
 After you provision a Kubernetes cluster using Rancher, you can still edit options and settings for the cluster.

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/downstream-cluster-configuration/downstream-cluster-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/downstream-cluster-configuration/downstream-cluster-configuration.md
@@ -3,7 +3,7 @@ title: Downstream Cluster Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/downstream-cluster-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/downstream-cluster-configuration"/>
 </head>
 
 The following docs will discuss [node template configuration](node-template-configuration/node-template-configuration.md) and [machine configuration](machine-configuration/machine-configuration.md).

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/machine-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/machine-configuration.md
@@ -3,7 +3,7 @@ title: Machine Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/machine-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration"/>
 </head>
 
 Machine configuration is the arrangement of resources assigned to a virtual machine. Please see the docs for [Amazon EC2](amazon-ec2.md), [DigitalOcean](digitalocean.md), and [Azure](azure.md) to learn more.

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/node-template-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/node-template-configuration.md
@@ -3,7 +3,7 @@ title: Node Template Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/node-template-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration"/>
 </head>
 
 To learn about node template config, refer to [EC2 Node Template Configuration](amazon-ec2.md), [DigitalOcean Node Template Configuration](digitalocean.md), [Azure Node Template Configuration](azure.md), [vSphere Node Template Configuration](vsphere.md), and [Nutanix Node Template Configuration](nutanix.md).

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
@@ -3,7 +3,7 @@ title: GKE Cluster Configuration Reference
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/gke-cluster-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration"/>
 </head>
 
 ## Changes in Rancher v2.6

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/rancher-server-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/rancher-server-configuration.md
@@ -3,7 +3,7 @@ title: Rancher Server Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-server-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration"/>
 </head>
 
 - [RKE1 Cluster Configuration](rke1-cluster-configuration.md)

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md
@@ -4,7 +4,7 @@ description: To create a cluster with custom nodes, you’ll need to access serv
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/use-existing-nodes"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes"/>
 </head>
 
 When you create a custom cluster, Rancher uses RKE (the Rancher Kubernetes Engine) to create a Kubernetes cluster in on-prem bare-metal servers, on-prem virtual machines, or in any node hosted by an infrastructure provider.

--- a/versioned_docs/version-2.8/reference-guides/monitoring-v2-configuration/monitoring-v2-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/monitoring-v2-configuration/monitoring-v2-configuration.md
@@ -3,7 +3,7 @@ title: Monitoring V2 Configuration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/monitoring-v2-configuration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/monitoring-v2-configuration"/>
 </head>
 
 The following sections will explain important options essential to configuring Monitoring V2 in Rancher:

--- a/versioned_docs/version-2.8/reference-guides/prometheus-federator/prometheus-federator.md
+++ b/versioned_docs/version-2.8/reference-guides/prometheus-federator/prometheus-federator.md
@@ -3,7 +3,7 @@ title: Prometheus Federator
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/prometheus-federator"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/prometheus-federator"/>
 </head>
 
 Prometheus Federator, also referred to as Project Monitoring v2, deploys a Helm Project Operator (based on the [rancher/helm-project-operator](https://github.com/rancher/helm-project-operator)), an operator that manages deploying Helm charts each containing a Project Monitoring Stack, where each stack contains:

--- a/versioned_docs/version-2.8/reference-guides/rancher-manager-architecture/rancher-manager-architecture.md
+++ b/versioned_docs/version-2.8/reference-guides/rancher-manager-architecture/rancher-manager-architecture.md
@@ -3,7 +3,7 @@ title: Architecture
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-manager-architecture"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-manager-architecture"/>
 </head>
 
 This section focuses on the [Rancher server and its components](rancher-server-and-components.md) and how [Rancher communicates with downstream Kubernetes clusters](communicating-with-downstream-user-clusters.md).

--- a/versioned_docs/version-2.8/reference-guides/rancher-security/hardening-guides/hardening-guides.md
+++ b/versioned_docs/version-2.8/reference-guides/rancher-security/hardening-guides/hardening-guides.md
@@ -3,7 +3,7 @@ title: Self-Assessment and Hardening Guides for Rancher
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-hardening-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/hardening-guides"/>
 </head>
 
 Rancher provides specific security hardening guides for each supported Rancher version's Kubernetes distributions.

--- a/versioned_docs/version-2.8/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-hardening-guide.md
+++ b/versioned_docs/version-2.8/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-hardening-guide.md
@@ -3,7 +3,7 @@ title: K3s Hardening Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/k3s-hardening-guide"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide"/>
 </head>
 
 This document provides prescriptive guidance for how to harden a K3s cluster intended for production, before provisioning it with Rancher. It outlines the configurations and controls required for Center for Information Security (CIS) Kubernetes benchmark controls.

--- a/versioned_docs/version-2.8/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-hardening-guide.md
+++ b/versioned_docs/version-2.8/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-hardening-guide.md
@@ -3,7 +3,7 @@ title: RKE Hardening Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rke1-hardening-guide"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide"/>
 </head>
 
 This document provides prescriptive guidance for how to harden an RKE cluster intended for production, before provisioning it with Rancher. It outlines the configurations and controls required for Center for Information Security (CIS) Kubernetes benchmark controls.

--- a/versioned_docs/version-2.8/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-hardening-guide.md
+++ b/versioned_docs/version-2.8/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-hardening-guide.md
@@ -3,7 +3,7 @@ title: RKE2 Hardening Guide
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rke2-hardening-guide"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide"/>
 </head>
 
 This document provides prescriptive guidance for how to harden an RKE2 cluster intended for production, before provisioning it with Rancher. It outlines the configurations and controls required for Center for Information Security (CIS) Kubernetes benchmark controls.

--- a/versioned_docs/version-2.8/reference-guides/rancher-security/rancher-security.md
+++ b/versioned_docs/version-2.8/reference-guides/rancher-security/rancher-security.md
@@ -3,7 +3,7 @@ title: Security
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/rancher-security"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security"/>
 </head>
 
 <table width="100%">

--- a/versioned_docs/version-2.8/reference-guides/rancher-security/rancher-webhook-hardening.md
+++ b/versioned_docs/version-2.8/reference-guides/rancher-security/rancher-webhook-hardening.md
@@ -2,6 +2,10 @@
 title: Hardening the Rancher Webhook
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/rancher-webhook-hardening"/>
+</head>
+
 Rancher Webhook is an important component within Rancher, playing a role in enforcing security requirements for Rancher and its workloads. To decrease its attack surface, access to it should be limited to the only valid caller it has: the Kubernetes API server. This can be done by using network policies and authentication independently or in conjunction with each other to harden the webhook against attacks.
 
 ## Block External Traffic Using Network Policies

--- a/versioned_docs/version-2.8/reference-guides/rancher-security/selinux-rpm/selinux-rpm.md
+++ b/versioned_docs/version-2.8/reference-guides/rancher-security/selinux-rpm/selinux-rpm.md
@@ -3,7 +3,7 @@ title: SELinux RPM
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/selinux-rpm"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/selinux-rpm"/>
 </head>
 
 [Security-Enhanced Linux (SELinux)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) is a security enhancement to Linux.

--- a/versioned_docs/version-2.8/reference-guides/single-node-rancher-in-docker/single-node-rancher-in-docker.md
+++ b/versioned_docs/version-2.8/reference-guides/single-node-rancher-in-docker/single-node-rancher-in-docker.md
@@ -3,7 +3,7 @@ title: Single Node Rancher in Docker
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/single-node-rancher-in-docker"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/single-node-rancher-in-docker"/>
 </head>
 
 The following docs will discuss [HTTP proxy configuration](http-proxy-configuration.md) and [advanced options](advanced-options.md) for Docker installs.

--- a/versioned_docs/version-2.8/reference-guides/user-settings/user-settings.md
+++ b/versioned_docs/version-2.8/reference-guides/user-settings/user-settings.md
@@ -3,7 +3,7 @@ title: User Settings
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/user-settings"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/user-settings"/>
 </head>
 
 Within Rancher, each user has a number of settings associated with their login: personal preferences, API keys, etc. You can configure these settings by choosing from the **User Settings** menu. You can open this menu by clicking your avatar, located within the main menu.

--- a/versioned_docs/version-2.8/security/security-scan/security-scan.md
+++ b/versioned_docs/version-2.8/security/security-scan/security-scan.md
@@ -3,7 +3,7 @@ title: Security Scans
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/cis-scan-guides"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/security/security-scan"/>
 </head>
 
 The documentation about CIS security scans has moved [here.](../../how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md)

--- a/versioned_docs/version-2.8/troubleshooting/kubernetes-components/kubernetes-components.md
+++ b/versioned_docs/version-2.8/troubleshooting/kubernetes-components/kubernetes-components.md
@@ -3,7 +3,7 @@ title: Kubernetes Components
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/pages-for-subheaders/kubernetes-components"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components"/>
 </head>
 
 The commands and steps listed in this section apply to the core Kubernetes components on [Rancher Launched Kubernetes](../../how-to-guides/new-user-guides/launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md) clusters.


### PR DESCRIPTION
## Description

This PR addresses the outdated canonical links as a result of the restructuring done to address https://github.com/rancher/rancher-docs/issues/635 (and other missed canonical links since they were last updated).