### PR TITLE
#1108 Migrating Rancher to a new cluster lists old chart version

### DIFF
--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -28,7 +28,7 @@ Since Rancher can be installed on any Kubernetes cluster, you can use this backu
 
 ### 1. Install the rancher-backup Helm chart
 
-Install the [rancher-backup chart](https://github.com/rancher/backup-restore-operator/tags), using a version in the 100.x.x major version range:
+Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-operator/tags):
 
   1. Add the Helm repository:
 
@@ -37,11 +37,11 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
      helm repo update
      ```
 
-  1. Select and set `CHART_VERSION` variable with a 100.x.x rancher-backup release version:
+  1. Set a `CHART_VERSION` variable, selecting a `rancher-backup` chart version compatible with your version of Rancher. See the [support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions), within the **Rancher Apps / Cluster Tools** section, to see which `rancher-backup` versions are supported:
 
      ```bash
      helm search repo --versions rancher-charts/rancher-backup
-     CHART_VERSION=<100.x.x>
+     CHART_VERSION=<x.x.x>
      ```
 
   1. Install the charts:

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -40,7 +40,7 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
   1. Set a `CHART_VERSION` variable, selecting a `rancher-backup` chart version compatible with your version of Rancher. See the [support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions), within the **Rancher Apps / Cluster Tools** section, to see which `rancher-backup` versions are supported:
 
      ```bash
-     CHART_VERSION=<x.x.x>
+     CHART_VERSION=<chart-version>
      ```
 
   1. Install the charts:

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -40,7 +40,6 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
   1. Set a `CHART_VERSION` variable, selecting a `rancher-backup` chart version compatible with your version of Rancher. See the [support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions), within the **Rancher Apps / Cluster Tools** section, to see which `rancher-backup` versions are supported:
 
      ```bash
-     helm search repo --versions rancher-charts/rancher-backup
      CHART_VERSION=<x.x.x>
      ```
 

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -27,7 +27,8 @@ Since Rancher can be installed on any Kubernetes cluster, you can use this backu
 
 
 ### 1. Install the rancher-backup Helm chart
-Install the [rancher-backup chart](https://github.com/rancher/backup-restore-operator/tags), using a version in the 2.x.x major version range:
+
+Install the [rancher-backup chart](https://github.com/rancher/backup-restore-operator/tags), using a version in the 100.x.x major version range:
 
   1. Add the Helm repository:
 
@@ -36,13 +37,15 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
      helm repo update
      ```
 
-  1. Select and set `CHART_VERSION` variable with a 2.x.x rancher-backup release version:
+  1. Select and set `CHART_VERSION` variable with a 100.x.x rancher-backup release version:
+
      ```bash
      helm search repo --versions rancher-charts/rancher-backup
-     CHART_VERSION=<2.x.x>
+     CHART_VERSION=<100.x.x>
      ```
 
   1. Install the charts:
+   
      ```bash
      helm install rancher-backup-crd rancher-charts/rancher-backup-crd -n cattle-resources-system --create-namespace --version $CHART_VERSION
      helm install rancher-backup rancher-charts/rancher-backup -n cattle-resources-system --version $CHART_VERSION
@@ -50,7 +53,7 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
 
      :::note
 
-     The above assumes an environment with outbound connectivity to Docker Hub
+     The above assumes an environment with outbound connectivity to Docker Hub.
 
      For an **air-gapped environment**, use the Helm value below to pull the `backup-restore-operator` image from your private registry when installing the rancher-backup Helm chart.
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -26,7 +26,7 @@ Since Rancher can be installed on any Kubernetes cluster, you can use this backu
 
 ### 1. Install the rancher-backup Helm chart
 
-Install the [rancher-backup chart](https://github.com/rancher/backup-restore-operator/tags), using a version in the 2.x.x major version range:
+Install the [rancher-backup chart](https://github.com/rancher/backup-restore-operator/tags):
 
   1. Add the Helm repository:
 
@@ -35,11 +35,11 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
      helm repo update
      ```
 
