### PR TITLE
Add Helm 2 deprecation note

### DIFF
--- a/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.md
+++ b/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.md
@@ -28,9 +28,12 @@ The kubeconfig can also be manually targeted for the intended cluster with the `
 Review the list of known issues for each Rancher version, which can be found in the release notes on [GitHub](https://github.com/rancher/rancher/releases) and on the [Rancher forums.](https://forums.rancher.com/c/announcements/12)
 
 Note that upgrades _to_ or _from_ any chart in the [rancher-alpha repository](../resources/choose-a-rancher-version.md#helm-chart-repositories) aren't supported.
+
 ### Helm Version
 
 The upgrade instructions assume you are using Helm 3.
+
+<DeprecationHelm2 />
 
 For migration of installs started with Helm 2, refer to the official [Helm 2 to 3 migration docs.](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/) The [Helm 2 upgrade page here](/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades/helm2.md)provides a copy of the older upgrade instructions that used Helm 2, and it is intended to be used if upgrading to Helm 3 is not feasible.
 

--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher.md
@@ -10,6 +10,8 @@ Now that you have a running RKE cluster, you can install Rancher in it. For secu
 
 ### Install the Helm CLI
 
+<DeprecationHelm2 />
+
 Install the [Helm](https://helm.sh/docs/intro/install/) CLI on a host where you have a kubeconfig to access your Kubernetes cluster:
 
 ```

--- a/docs/getting-started/installation-and-upgrade/resources/helm-version-requirements.md
+++ b/docs/getting-started/installation-and-upgrade/resources/helm-version-requirements.md
@@ -10,6 +10,8 @@ This section contains the requirements for Helm, which is the tool used to insta
 
 > The installation instructions have been updated for Helm 3. For migration of installs started with Helm 2, refer to the official [Helm 2 to 3 Migration Docs.](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/) [This section](/versioned_docs/version-2.0-2.4/pages-for-subheaders/helm2.md) provides a copy of the older high-availability Rancher installation instructions that used Helm 2, and it is intended to be used if upgrading to Helm 3 is not feasible.
 
