### PR TITLE
Update Body Text/Heading - Rancher backup-restore-operator Default Storage Location

### DIFF
--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
@@ -91,7 +91,7 @@ A migration is performed by following [these steps.](migrate-rancher-to-new-clus
 
 ## Default Storage Location Configuration
 
-Configure a storage location where all backups are saved by default. Various configuration options are available, including specifying an S3-compatible object store as the location for individual backups or choosing an existing `StorageClass` during installation of the `backup-restore-operator` helm chart. You will also have the option to override the configured storage location with each backup, but will be limited to using an S3-compatible or Minio object store.
+Configure a default storage location for your backups. There are various configuration options, such as specifying an S3-compatible object store as the location for individual backups or choosing an existing `StorageClass` during installation of the `backup-restore-operator` Helm chart. You also have the option to override the configured storage location with each backup, but are limited to using an S3-compatible or Minio object store.
 
 For information on configuring these options, refer to [this page.](../../../reference-guides/backup-restore-configuration/storage-configuration.md)
 

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
@@ -91,10 +91,10 @@ A migration is performed by following [these steps.](migrate-rancher-to-new-clus
 
 ## Default Storage Location Configuration
 
-Configure a storage location where all backups are saved by default. You will have the option to override this with each backup, but will be limited to using an S3-compatible or Minio object store.
+Configure a storage location where all backups are saved by default. Various configuration options are available, including specifying an S3-compatible object store as the location for individual backups or choosing an existing `StorageClass` during installation of the `backup-restore-operator` helm chart. You will also have the option to override the configured storage location with each backup, but will be limited to using an S3-compatible or Minio object store.
 
 For information on configuring these options, refer to [this page.](../../../reference-guides/backup-restore-configuration/storage-configuration.md)
 
-### Example values.yaml for the rancher-backup Helm Chart
+### Example YAML File: Rancher Backup Helm Chart
 
-The example [values.yaml file](../../../reference-guides/backup-restore-configuration/storage-configuration.md#example-valuesyaml-for-the-rancher-backup-helm-chart) can be used to configure the `rancher-backup` operator when the Helm CLI is used to install it.
+The example [values.yaml file](../../../reference-guides/backup-restore-configuration/storage-configuration.md#example-valuesyaml-for-the-rancher-backup-helm-chart) can be used to configure the `backup-restore-operator` when the Helm CLI is used to install it.

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
@@ -97,4 +97,4 @@ For information on configuring these options, refer to [this page.](../../../ref
 
 ### Example YAML File: Rancher Backup Helm Chart
 
-The example [values.yaml file](../../../reference-guides/backup-restore-configuration/storage-configuration.md#example-valuesyaml-for-the-rancher-backup-helm-chart) can be used to configure the `backup-restore-operator` when the Helm CLI is used to install it.
+The example [values.yaml file](../../../reference-guides/backup-restore-configuration/storage-configuration.md#example-yaml-file-rancher-backup-helm-chart) can be used to configure the `backup-restore-operator` when the Helm CLI is used to install it.

--- a/docs/reference-guides/backup-restore-configuration/storage-configuration.md
+++ b/docs/reference-guides/backup-restore-configuration/storage-configuration.md
@@ -52,9 +52,8 @@ It is highly recommended to use a Persistent Volume with a reclaim policy of "Re
 
 :::
 
-## Example values.yaml for the rancher-backup Helm Chart
+## Example YAML File: Rancher Backup Helm Chart
 
-The documented `values.yaml` file that can be used to configure `rancher-backup` operator when the Helm CLI is used can be found in the [backup-restore-operator repository.](https://github.com/rancher/backup-restore-operator/blob/master/charts/rancher-backup/values.yaml)
+The documented `values.yaml` file that can be used to configure the `backup-restore-operator` when the Helm CLI is used can be found in the [backup-restore-operator repository.](https://github.com/rancher/backup-restore-operator/blob/master/charts/rancher-backup/values.yaml)
 
 For more information about `values.yaml` files and configuring Helm charts during installation, refer to the [Helm documentation.](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing)
-

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
@@ -91,7 +91,7 @@ A migration is performed by following [these steps.](migrate-rancher-to-new-clus
 
 ## Default Storage Location Configuration
 
-Configure a storage location where all backups are saved by default. Various configuration options are available, including specifying an S3-compatible object store as the location for individual backups or choosing an existing `StorageClass` during installation of the `backup-restore-operator` helm chart. You will also have the option to override the configured storage location with each backup, but will be limited to using an S3-compatible or Minio object store.
+Configure a default storage location for your backups. There are various configuration options, such as specifying an S3-compatible object store as the location for individual backups or choosing an existing `StorageClass` during installation of the `backup-restore-operator` Helm chart. You also have the option to override the configured storage location with each backup, but are limited to using an S3-compatible or Minio object store.
 
 For information on configuring these options, refer to [this page.](../../../reference-guides/backup-restore-configuration/storage-configuration.md)
 

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
@@ -91,10 +91,10 @@ A migration is performed by following [these steps.](migrate-rancher-to-new-clus
 
 ## Default Storage Location Configuration
 
-Configure a storage location where all backups are saved by default. You will have the option to override this with each backup, but will be limited to using an S3-compatible or Minio object store.
+Configure a storage location where all backups are saved by default. Various configuration options are available, including specifying an S3-compatible object store as the location for individual backups or choosing an existing `StorageClass` during installation of the `backup-restore-operator` helm chart. You will also have the option to override the configured storage location with each backup, but will be limited to using an S3-compatible or Minio object store.
 
 For information on configuring these options, refer to [this page.](../../../reference-guides/backup-restore-configuration/storage-configuration.md)
 
-### Example values.yaml for the rancher-backup Helm Chart
+### Example YAML File: Rancher Backup Helm Chart
 
-The example [values.yaml file](../../../reference-guides/backup-restore-configuration/storage-configuration.md#example-valuesyaml-for-the-rancher-backup-helm-chart) can be used to configure the `rancher-backup` operator when the Helm CLI is used to install it.
+The example [values.yaml file](../../../reference-guides/backup-restore-configuration/storage-configuration.md#example-valuesyaml-for-the-rancher-backup-helm-chart) can be used to configure the `backup-restore-operator` when the Helm CLI is used to install it.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
@@ -97,4 +97,4 @@ For information on configuring these options, refer to [this page.](../../../ref
 
 ### Example YAML File: Rancher Backup Helm Chart
 
-The example [values.yaml file](../../../reference-guides/backup-restore-configuration/storage-configuration.md#example-valuesyaml-for-the-rancher-backup-helm-chart) can be used to configure the `backup-restore-operator` when the Helm CLI is used to install it.
+The example [values.yaml file](../../../reference-guides/backup-restore-configuration/storage-configuration.md#example-yaml-file-rancher-backup-helm-chart) can be used to configure the `backup-restore-operator` when the Helm CLI is used to install it.

--- a/versioned_docs/version-2.7/reference-guides/backup-restore-configuration/storage-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/backup-restore-configuration/storage-configuration.md
@@ -52,9 +52,8 @@ It is highly recommended to use a Persistent Volume with a reclaim policy of "Re
 
 :::
 
-## Example values.yaml for the rancher-backup Helm Chart
+## Example YAML File: Rancher Backup Helm Chart
 
-The documented `values.yaml` file that can be used to configure `rancher-backup` operator when the Helm CLI is used can be found in the [backup-restore-operator repository.](https://github.com/rancher/backup-restore-operator/blob/master/charts/rancher-backup/values.yaml)
+The documented `values.yaml` file that can be used to configure the `backup-restore-operator` when the Helm CLI is used can be found in the [backup-restore-operator repository.](https://github.com/rancher/backup-restore-operator/blob/master/charts/rancher-backup/values.yaml)
 
 For more information about `values.yaml` files and configuring Helm charts during installation, refer to the [Helm documentation.](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing)
-

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
@@ -91,7 +91,7 @@ A migration is performed by following [these steps.](migrate-rancher-to-new-clus
 
 ## Default Storage Location Configuration
 
-Configure a storage location where all backups are saved by default. Various configuration options are available, including specifying an S3-compatible object store as the location for individual backups or choosing an existing `StorageClass` during installation of the `backup-restore-operator` helm chart. You will also have the option to override the configured storage location with each backup, but will be limited to using an S3-compatible or Minio object store.
+Configure a default storage location for your backups. There are various configuration options, such as specifying an S3-compatible object store as the location for individual backups or choosing an existing `StorageClass` during installation of the `backup-restore-operator` Helm chart. You also have the option to override the configured storage location with each backup, but are limited to using an S3-compatible or Minio object store.
 
 For information on configuring these options, refer to [this page.](../../../reference-guides/backup-restore-configuration/storage-configuration.md)
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
@@ -91,10 +91,10 @@ A migration is performed by following [these steps.](migrate-rancher-to-new-clus
 
 ## Default Storage Location Configuration
 
-Configure a storage location where all backups are saved by default. You will have the option to override this with each backup, but will be limited to using an S3-compatible or Minio object store.
+Configure a storage location where all backups are saved by default. Various configuration options are available, including specifying an S3-compatible object store as the location for individual backups or choosing an existing `StorageClass` during installation of the `backup-restore-operator` helm chart. You will also have the option to override the configured storage location with each backup, but will be limited to using an S3-compatible or Minio object store.
 
 For information on configuring these options, refer to [this page.](../../../reference-guides/backup-restore-configuration/storage-configuration.md)
 
-### Example values.yaml for the rancher-backup Helm Chart
+### Example YAML File: Rancher Backup Helm Chart
 
-The example [values.yaml file](../../../reference-guides/backup-restore-configuration/storage-configuration.md#example-valuesyaml-for-the-rancher-backup-helm-chart) can be used to configure the `rancher-backup` operator when the Helm CLI is used to install it.
+The example [values.yaml file](../../../reference-guides/backup-restore-configuration/storage-configuration.md#example-valuesyaml-for-the-rancher-backup-helm-chart) can be used to configure the `backup-restore-operator` when the Helm CLI is used to install it.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery.md
@@ -97,4 +97,4 @@ For information on configuring these options, refer to [this page.](../../../ref
 
 ### Example YAML File: Rancher Backup Helm Chart
 
-The example [values.yaml file](../../../reference-guides/backup-restore-configuration/storage-configuration.md#example-valuesyaml-for-the-rancher-backup-helm-chart) can be used to configure the `backup-restore-operator` when the Helm CLI is used to install it.
+The example [values.yaml file](../../../reference-guides/backup-restore-configuration/storage-configuration.md#example-yaml-file-rancher-backup-helm-chart) can be used to configure the `backup-restore-operator` when the Helm CLI is used to install it.

--- a/versioned_docs/version-2.8/reference-guides/backup-restore-configuration/storage-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/backup-restore-configuration/storage-configuration.md
@@ -52,9 +52,8 @@ It is highly recommended to use a Persistent Volume with a reclaim policy of "Re
 
 :::
 
-## Example values.yaml for the rancher-backup Helm Chart
+## Example YAML File: Rancher Backup Helm Chart
 
-The documented `values.yaml` file that can be used to configure `rancher-backup` operator when the Helm CLI is used can be found in the [backup-restore-operator repository.](https://github.com/rancher/backup-restore-operator/blob/master/charts/rancher-backup/values.yaml)
+The documented `values.yaml` file that can be used to configure the `backup-restore-operator` when the Helm CLI is used can be found in the [backup-restore-operator repository.](https://github.com/rancher/backup-restore-operator/blob/master/charts/rancher-backup/values.yaml)
 
 For more information about `values.yaml` files and configuring Helm charts during installation, refer to the [Helm documentation.](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing)
-


### PR DESCRIPTION
## Description

Updating the default storage location body text to better describe options for configuring the location in the [Rancher How-To](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery#default-storage-location-configuration) section, and revising the heading/term for the Rancher backup-restore-operator Helm chart in both the How-To and Reference pages to add a bit of clarification.

Storage location configuration reference page: https://ranchermanager.docs.rancher.com/reference-guides/backup-restore-configuration/storage-configuration

Related to and fixes https://github.com/rancher/rancher-docs/issues/1037.