### PR TITLE
#991 Update AWS info about setting up cloud provider

### DIFF
--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/migrate-to-an-out-of-tree-cloud-provider/migrate-to-out-of-tree-amazon.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/migrate-to-an-out-of-tree-cloud-provider/migrate-to-out-of-tree-amazon.md
@@ -12,7 +12,7 @@ You can migrate from an in-tree to an out-of-tree AWS cloud provider on Kubernet
 
 To migrate from the in-tree cloud provider to the out-of-tree AWS cloud provider, you must stop the existing cluster's kube controller manager and install the AWS cloud controller manager. There are many ways to do this. Refer to the official AWS documentation on the [external cloud controller manager](https://cloud-provider-aws.sigs.k8s.io/getting_started/) for details.
 
-If it's acceptable to have some downtime, you can [switch to an external cloud provider](../set-up-cloud-providers/amazon.md#using-the-out-of-tree-aws-cloud-provider), which removes in-tree components and then deploy charts to install the AWS cloud controller manager.
+If it's acceptable to have some downtime during migration, follow the instructions to [set up an external cloud provider](../set-up-cloud-providers/amazon.md#using-the-out-of-tree-aws-cloud-provider). These instructions outline how to configure the out-of-tree cloud provider for a newly provisioned cluster. During set up, there will be some downtime, as there is a time gap between when the old cloud provider stops running and when the new cloud provider starts to run.
 
 If your setup can't tolerate any control plane downtime, you must enable leader migration. This facilitates a smooth transition from the controllers in the kube controller manager to their counterparts in the cloud controller manager. Refer to the official AWS documentation on [Using leader migration](https://cloud-provider-aws.sigs.k8s.io/getting_started/) for more details.
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/migrate-to-an-out-of-tree-cloud-provider/migrate-to-out-of-tree-amazon.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/migrate-to-an-out-of-tree-cloud-provider/migrate-to-out-of-tree-amazon.md
@@ -12,7 +12,7 @@ You can migrate from an in-tree to an out-of-tree AWS cloud provider on Kubernet
 
 To migrate from the in-tree cloud provider to the out-of-tree AWS cloud provider, you must stop the existing cluster's kube controller manager and install the AWS cloud controller manager. There are many ways to do this. Refer to the official AWS documentation on the [external cloud controller manager](https://cloud-provider-aws.sigs.k8s.io/getting_started/) for details.
 
-If it's acceptable to have some downtime, you can [switch to an external cloud provider](../set-up-cloud-providers/amazon.md#using-the-out-of-tree-aws-cloud-provider), which removes in-tree components and then deploy charts to install the AWS cloud controller manager.
+If it's acceptable to have some downtime during migration, follow the instructions to [set up an external cloud provider](../set-up-cloud-providers/amazon.md#using-the-out-of-tree-aws-cloud-provider). These instructions outline how to configure the out-of-tree cloud provider for a newly provisioned cluster. During set up, there will be some downtime, as there is a time gap between when the old cloud provider stops running and when the new cloud provider starts to run.
 
 If your setup can't tolerate any control plane downtime, you must enable leader migration. This facilitates a smooth transition from the controllers in the kube controller manager to their counterparts in the cloud controller manager. Refer to the official AWS documentation on [Using leader migration](https://cloud-provider-aws.sigs.k8s.io/getting_started/) for more details.
 


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Related to #991 

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

https://github.com/rancher/rancher-docs/issues/991#issuecomment-1927832781

From Slack:

> AWS cloud provider docs are definitely looking better than the state I left them in so I thank you for that, I do have a suggestion though. On [https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in[…]-of-tree-cloud-provider/migrate-to-out-of-tree-amazon](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/migrate-to-an-out-of-tree-cloud-provider/migrate-to-out-of-tree-amazon), the following line:

>> If it's acceptable to have some downtime, you can [switch to an external cloud provider](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon#using-the-out-of-tree-aws-cloud-provider), which removes in-tree components and then deploy charts to install the AWS cloud controller manager.

> reads like it's optional. I think I wrote it initially but now that I'm looking at it with fresh eyes, it doesn't really make sense. The link is for setting up the external cloud-provider on a fresh cluster, so I feel like the sentence should read something like:

>> If it's acceptable to have some downtime during migration, you can follow the [cluster external amazon cloud provider documentation](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon#using-the-out-of-tree-aws-cloud-provider) which outlines how to configure the out of tree provider for a newly provisioned cluster. There will be a period where specific cloud-provider functionality is unavailable within your cluster, as there will effectively be no cloud-provider running until the out of tree provider is functional.

> Or something to that effect.
In addition, it kind of makes it seem like the only thing needed is to enable leader-migration, but that doesn't really make sense in this context because one would still need to follow all the RKE2 steps from [https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon#usin[…]ider](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon#using-the-out-of-tree-aws-cloud-provider). Not suggesting anything specifically, I'm fine if we just duplicate the docs to the migration page or if we link and say "here is what must be done before", then link to the steps, and then "here is what must be done afterwards" or something. WDYT?

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->