### PR TITLE
Add missing frail flag

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Check Markdown links
-        run: yarn run remark --quiet --use remark-validate-links ./docs
+        run: yarn run remark --quiet --frail --use remark-validate-links ./docs
       - name: Check External links
         run: yarn run remark --quiet --use remark-lint-no-dead-urls ./docs
       - name: Test build website


### PR DESCRIPTION
## Description

Frail mode was intended to be enabled as part of https://github.com/rancher/rancher-docs/pull/1056/files, but was missed. This adds it back.