### PR TITLE
docs: edit custom launch template updates for eks

### DIFF
--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/eks-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/eks-cluster-configuration.md
@@ -101,6 +101,13 @@ Also, if you provide the launch template, you can only update the template versi
 | User Data | Cloud init script in [MIME multi-part format](https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html#launch-template-user-data) | Optional |
 | Instance Resource Tags | Tag each EC2 instance and its volumes in the node group | Optional |
 
+:::caution
+
+You can't directly update a node group to a newer Kubernetes version if the node group was created from a custom launch template. You must create a new launch template with the proper Kubernetes version, and associate the node group with the new template.
+
+:::
+
+
 #### Rancher-managed Launch Templates
 
 If you do not specify a launch template, then you will be able to configure the above options in the Rancher UI and all of them can be updated after creation. In order to take advantage of all of these options, Rancher will create and manage a launch template for you. Each cluster in Rancher will have one Rancher-managed launch template and each managed node group that does not have a specified launch template will have one version of the managed launch template. The name of this launch template will have the prefix "rancher-managed-lt-" followed by the display name of the cluster. In addition, the Rancher-managed launch template will be tagged with the key "rancher-managed-template" and value "do-not-modify-or-delete" to help identify it as Rancher-managed. It is important that this launch template and its versions not be modified, deleted, or used with any other clusters or managed node groups. Doing so could result in your node groups being "degraded" and needing to be destroyed and recreated.

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/eks-cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/eks-cluster-configuration.md
@@ -101,6 +101,12 @@ Also, if you provide the launch template, you can only update the template versi
 | User Data | Cloud init script in [MIME multi-part format](https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html#launch-template-user-data) | Optional |
 | Instance Resource Tags | Tag each EC2 instance and its volumes in the node group | Optional |
 
+:::caution
+
+You can't directly update a node group to a newer Kubernetes version if the node group was created from a custom launch template. You must create a new launch template with the proper Kubernetes version, and associate the node group with the new template.
+
+:::
+
 #### Rancher-managed Launch Templates
 
 If you do not specify a launch template, then you will be able to configure the above options in the Rancher UI and all of them can be updated after creation. In order to take advantage of all of these options, Rancher will create and manage a launch template for you. Each cluster in Rancher will have one Rancher-managed launch template and each managed node group that does not have a specified launch template will have one version of the managed launch template. The name of this launch template will have the prefix "rancher-managed-lt-" followed by the display name of the cluster. In addition, the Rancher-managed launch template will be tagged with the key "rancher-managed-template" and value "do-not-modify-or-delete" to help identify it as Rancher-managed. It is important that this launch template and its versions not be modified, deleted, or used with any other clusters or managed node groups. Doing so could result in your node groups being "degraded" and needing to be destroyed and recreated.

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/eks-cluster-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/eks-cluster-configuration.md
@@ -101,6 +101,12 @@ Also, if you provide the launch template, you can only update the template versi
 | User Data | Cloud init script in [MIME multi-part format](https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html#launch-template-user-data) | Optional |
 | Instance Resource Tags | Tag each EC2 instance and its volumes in the node group | Optional |
 
+:::caution
+
+You can't directly update a node group to a newer Kubernetes version if the node group was created from a custom launch template. You must create a new launch template with the proper Kubernetes version, and associate the node group with the new template.
+
+:::
+
 #### Rancher-managed Launch Templates
 
 If you do not specify a launch template, then you will be able to configure the above options in the Rancher UI and all of them can be updated after creation. In order to take advantage of all of these options, Rancher will create and manage a launch template for you. Each cluster in Rancher will have one Rancher-managed launch template and each managed node group that does not have a specified launch template will have one version of the managed launch template. The name of this launch template will have the prefix "rancher-managed-lt-" followed by the display name of the cluster. In addition, the Rancher-managed launch template will be tagged with the key "rancher-managed-template" and value "do-not-modify-or-delete" to help identify it as Rancher-managed. It is important that this launch template and its versions not be modified, deleted, or used with any other clusters or managed node groups. Doing so could result in your node groups being "degraded" and needing to be destroyed and recreated.


### PR DESCRIPTION
Fixes #1110 

## Description

This edit affects documentation on https://github.com/rancher/eks-operator.

From `rancher:v2.7` onward, we specify that node groups created using a user-provided launch template can upgrade their k8s version only by creating a new launch template and then associating this new version with the node group.

## Comments

- This is a requirement from AWS EKS, you can read more about this [here](https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html).
- Rancher `eks-operator` was updated to align with this requirement [here](https://github.com/rancher/eks-operator/pull/186).