### PR TITLE
update monitoring node-exporter ports

### DIFF
--- a/docs/shared-files/_common-ports-table.md
+++ b/docs/shared-files/_common-ports-table.md
@@ -1,19 +1,18 @@
-| Protocol 	|       Port       	| Description                                     	                                |
-|:--------:	|:----------------:	|----------------------------------------------------------------------------------	|
-|    TCP   	|         22      	| Node driver SSH provisioning                    	                                |
-|    TCP    |        179        | Calico BGP Port                                                                   |
-|    TCP   	|       2376       	| Node driver Docker daemon TLS port              	                                |
-|    TCP   	|       2379       	| etcd client requests                           	                                |
-|    TCP   	|       2380       	| etcd peer communication                         	                                |
-|    UDP   	|       8472       	| Canal/Flannel VXLAN overlay networking          	                                |
-|    UDP   	|       4789       	| Flannel VXLAN overlay networking on Windows cluster                               |
-|    TCP   	|       8443       	| Rancher webhook                                                                   |
-|    TCP   	|       9099       	| Canal/Flannel livenessProbe/readinessProbe      	                                |
-|    TCP    |       9100        | Default port required by Monitoring to scrape metrics from Linux node-exporters   |
-|    TCP   	|       9443       	| Rancher webhook                                                                   |
-|    TCP    |       9796        | Default port required by Monitoring to scrape metrics from Windows node-exporters |
-|    TCP   	|       6783       	| Weave Port      	                                                                |
-|    UDP   	|       6783-6784   | Weave UDP Ports      	                                                            |
-|    TCP   	|       10250      	| Metrics server communication with all nodes API                                     	                                |
-|    TCP   	|       10254      	| Ingress controller livenessProbe/readinessProbe 	                                |
-| TCP/UDP	|       30000-32767 | NodePort port range                             	                                |
+| Protocol 	|       Port       	| Description                                     	                                          |
+|:--------:	|:----------------:	|---------------------------------------------------------------------------------------------|
+|    TCP   	|         22      	| Node driver SSH provisioning                    	                                          |
+|    TCP    |        179        | Calico BGP Port                                                                             |
+|    TCP   	|       2376       	| Node driver Docker daemon TLS port              	                                          |
+|    TCP   	|       2379       	| etcd client requests                           	                                          |
+|    TCP   	|       2380       	| etcd peer communication                         	                                          |
+|    UDP   	|       8472       	| Canal/Flannel VXLAN overlay networking          	                                          |
+|    UDP   	|       4789       	| Flannel VXLAN overlay networking on Windows cluster                                         |
+|    TCP   	|       8443       	| Rancher webhook                                                                             |
+|    TCP   	|       9099       	| Canal/Flannel livenessProbe/readinessProbe      	                                          |
+|    TCP   	|       9443       	| Rancher webhook                                                                             |
+|    TCP    |       9796        | Default port required by Monitoring to scrape metrics from Linux and Windows node-exporters |
+|    TCP   	|       6783       	| Weave Port      	                                                                          |
+|    UDP   	|       6783-6784   | Weave UDP Ports      	                                                                      |
+|    TCP   	|       10250      	| Metrics server communication with all nodes API                                             |
+|    TCP   	|       10254      	| Ingress controller livenessProbe/readinessProbe 	                                          |
+| TCP/UDP	|       30000-32767 | NodePort port range                             	                                          |