-  1. Select and set `CHART_VERSION` variable with a 100.x.x rancher-backup release version:
+  1. Select and set a `CHART_VERSION` variable with a rancher-backup release version compatible with your version of Rancher. See the [support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions), within the **Rancher Apps / Cluster Tools** section, to see which rancher-backup release versions are supported:
 
      ```bash
      helm search repo --versions rancher-charts/rancher-backup
-     CHART_VERSION=<2.x.x>
+     CHART_VERSION=<x.x.x>
      ```
 
   1. Install the charts:

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -38,7 +38,7 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
   1. Set a `CHART_VERSION` variable, selecting a `rancher-backup` chart version compatible with your version of Rancher. See the [support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions), within the **Rancher Apps / Cluster Tools** section, to see which `rancher-backup` versions are supported:
 
      ```bash
-     CHART_VERSION=<x.x.x>
+     CHART_VERSION=<chart-version>
      ```
 
   1. Install the charts:

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -26,7 +26,7 @@ Since Rancher can be installed on any Kubernetes cluster, you can use this backu
 
 ### 1. Install the rancher-backup Helm chart
 
-Install the [rancher-backup chart](https://github.com/rancher/backup-restore-operator/tags):
+Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-operator/tags):
 
   1. Add the Helm repository:
 
@@ -35,7 +35,7 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
      helm repo update
      ```
 
-  1. Select and set a `CHART_VERSION` variable with a rancher-backup release version compatible with your version of Rancher. See the [support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions), within the **Rancher Apps / Cluster Tools** section, to see which rancher-backup release versions are supported:
+  1. Set a `CHART_VERSION` variable, selecting a `rancher-backup` chart version compatible with your version of Rancher. See the [support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions), within the **Rancher Apps / Cluster Tools** section, to see which `rancher-backup` versions are supported:
 
      ```bash
      helm search repo --versions rancher-charts/rancher-backup

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -26,7 +26,7 @@ Since Rancher can be installed on any Kubernetes cluster, you can use this backu
 
 ### 1. Install the rancher-backup Helm chart
 
