### PR TITLE
Add Weave deprecation notice

### DIFF
--- a/docs/faq/container-network-interface-providers.md
+++ b/docs/faq/container-network-interface-providers.md
@@ -86,6 +86,8 @@ For more information, see the [Flannel GitHub Page](https://github.com/flannel-i
 
 #### Weave
 
+<DeprecationWeave />
+
 ![Weave Logo](/img/weave-logo.png)
 
 Weave enables networking and network policy in Kubernetes clusters across the cloud. Additionally, it support encrypting traffic between the peers.

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md
@@ -78,6 +78,8 @@ Out of the box, Rancher is compatible with the following network providers:
 - [Calico](https://docs.projectcalico.org/v3.11/introduction/)
 - [Weave](https://github.com/weaveworks/weave)
 
+<DeprecationWeave />
+
 :::note Notes on Weave:
 
 When Weave is selected as network provider, Rancher will automatically enable encryption by generating a random password. If you want to specify the password manually, please see how to configure your cluster using a [Config File](#rke-cluster-config-file-reference) and the [Weave Network Plug-in Options](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/#weave-network-plug-in-options).

--- a/shared-files/_deprecation-weave.md
+++ b/shared-files/_deprecation-weave.md
@@ -1,0 +1,5 @@
+:::warning
+
+The Weave CNI plugin for RKE with Kubernetes v1.27 and later is now deprecated. Weave will be removed in RKE with Kubernetes v1.30.
+
+:::

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -8,6 +8,7 @@ import { CardSection, Card } from '../components/CardComponents';
 
 import CNIPopularityTable from '/shared-files/_cni-popularity.md';
 import DeprecationOPAGatekeeper from '/shared-files/_deprecation-opa-gatekeeper.md';
+import DeprecationWeave from '/shared-files/_deprecation-weave.md';
 
 export default {
   // Re-use the default mapping
@@ -21,4 +22,5 @@ export default {
 
   CNIPopularityTable,
   DeprecationOPAGatekeeper,
+  DeprecationWeave,
 };

--- a/versioned_docs/version-2.7/faq/container-network-interface-providers.md
+++ b/versioned_docs/version-2.7/faq/container-network-interface-providers.md
@@ -86,6 +86,8 @@ For more information, see the [Flannel GitHub Page](https://github.com/flannel-i
 
 #### Weave
 
+<DeprecationWeave />
+
 ![Weave Logo](/img/weave-logo.png)
 
 Weave enables networking and network policy in Kubernetes clusters across the cloud. Additionally, it support encrypting traffic between the peers.

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md
@@ -78,6 +78,8 @@ Out of the box, Rancher is compatible with the following network providers:
 - [Calico](https://docs.projectcalico.org/v3.11/introduction/)
 - [Weave](https://github.com/weaveworks/weave)
 
+<DeprecationWeave />
+
 :::note Notes on Weave:
 
 When Weave is selected as network provider, Rancher will automatically enable encryption by generating a random password. If you want to specify the password manually, please see how to configure your cluster using a [Config File](#rke-cluster-config-file-reference) and the [Weave Network Plug-in Options](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/#weave-network-plug-in-options).

--- a/versioned_docs/version-2.8/faq/container-network-interface-providers.md
+++ b/versioned_docs/version-2.8/faq/container-network-interface-providers.md
@@ -86,6 +86,8 @@ For more information, see the [Flannel GitHub Page](https://github.com/flannel-i
 
 #### Weave
 
+<DeprecationWeave />
+
 ![Weave Logo](/img/weave-logo.png)
 
 Weave enables networking and network policy in Kubernetes clusters across the cloud. Additionally, it support encrypting traffic between the peers.

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md
@@ -78,6 +78,8 @@ Out of the box, Rancher is compatible with the following network providers:
 - [Calico](https://docs.projectcalico.org/v3.11/introduction/)
 - [Weave](https://github.com/weaveworks/weave)
 
+<DeprecationWeave />
+
 :::note Notes on Weave:
 
 When Weave is selected as network provider, Rancher will automatically enable encryption by generating a random password. If you want to specify the password manually, please see how to configure your cluster using a [Config File](#rke-cluster-config-file-reference) and the [Weave Network Plug-in Options](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/#weave-network-plug-in-options).


### PR DESCRIPTION
## Description

Our [release notes](https://github.com/rancher/rancher/releases/tag/v2.8.0) mention the deprecation of Weave with RKE K8s v1.27, but it's not mentioned in our docs.

## Comments

Including as part of 2.7.11 milestone since that's when 1.27 is added for 2.7.