--- a/versioned_docs/version-2.0-2.4/shared-files/_common-ports-table.md
+++ b/versioned_docs/version-2.0-2.4/shared-files/_common-ports-table.md
@@ -1,19 +1,18 @@
-| Protocol 	|       Port       	| Description                                     	                                |
-|:--------:	|:----------------:	|----------------------------------------------------------------------------------	|
-|    TCP   	|         22      	| Node driver SSH provisioning                    	                                |
-|    TCP    |        179        | Calico BGP Port                                                                   |
-|    TCP   	|       2376       	| Node driver Docker daemon TLS port              	                                |
-|    TCP   	|       2379       	| etcd client requests                           	                                |
-|    TCP   	|       2380       	| etcd peer communication                         	                                |
-|    UDP   	|       8472       	| Canal/Flannel VXLAN overlay networking          	                                |
-|    UDP   	|       4789       	| Flannel VXLAN overlay networking on Windows cluster                               |
-|    TCP   	|       8443       	| Rancher webhook                                                                   |
-|    TCP   	|       9099       	| Canal/Flannel livenessProbe/readinessProbe      	                                |
-|    TCP    |       9100        | Default port required by Monitoring to scrape metrics from Linux node-exporters   |
-|    TCP   	|       9443       	| Rancher webhook                                                                   |
-|    TCP    |       9796        | Default port required by Monitoring to scrape metrics from Windows node-exporters |
-|    TCP   	|       6783       	| Weave Port      	                                                                |
-|    UDP   	|       6783-6784   | Weave UDP Ports      	                                                            |
-|    TCP   	|       10250      	| kubelet API                                     	                                |
-|    TCP   	|       10254      	| Ingress controller livenessProbe/readinessProbe 	                                |
-| TCP/UDP	|       30000-32767 | NodePort port range                             	                                |
+| Protocol 	|       Port       	| Description                                     	                                          |
+|:--------:	|:----------------:	|-------------------------------------------------------------------------------------------- |
+|    TCP   	|         22      	| Node driver SSH provisioning                    	                                          |
+|    TCP    |        179        | Calico BGP Port                                                                             |
+|    TCP   	|       2376       	| Node driver Docker daemon TLS port              	                                          |
+|    TCP   	|       2379       	| etcd client requests                           	                                          |
+|    TCP   	|       2380       	| etcd peer communication                         	                                          |
+|    UDP   	|       8472       	| Canal/Flannel VXLAN overlay networking          	                                          |
+|    UDP   	|       4789       	| Flannel VXLAN overlay networking on Windows cluster                                         |
+|    TCP   	|       8443       	| Rancher webhook                                                                             |
+|    TCP   	|       9099       	| Canal/Flannel livenessProbe/readinessProbe      	                                          |
+|    TCP   	|       9443       	| Rancher webhook                                                                             |
+|    TCP    |       9796        | Default port required by Monitoring to scrape metrics from Linux and Windows node-exporters |
+|    TCP   	|       6783       	| Weave Port      	                                                                          |
+|    UDP   	|       6783-6784   | Weave UDP Ports      	                                                                      |
+|    TCP   	|       10250      	| kubelet API                                     	                                          |
+|    TCP   	|       10254      	| Ingress controller livenessProbe/readinessProbe 	                                          |
+| TCP/UDP	|       30000-32767 | NodePort port range                             	                                          |