-Install the [rancher-backup chart](https://github.com/rancher/backup-restore-operator/tags), using a version in the 100.x.x major version range:
+Install the [rancher-backup chart](https://github.com/rancher/backup-restore-operator/tags), using a version in the 2.x.x major version range:
 
   1. Add the Helm repository:
 
@@ -39,7 +39,7 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
 
      ```bash
      helm search repo --versions rancher-charts/rancher-backup
-     CHART_VERSION=<100.x.x>
+     CHART_VERSION=<2.x.x>
      ```
 
   1. Install the charts:

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -38,7 +38,6 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
   1. Set a `CHART_VERSION` variable, selecting a `rancher-backup` chart version compatible with your version of Rancher. See the [support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions), within the **Rancher Apps / Cluster Tools** section, to see which `rancher-backup` versions are supported:
 
      ```bash
-     helm search repo --versions rancher-charts/rancher-backup
      CHART_VERSION=<x.x.x>
      ```
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -25,7 +25,8 @@ Rancher can be installed on any Kubernetes cluster, including hosted Kubernetes 
 Since Rancher can be installed on any Kubernetes cluster, you can use this backup and restore method to migrate Rancher from one Kubernetes cluster to any other Kubernetes cluster. This method *only* migrates Rancher-related resources and won't affect other applications on the cluster. Refer to the [support matrix](https://www.suse.com/lifecycle/) to identify which Kubernetes cluster types and versions are supported for your Rancher version.
 
 ### 1. Install the rancher-backup Helm chart
-Install the [rancher-backup chart](https://github.com/rancher/backup-restore-operator/tags), using a version in the 2.x.x major version range:
+
+Install the [rancher-backup chart](https://github.com/rancher/backup-restore-operator/tags), using a version in the 100.x.x major version range:
 
   1. Add the Helm repository:
 
@@ -34,13 +35,15 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
      helm repo update
      ```
 
-  1. Select and set `CHART_VERSION` variable with a 2.x.x rancher-backup release version:
+  1. Select and set `CHART_VERSION` variable with a 100.x.x rancher-backup release version:
+
      ```bash
      helm search repo --versions rancher-charts/rancher-backup
-     CHART_VERSION=<2.x.x>
+     CHART_VERSION=<100.x.x>
      ```
 
   1. Install the charts:
+   
      ```bash
      helm install rancher-backup-crd rancher-charts/rancher-backup-crd -n cattle-resources-system --create-namespace --version $CHART_VERSION
      helm install rancher-backup rancher-charts/rancher-backup -n cattle-resources-system --version $CHART_VERSION
@@ -48,7 +51,7 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
 
      :::note
 
-     The above assumes an environment with outbound connectivity to Docker Hub
+     The above assumes an environment with outbound connectivity to Docker Hub.
 
      For an **air-gapped environment**, use the Helm value below to pull the `backup-restore-operator` image from your private registry when installing the rancher-backup Helm chart.
 

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -28,7 +28,7 @@ Since Rancher can be installed on any Kubernetes cluster, you can use this backu
 
 ### 1. Install the rancher-backup Helm chart
 
-Install the [rancher-backup chart](https://github.com/rancher/backup-restore-operator/tags), using a version in the 100.x.x major version range:
+Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-operator/tags):
 
   1. Add the Helm repository:
 
@@ -37,11 +37,11 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
      helm repo update
      ```
 
-  1. Select and set `CHART_VERSION` variable with a 100.x.x rancher-backup release version:
+  1. Set a `CHART_VERSION` variable, selecting a `rancher-backup` chart version compatible with your version of Rancher. See the [support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions), within the **Rancher Apps / Cluster Tools** section, to see which `rancher-backup` versions are supported:
 
      ```bash
      helm search repo --versions rancher-charts/rancher-backup
-     CHART_VERSION=<100.x.x>
+     CHART_VERSION=<x.x.x>
      ```
 
   1. Install the charts:

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -40,7 +40,7 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
   1. Set a `CHART_VERSION` variable, selecting a `rancher-backup` chart version compatible with your version of Rancher. See the [support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions), within the **Rancher Apps / Cluster Tools** section, to see which `rancher-backup` versions are supported:
 
      ```bash
-     CHART_VERSION=<x.x.x>
+     CHART_VERSION=<chart-version>
      ```
 
   1. Install the charts:

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -40,7 +40,6 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
   1. Set a `CHART_VERSION` variable, selecting a `rancher-backup` chart version compatible with your version of Rancher. See the [support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions), within the **Rancher Apps / Cluster Tools** section, to see which `rancher-backup` versions are supported:
 
      ```bash
-     helm search repo --versions rancher-charts/rancher-backup
      CHART_VERSION=<x.x.x>
      ```
 

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -27,7 +27,8 @@ Since Rancher can be installed on any Kubernetes cluster, you can use this backu
 
 
 ### 1. Install the rancher-backup Helm chart
-Install the [rancher-backup chart](https://github.com/rancher/backup-restore-operator/tags), using a version in the 2.x.x major version range:
+
+Install the [rancher-backup chart](https://github.com/rancher/backup-restore-operator/tags), using a version in the 100.x.x major version range:
 
   1. Add the Helm repository:
 
@@ -36,13 +37,15 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
      helm repo update
      ```
 
-  1. Select and set `CHART_VERSION` variable with a 2.x.x rancher-backup release version:
+  1. Select and set `CHART_VERSION` variable with a 100.x.x rancher-backup release version:
+
      ```bash
      helm search repo --versions rancher-charts/rancher-backup
-     CHART_VERSION=<2.x.x>
+     CHART_VERSION=<100.x.x>
      ```
 
   1. Install the charts:
+   
      ```bash
      helm install rancher-backup-crd rancher-charts/rancher-backup-crd -n cattle-resources-system --create-namespace --version $CHART_VERSION
      helm install rancher-backup rancher-charts/rancher-backup -n cattle-resources-system --version $CHART_VERSION
@@ -50,7 +53,7 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
 
      :::note
 
-     The above assumes an environment with outbound connectivity to Docker Hub
+     The above assumes an environment with outbound connectivity to Docker Hub.
 
      For an **air-gapped environment**, use the Helm value below to pull the `backup-restore-operator` image from your private registry when installing the rancher-backup Helm chart.
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -28,7 +28,7 @@ Since Rancher can be installed on any Kubernetes cluster, you can use this backu
 
 ### 1. Install the rancher-backup Helm chart
 
-Install the [rancher-backup chart](https://github.com/rancher/backup-restore-operator/tags), using a version in the 100.x.x major version range:
+Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-operator/tags):
 
   1. Add the Helm repository:
 
@@ -37,11 +37,11 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
      helm repo update
      ```
 
-  1. Select and set `CHART_VERSION` variable with a 100.x.x rancher-backup release version:
+  1. Set a `CHART_VERSION` variable, selecting a `rancher-backup` chart version compatible with your version of Rancher. See the [support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions), within the **Rancher Apps / Cluster Tools** section, to see which `rancher-backup` versions are supported:
 
      ```bash
      helm search repo --versions rancher-charts/rancher-backup
-     CHART_VERSION=<100.x.x>
+     CHART_VERSION=<x.x.x>
      ```
 
   1. Install the charts:

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -40,7 +40,7 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
   1. Set a `CHART_VERSION` variable, selecting a `rancher-backup` chart version compatible with your version of Rancher. See the [support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions), within the **Rancher Apps / Cluster Tools** section, to see which `rancher-backup` versions are supported:
 
      ```bash
-     CHART_VERSION=<x.x.x>
+     CHART_VERSION=<chart-version>
      ```
 
   1. Install the charts:

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -40,7 +40,6 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
   1. Set a `CHART_VERSION` variable, selecting a `rancher-backup` chart version compatible with your version of Rancher. See the [support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions), within the **Rancher Apps / Cluster Tools** section, to see which `rancher-backup` versions are supported:
 
      ```bash
-     helm search repo --versions rancher-charts/rancher-backup
      CHART_VERSION=<x.x.x>
      ```
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -27,7 +27,8 @@ Since Rancher can be installed on any Kubernetes cluster, you can use this backu
 
 
 ### 1. Install the rancher-backup Helm chart
-Install the [rancher-backup chart](https://github.com/rancher/backup-restore-operator/tags), using a version in the 2.x.x major version range:
+
+Install the [rancher-backup chart](https://github.com/rancher/backup-restore-operator/tags), using a version in the 100.x.x major version range:
 
   1. Add the Helm repository:
 
@@ -36,13 +37,15 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
      helm repo update
      ```
 
-  1. Select and set `CHART_VERSION` variable with a 2.x.x rancher-backup release version:
+  1. Select and set `CHART_VERSION` variable with a 100.x.x rancher-backup release version:
+
      ```bash
      helm search repo --versions rancher-charts/rancher-backup
-     CHART_VERSION=<2.x.x>
+     CHART_VERSION=<100.x.x>
      ```
 
   1. Install the charts:
+   
      ```bash
      helm install rancher-backup-crd rancher-charts/rancher-backup-crd -n cattle-resources-system --create-namespace --version $CHART_VERSION
      helm install rancher-backup rancher-charts/rancher-backup -n cattle-resources-system --version $CHART_VERSION
@@ -50,7 +53,7 @@ Install the [rancher-backup chart](https://github.com/rancher/backup-restore-ope
 
      :::note
 
-     The above assumes an environment with outbound connectivity to Docker Hub
+     The above assumes an environment with outbound connectivity to Docker Hub.
 
      For an **air-gapped environment**, use the Helm value below to pull the `backup-restore-operator` image from your private registry when installing the rancher-backup Helm chart.
 


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #1108

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

From a contributor:

> 2.x.x is old and latest is 103.0.0+up4.0.0. Assuming latest should be used, the docs need to be updated to reflect this.

Initially edited to reflect this suggestion, then thought better of it, and linked users to the support matrix. I removed the specific mention of version numbers because that is going to continuously change. 

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->

I did some investigating to confirm. From our release notes:

> Rancher Helm Chart Versions
> Starting in 2.6.0, many of the Rancher Helm charts available in the Apps & Marketplace will start with a major version of 100. This was done to avoid simultaneous upstream changes and Rancher changes from causing conflicting version increments. This also brings us into compliance with semver, which is a requirement for newer versions of Helm. You can now see the upstream version of a chart in the build metadata, for example: 100.0.0+up2.1.0. See https://github.com/rancher/rancher/issues/32294.

The issue the release notes link to is from 2021 -- and specifically notes that rancher-backup wasn't included in the updated numbering system: https://github.com/rancher/rancher/issues/32294#issuecomment-906006333

However, at some point **after** 2021, this was changed, and this is confirmed both by the [support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-8-1/) and by running `helm search repo --versions rancher-charts/rancher-backup` to view available versions. 

Note that the [support matrix for v2.6](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-6-13/) states that **the latest version of v2.6 is still using backup charts in the 2.x.x line**.

<s>Creating as a draft as I still need to add some lines about how the user can refer to the support matrix to confirm compatibility with their version of Rancher.</s>