+<DeprecationHelm2 />
+
 - Helm v3.2.x or higher is required to install or upgrade Rancher v2.5.
 - Helm v2.16.0 or higher is required for Kubernetes v1.16. For the default Kubernetes version, refer to the [release notes](https://github.com/rancher/rke/releases) for the version of RKE that you are using.
 - Helm v2.15.0 should not be used, because of an issue with converting/comparing numbers.

--- a/docs/getting-started/installation-and-upgrade/resources/upgrade-cert-manager.md
+++ b/docs/getting-started/installation-and-upgrade/resources/upgrade-cert-manager.md
@@ -145,6 +145,8 @@ Before you can perform the upgrade, you must prepare your air gapped environment
     --set cainjector.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-cainjector
     ```
 
+    <DeprecationHelm2 />
+    
     The Helm 2 command is as follows:
 
     ```plain

--- a/shared-files/_deprecation-helm2.md
+++ b/shared-files/_deprecation-helm2.md
@@ -1,0 +1,5 @@
+:::warning
+
+Helm v2 support is deprecated as of the Rancher v2.7 line and will be removed in Rancher v2.9.
+
+:::

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -8,6 +8,7 @@ import { CardSection, Card } from '../components/CardComponents';
 
 import CNIPopularityTable from '/shared-files/_cni-popularity.md';
 import DeprecationOPAGatekeeper from '/shared-files/_deprecation-opa-gatekeeper.md';
+import DeprecationHelm2 from '/shared-files/_deprecation-helm2.md';
 
 export default {
   // Re-use the default mapping
@@ -21,4 +22,5 @@ export default {
 
   CNIPopularityTable,
   DeprecationOPAGatekeeper,
+  DeprecationHelm2,
 };

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.md
@@ -28,7 +28,10 @@ The kubeconfig can also be manually targeted for the intended cluster with the `
 Review the list of known issues for each Rancher version, which can be found in the release notes on [GitHub](https://github.com/rancher/rancher/releases) and on the [Rancher forums.](https://forums.rancher.com/c/announcements/12)
 
 Note that upgrades _to_ or _from_ any chart in the [rancher-alpha repository](../resources/choose-a-rancher-version.md#helm-chart-repositories) aren't supported.
+
 ### Helm Version
+
+<DeprecationHelm2 />
 
 The upgrade instructions assume you are using Helm 3.
 

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher.md
@@ -10,6 +10,8 @@ Now that you have a running RKE cluster, you can install Rancher in it. For secu
 
 ### Install the Helm CLI
 
+<DeprecationHelm2 />
+
 Install the [Helm](https://helm.sh/docs/intro/install/) CLI on a host where you have a kubeconfig to access your Kubernetes cluster:
 
 ```

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/resources/helm-version-requirements.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/resources/helm-version-requirements.md
@@ -10,6 +10,8 @@ This section contains the requirements for Helm, which is the tool used to insta
 
 > The installation instructions have been updated for Helm 3. For migration of installs started with Helm 2, refer to the official [Helm 2 to 3 Migration Docs.](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/) [This section](/versioned_docs/version-2.0-2.4/pages-for-subheaders/helm2.md) provides a copy of the older high-availability Rancher installation instructions that used Helm 2, and it is intended to be used if upgrading to Helm 3 is not feasible.
 
+<DeprecationHelm2 />
+
 - Helm v3.2.x or higher is required to install or upgrade Rancher v2.5.
 - Helm v2.16.0 or higher is required for Kubernetes v1.16. For the default Kubernetes version, refer to the [release notes](https://github.com/rancher/rke/releases) for the version of RKE that you are using.
 - Helm v2.15.0 should not be used, because of an issue with converting/comparing numbers.

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/resources/upgrade-cert-manager.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/resources/upgrade-cert-manager.md
@@ -145,6 +145,8 @@ Before you can perform the upgrade, you must prepare your air gapped environment
     --set cainjector.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-cainjector
     ```
 
+    <DeprecationHelm2 />
+    
     The Helm 2 command is as follows:
 
     ```plain

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.md
@@ -28,7 +28,10 @@ The kubeconfig can also be manually targeted for the intended cluster with the `
 Review the list of known issues for each Rancher version, which can be found in the release notes on [GitHub](https://github.com/rancher/rancher/releases) and on the [Rancher forums.](https://forums.rancher.com/c/announcements/12)
 
 Note that upgrades _to_ or _from_ any chart in the [rancher-alpha repository](../resources/choose-a-rancher-version.md#helm-chart-repositories) aren't supported.
+
 ### Helm Version
+
+<DeprecationHelm2 />
 
 The upgrade instructions assume you are using Helm 3.
 

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher.md
@@ -10,6 +10,8 @@ Now that you have a running RKE cluster, you can install Rancher in it. For secu
 
 ### Install the Helm CLI
 
+<DeprecationHelm2 />
+
 Install the [Helm](https://helm.sh/docs/intro/install/) CLI on a host where you have a kubeconfig to access your Kubernetes cluster:
 
 ```

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/resources/helm-version-requirements.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/resources/helm-version-requirements.md
@@ -10,6 +10,8 @@ This section contains the requirements for Helm, which is the tool used to insta
 
 > The installation instructions have been updated for Helm 3. For migration of installs started with Helm 2, refer to the official [Helm 2 to 3 Migration Docs.](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/) [This section](/versioned_docs/version-2.0-2.4/pages-for-subheaders/helm2.md) provides a copy of the older high-availability Rancher installation instructions that used Helm 2, and it is intended to be used if upgrading to Helm 3 is not feasible.
 
+<DeprecationHelm2 />
+
 - Helm v3.2.x or higher is required to install or upgrade Rancher v2.5.
 - Helm v2.16.0 or higher is required for Kubernetes v1.16. For the default Kubernetes version, refer to the [release notes](https://github.com/rancher/rke/releases) for the version of RKE that you are using.
 - Helm v2.15.0 should not be used, because of an issue with converting/comparing numbers.

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/resources/upgrade-cert-manager.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/resources/upgrade-cert-manager.md
@@ -145,6 +145,8 @@ Before you can perform the upgrade, you must prepare your air gapped environment
     --set cainjector.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-cainjector
     ```
 
+    <DeprecationHelm2 />
+
     The Helm 2 command is as follows:
 
     ```plain


### PR DESCRIPTION
## Description

Our [release notes](https://github.com/rancher/rancher/releases/tag/v2.8.0) added a note on the deprecation (and future removal) of Helm 2 support.

## Comments

I limited adding the note to only areas where Helm 2 is explicitly called out and to prominent sections about install Helm. I omitted areas where Helm is mentioned as part of a long list/paragraph of other things to install as to not go overboard.