--- a/versioned_docs/version-2.5/shared-files/_common-ports-table.md
+++ b/versioned_docs/version-2.5/shared-files/_common-ports-table.md
@@ -1,19 +1,18 @@
-| Protocol 	|       Port       	| Description                                     	                                |
-|:--------:	|:----------------:	|----------------------------------------------------------------------------------	|
-|    TCP   	|         22      	| Node driver SSH provisioning                    	                                |
-|    TCP    |        179        | Calico BGP Port                                                                   |
-|    TCP   	|       2376       	| Node driver Docker daemon TLS port              	                                |
-|    TCP   	|       2379       	| etcd client requests                           	                                |
-|    TCP   	|       2380       	| etcd peer communication                         	                                |
-|    UDP   	|       8472       	| Canal/Flannel VXLAN overlay networking          	                                |
-|    UDP   	|       4789       	| Flannel VXLAN overlay networking on Windows cluster                               |
-|    TCP   	|       8443       	| Rancher webhook                                                                   |
-|    TCP   	|       9099       	| Canal/Flannel livenessProbe/readinessProbe      	                                |
-|    TCP    |       9100        | Default port required by Monitoring to scrape metrics from Linux node-exporters   |
-|    TCP   	|       9443       	| Rancher webhook                                                                   |
-|    TCP    |       9796        | Default port required by Monitoring to scrape metrics from Windows node-exporters |
-|    TCP   	|       6783       	| Weave Port      	                                                                |
-|    UDP   	|       6783-6784   | Weave UDP Ports      	                                                            |
-|    TCP   	|       10250      	| Metrics server communication with all nodes API                                     	                                |
-|    TCP   	|       10254      	| Ingress controller livenessProbe/readinessProbe 	                                |
-| TCP/UDP	|       30000-32767 | NodePort port range                             	                                |
+| Protocol 	|       Port       	| Description                                     	                                          |
+|:--------:	|:----------------:	|-------------------------------------------------------------------------------------------- |
+|    TCP   	|         22      	| Node driver SSH provisioning                    	                                          |
+|    TCP    |        179        | Calico BGP Port                                                                             |
+|    TCP   	|       2376       	| Node driver Docker daemon TLS port              	                                          |
+|    TCP   	|       2379       	| etcd client requests                           	                                          |
+|    TCP   	|       2380       	| etcd peer communication                         	                                          |
+|    UDP   	|       8472       	| Canal/Flannel VXLAN overlay networking          	                                          |
+|    UDP   	|       4789       	| Flannel VXLAN overlay networking on Windows cluster                                         |
+|    TCP   	|       8443       	| Rancher webhook                                                                             |
+|    TCP   	|       9099       	| Canal/Flannel livenessProbe/readinessProbe      	                                          |
+|    TCP   	|       9443       	| Rancher webhook                                                                             |
+|    TCP    |       9796        | Default port required by Monitoring to scrape metrics from Linux and Windows node-exporters |
+|    TCP   	|       6783       	| Weave Port      	                                                                          |
+|    UDP   	|       6783-6784   | Weave UDP Ports      	                                                                      |
+|    TCP   	|       10250      	| Metrics server communication with all nodes API                                     	      |
+|    TCP   	|       10254      	| Ingress controller livenessProbe/readinessProbe 	                                          |
+| TCP/UDP	|       30000-32767 | NodePort port range                             	                                          |

--- a/versioned_docs/version-2.6/shared-files/_common-ports-table.md
+++ b/versioned_docs/version-2.6/shared-files/_common-ports-table.md
@@ -1,19 +1,18 @@
-| Protocol 	|       Port       	| Description                                     	                                |
-|:--------:	|:----------------:	|----------------------------------------------------------------------------------	|
-|    TCP   	|         22      	| Node driver SSH provisioning                    	                                |
-|    TCP    |        179        | Calico BGP Port                                                                   |
-|    TCP   	|       2376       	| Node driver Docker daemon TLS port              	                                |
-|    TCP   	|       2379       	| etcd client requests                           	                                |
-|    TCP   	|       2380       	| etcd peer communication                         	                                |
-|    UDP   	|       8472       	| Canal/Flannel VXLAN overlay networking          	                                |
-|    UDP   	|       4789       	| Flannel VXLAN overlay networking on Windows cluster                               |
-|    TCP   	|       8443       	| Rancher webhook                                                                   |
-|    TCP   	|       9099       	| Canal/Flannel livenessProbe/readinessProbe      	                                |
-|    TCP    |       9100        | Default port required by Monitoring to scrape metrics from Linux node-exporters   |
-|    TCP   	|       9443       	| Rancher webhook                                                                   |
-|    TCP    |       9796        | Default port required by Monitoring to scrape metrics from Windows node-exporters |
-|    TCP   	|       6783       	| Weave Port      	                                                                |
-|    UDP   	|       6783-6784   | Weave UDP Ports      	                                                            |
-|    TCP   	|       10250      	| Metrics server communication with all nodes API                                     	                                |
-|    TCP   	|       10254      	| Ingress controller livenessProbe/readinessProbe 	                                |
-| TCP/UDP	|       30000-32767 | NodePort port range                             	                                |
+| Protocol 	|       Port       	| Description                                     	                                          |
+|:--------:	|:----------------:	|---------------------------------------------------------------------------------------------|
+|    TCP   	|         22      	| Node driver SSH provisioning                    	                                          |
+|    TCP    |        179        | Calico BGP Port                                                                             |
+|    TCP   	|       2376       	| Node driver Docker daemon TLS port              	                                          |
+|    TCP   	|       2379       	| etcd client requests                           	                                          |
+|    TCP   	|       2380       	| etcd peer communication                         	                                          |
+|    UDP   	|       8472       	| Canal/Flannel VXLAN overlay networking          	                                          |
+|    UDP   	|       4789       	| Flannel VXLAN overlay networking on Windows cluster                                         |
+|    TCP   	|       8443       	| Rancher webhook                                                                             |
+|    TCP   	|       9099       	| Canal/Flannel livenessProbe/readinessProbe      	                                          |
+|    TCP   	|       9443       	| Rancher webhook                                                                             |
+|    TCP    |       9796        | Default port required by Monitoring to scrape metrics from Linux and Windows node-exporters |
+|    TCP   	|       6783       	| Weave Port      	                                                                          |
+|    UDP   	|       6783-6784   | Weave UDP Ports      	                                                                      |
+|    TCP   	|       10250      	| Metrics server communication with all nodes API                                             |
+|    TCP   	|       10254      	| Ingress controller livenessProbe/readinessProbe 	                                          |
+| TCP/UDP	|       30000-32767 | NodePort port range                             	                                          |

--- a/versioned_docs/version-2.7/shared-files/_common-ports-table.md
+++ b/versioned_docs/version-2.7/shared-files/_common-ports-table.md
@@ -1,19 +1,18 @@
-| Protocol 	|       Port       	| Description                                     	                                |
-|:--------:	|:----------------:	|----------------------------------------------------------------------------------	|
-|    TCP   	|         22      	| Node driver SSH provisioning                    	                                |
-|    TCP    |        179        | Calico BGP Port                                                                   |
-|    TCP   	|       2376       	| Node driver Docker daemon TLS port              	                                |
-|    TCP   	|       2379       	| etcd client requests                           	                                |
-|    TCP   	|       2380       	| etcd peer communication                         	                                |
-|    UDP   	|       8472       	| Canal/Flannel VXLAN overlay networking          	                                |
-|    UDP   	|       4789       	| Flannel VXLAN overlay networking on Windows cluster                               |
-|    TCP   	|       8443       	| Rancher webhook                                                                   |
-|    TCP   	|       9099       	| Canal/Flannel livenessProbe/readinessProbe      	                                |
-|    TCP    |       9100        | Default port required by Monitoring to scrape metrics from Linux node-exporters   |
-|    TCP   	|       9443       	| Rancher webhook                                                                   |
-|    TCP    |       9796        | Default port required by Monitoring to scrape metrics from Windows node-exporters |
-|    TCP   	|       6783       	| Weave Port      	                                                                |
-|    UDP   	|       6783-6784   | Weave UDP Ports      	                                                            |
-|    TCP   	|       10250      	| Metrics server communication with all nodes API                                     	                                |
-|    TCP   	|       10254      	| Ingress controller livenessProbe/readinessProbe 	                                |
-| TCP/UDP	|       30000-32767 | NodePort port range                             	                                |
+| Protocol 	|       Port       	| Description                                     	                                          |
+|:--------:	|:----------------:	|---------------------------------------------------------------------------------------------|
+|    TCP   	|         22      	| Node driver SSH provisioning                    	                                          |
+|    TCP    |        179        | Calico BGP Port                                                                             |
+|    TCP   	|       2376       	| Node driver Docker daemon TLS port              	                                          |
+|    TCP   	|       2379       	| etcd client requests                           	                                          |
+|    TCP   	|       2380       	| etcd peer communication                         	                                          |
+|    UDP   	|       8472       	| Canal/Flannel VXLAN overlay networking          	                                          |
+|    UDP   	|       4789       	| Flannel VXLAN overlay networking on Windows cluster                                         |
+|    TCP   	|       8443       	| Rancher webhook                                                                             |
+|    TCP   	|       9099       	| Canal/Flannel livenessProbe/readinessProbe      	                                          |
+|    TCP   	|       9443       	| Rancher webhook                                                                             |
+|    TCP    |       9796        | Default port required by Monitoring to scrape metrics from Linux and Windows node-exporters |
+|    TCP   	|       6783       	| Weave Port      	                                                                          |
+|    UDP   	|       6783-6784   | Weave UDP Ports      	                                                                      |
+|    TCP   	|       10250      	| Metrics server communication with all nodes API                                             |
+|    TCP   	|       10254      	| Ingress controller livenessProbe/readinessProbe 	                                          |
+| TCP/UDP	|       30000-32767 | NodePort port range                             	                                          |

--- a/versioned_docs/version-2.8/shared-files/_common-ports-table.md
+++ b/versioned_docs/version-2.8/shared-files/_common-ports-table.md
@@ -1,19 +1,18 @@
-| Protocol 	|       Port       	| Description                                     	                                |
-|:--------:	|:----------------:	|----------------------------------------------------------------------------------	|
-|    TCP   	|         22      	| Node driver SSH provisioning                    	                                |
-|    TCP    |        179        | Calico BGP Port                                                                   |
-|    TCP   	|       2376       	| Node driver Docker daemon TLS port              	                                |
-|    TCP   	|       2379       	| etcd client requests                           	                                |
-|    TCP   	|       2380       	| etcd peer communication                         	                                |
-|    UDP   	|       8472       	| Canal/Flannel VXLAN overlay networking          	                                |
-|    UDP   	|       4789       	| Flannel VXLAN overlay networking on Windows cluster                               |
-|    TCP   	|       8443       	| Rancher webhook                                                                   |
-|    TCP   	|       9099       	| Canal/Flannel livenessProbe/readinessProbe      	                                |
-|    TCP    |       9100        | Default port required by Monitoring to scrape metrics from Linux node-exporters   |
-|    TCP   	|       9443       	| Rancher webhook                                                                   |
-|    TCP    |       9796        | Default port required by Monitoring to scrape metrics from Windows node-exporters |
-|    TCP   	|       6783       	| Weave Port      	                                                                |
-|    UDP   	|       6783-6784   | Weave UDP Ports      	                                                            |
-|    TCP   	|       10250      	| Metrics server communication with all nodes API                                     	                                |
-|    TCP   	|       10254      	| Ingress controller livenessProbe/readinessProbe 	                                |
-| TCP/UDP	|       30000-32767 | NodePort port range                             	                                |
+| Protocol 	|       Port       	| Description                                     	                                          |
+|:--------:	|:----------------:	|---------------------------------------------------------------------------------------------|
+|    TCP   	|         22      	| Node driver SSH provisioning                    	                                          |
+|    TCP    |        179        | Calico BGP Port                                                                             |
+|    TCP   	|       2376       	| Node driver Docker daemon TLS port              	                                          |
+|    TCP   	|       2379       	| etcd client requests                           	                                          |
+|    TCP   	|       2380       	| etcd peer communication                         	                                          |
+|    UDP   	|       8472       	| Canal/Flannel VXLAN overlay networking          	                                          |
+|    UDP   	|       4789       	| Flannel VXLAN overlay networking on Windows cluster                                         |
+|    TCP   	|       8443       	| Rancher webhook                                                                             |
+|    TCP   	|       9099       	| Canal/Flannel livenessProbe/readinessProbe      	                                          |
+|    TCP   	|       9443       	| Rancher webhook                                                                             |
+|    TCP    |       9796        | Default port required by Monitoring to scrape metrics from Linux and Windows node-exporters |
+|    TCP   	|       6783       	| Weave Port      	                                                                          |
+|    UDP   	|       6783-6784   | Weave UDP Ports      	                                                                      |
+|    TCP   	|       10250      	| Metrics server communication with all nodes API                                             |
+|    TCP   	|       10254      	| Ingress controller livenessProbe/readinessProbe 	                                          |
+| TCP/UDP	|       30000-32767 | NodePort port range                             	                                          |


### PR DESCRIPTION
Fixes SURE-7491

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

Update the ports used by rancher-monitoring node-exporters. Both use `9796`, where the current documentation shows lnux exporters using port `9100`.

## Comments
