### PR TITLE
#743 Role template management title updated

### DIFF
--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/creator-permissions.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/creator-permissions.md
@@ -40,8 +40,8 @@ An administrator can individually grant the role **Create RKE Templates** to any
 Alternatively, the administrator can give all new users the default permission to create RKE templates by following the following steps. This will not affect the permissions of existing users.
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
-1. Go to the role named **Create new RKE Cluster Templates and click **⋮ > Edit Config**.
+1. In the left navigation bar, click **Role Templates**.
+1. Select **Create new RKE Cluster Templates** and click **⋮ > Edit Config**.
 1. Select the option **Yes: Default role for new users**.
 1. Click **Save**.
 1. If you would like new users to also be able to create RKE template revisions, enable that role as default as well.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/cluster-and-project-roles.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/cluster-and-project-roles.md
@@ -215,7 +215,7 @@ There are two methods for changing default cluster/project roles:
 
 :::
 
-### Configuring Default Role Templates for Cluster and Project Creators
+### Configuring Default Roles for Cluster and Project Creators
 
 You can change the cluster or project role(s) that are automatically assigned to the creating user.
 

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/cluster-and-project-roles.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/cluster-and-project-roles.md
@@ -11,7 +11,7 @@ Cluster and project roles define user authorization inside a cluster or project.
 To manage these roles,
 
 1. Click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles** and go to the **Cluster** or **Project/Namespaces** tab.
+1. In the left navigation bar, click **Role Templates** and go to the **Cluster** or **Project/Namespaces** tab.
 
 ### Membership and Role Assignment
 
@@ -73,7 +73,7 @@ The following table lists the permissions available for the `Manage Nodes` role 
 For details on how each cluster role can access Kubernetes resources, you can look them up in the Rancher UI:
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**.
 1. Click the **Cluster** tab.
 1. Click the name of an individual role. The table shows all of the operations and resources that are permitted by the role.
 
@@ -215,12 +215,12 @@ There are two methods for changing default cluster/project roles:
 
 :::
 
-### Configuring Default Roles for Cluster and Project Creators
+### Configuring Default Role Templates for Cluster and Project Creators
 
 You can change the cluster or project role(s) that are automatically assigned to the creating user.
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**.
 1. Click the **Cluster** or **Project/Namespaces** tab.
 1. Find the custom or individual role that you want to use as default. Then edit the role by selecting **⋮ > Edit Config**.
 1. In the **Cluster Creator Default** or **Project Creator Default** section, enable the role as the default.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/custom-roles.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/custom-roles.md
@@ -31,7 +31,7 @@ While Rancher comes out-of-the-box with a set of default user roles, you can als
 The steps to add custom roles differ depending on the version of Rancher.
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**.
 1.  Select a tab to determine the scope of the role you're adding. The tabs are:
 
   - **Global:** The role is valid for allowing members to manage global scoped resources.
@@ -65,7 +65,7 @@ The custom role can then be assigned to a user or group so that the role takes e
 To create a custom role based on an existing role,
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**.
 1. Click the **Cluster** or **Project/Namespaces** tab. Click **Create Cluster Role** or **Create Project/Namespaces Role** depending on the scope. Note: Only cluster roles and project/namespace roles can inherit from another role.
 1. Enter a name for the role.
 1. In the **Inherit From** tab, select the role(s) that the custom role will inherit permissions from.
@@ -86,7 +86,7 @@ Custom roles can be deleted, but built-in roles cannot be deleted.
 To delete a custom role,
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**.
 2. Go to the custom global role that should be deleted and click **⋮ (…) > Delete**.
 3. Click **Delete**.
 

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions.md
@@ -31,8 +31,8 @@ When you create a new local user, you assign them a global permission as you com
 To see the default permissions for new users,
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
-1. The **Roles** page has tabs for roles grouped by scope. Each table lists the roles in that scope. In the **Global** tab, in the **New User Default** column, the permissions given to new users by default are indicated with a checkmark.
+1. In the left navigation bar, click **Role Templates**.
+1. The **Role Templates** page has tabs for roles grouped by scope. Each table lists the roles in that scope. In the **Global** tab, in the **New User Default** column, the permissions given to new users by default are indicated with a checkmark.
 
 You can [change the default global permissions to meet your needs.](#configuring-default-global-permissions)
 
@@ -43,8 +43,8 @@ When a user logs into Rancher using an external authentication provider for the 
 To see the default permissions for new users,
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
-1. The **Roles** page has tabs for roles grouped by scope. Each table lists the roles in that scope. In the **New User Default** column on each page, the permissions given to new users by default are indicated with a checkmark.
+1. In the left navigation bar, click **Role Templates**.
+1. The **Role Templates** page has tabs for roles grouped by scope. Each table lists the roles in that scope. In the **New User Default** column on each page, the permissions given to new users by default are indicated with a checkmark.
 
 You can [change the default permissions to meet your needs.](#configuring-default-global-permissions)
 
@@ -92,7 +92,7 @@ The following table lists each built-in global permission and whether it is incl
 For details on which Kubernetes resources correspond to each global permission,
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**.
 1.  If you click the name of an individual role, a table shows all of the operations and resources that are permitted by the role.
 
 :::note Notes:
@@ -221,7 +221,7 @@ Default roles are only assigned to users added from an external authentication p
 To change the default global permissions that are assigned to external users upon their first log in, follow these steps:
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**. On the **Roles** page, make sure the **Global** tab is selected.
+1. In the left navigation bar, click **Role Templates**. On the **Role Templates** page, make sure the **Global** tab is selected.
 1. Find the permissions set that you want to add or remove as a default. Then edit the permission by selecting **⋮ > Edit Config**.
 1. If you want to add the permission as a default, Select **Yes: Default role for new users** and then click **Save**. If you want to remove a default permission, edit the permission and select **No**.
 
@@ -234,7 +234,7 @@ To configure permission for a user,
 1. In the upper left corner, click **☰ > Users & Authentication**.
 1. In the left navigation bar, click **Users**.
 1. Go to the user whose access level you want to change and click **⋮ > Edit Config**.
-1. In the **Global Permissions** and **Built-in** sections, check the boxes for each permission you want the user to have. If you have created roles from the **Roles** page, they will appear in the **Custom** section and you can choose from them as well.
+1. In the **Global Permissions** and **Built-in** sections, check the boxes for each permission you want the user to have. If you have created roles from the **Role Templates** page, they will appear in the **Custom** section and you can choose from them as well.
 1. Click **Save**.
 
 **Result:** The user's global permissions have been updated.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/locked-roles.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/locked-roles.md
@@ -36,7 +36,7 @@ You can lock roles in two contexts:
 Cluster roles and project/namespace roles can be locked, but global roles cannot.
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**.
 1. Go to the **Cluster** tab or the **Project/Namespaces** tab.
 1. From the role that you want to lock (or unlock), select **⋮ > Edit Config**.
 1. From the **Locked** option, choose the **Yes** or **No** radio button. Then click **Save**.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/creator-permissions.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/creator-permissions.md
@@ -41,7 +41,7 @@ Alternatively, the administrator can give all new users the default permission t
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
 1. In the left navigation bar, click **Roles**.
-1. Go to the role named **Create new RKE Cluster Templates and click **⋮ > Edit Config**.
+1. Select **Create new RKE Cluster Templates** and click **⋮ > Edit Config**.
 1. Select the option **Yes: Default role for new users**.
 1. Click **Save**.
 1. If you would like new users to also be able to create RKE template revisions, enable that role as default as well.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/creator-permissions.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/creator-permissions.md
@@ -41,7 +41,7 @@ Alternatively, the administrator can give all new users the default permission t
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
 1. In the left navigation bar, click **Role Templates**.
-    * In Rancher 2.7.6 and earlier, the **Role Templates** section is labeled **Roles**.
+    * In Rancher v2.7.6 and earlier, the **Role Templates** page is labeled **Roles**.
 1. Go to the role named **Create new RKE Cluster Templates and click **⋮ > Edit Config**.
 1. Select the option **Yes: Default role for new users**.
 1. Click **Save**.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/creator-permissions.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/creator-permissions.md
@@ -40,7 +40,8 @@ An administrator can individually grant the role **Create RKE Templates** to any
 Alternatively, the administrator can give all new users the default permission to create RKE templates by following the following steps. This will not affect the permissions of existing users.
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**.
+    * In Rancher 2.7.6 and earlier, the **Role Templates** section is labeled **Roles**.
 1. Go to the role named **Create new RKE Cluster Templates and click **⋮ > Edit Config**.
 1. Select the option **Yes: Default role for new users**.
 1. Click **Save**.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/creator-permissions.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/creator-permissions.md
@@ -42,7 +42,7 @@ Alternatively, the administrator can give all new users the default permission t
 1. In the upper left corner, click **☰ > Users & Authentication**.
 1. In the left navigation bar, click **Role Templates**.
     * In Rancher v2.7.6 and earlier, the **Role Templates** page is labeled **Roles**.
-1. Go to the role named **Create new RKE Cluster Templates and click **⋮ > Edit Config**.
+1. Select **Create new RKE Cluster Templates** and click **⋮ > Edit Config**.
 1. Select the option **Yes: Default role for new users**.
 1. Click **Save**.
 1. If you would like new users to also be able to create RKE template revisions, enable that role as default as well.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/cluster-and-project-roles.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/cluster-and-project-roles.md
@@ -11,7 +11,8 @@ Cluster and project roles define user authorization inside a cluster or project.
 To manage these roles,
 
 1. Click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles** and go to the **Cluster** or **Project/Namespaces** tab.
+1. In the left navigation bar, click **Role Templates** and go to the **Cluster** or **Project/Namespaces** tab.
+    * In Rancher v2.7.6 and earlier, the **Role Templates** page is labeled **Roles**.
 
 ### Membership and Role Assignment
 
@@ -73,7 +74,8 @@ The following table lists the permissions available for the `Manage Nodes` role 
 For details on how each cluster role can access Kubernetes resources, you can look them up in the Rancher UI:
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**. 
+    * In Rancher v2.7.6 and earlier, the **Role Templates** page is labeled **Roles**.
 1. Click the **Cluster** tab.
 1. Click the name of an individual role. The table shows all of the operations and resources that are permitted by the role.
 
@@ -220,7 +222,8 @@ There are two methods for changing default cluster/project roles:
 You can change the cluster or project role(s) that are automatically assigned to the creating user.
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**. 
+    * In Rancher v2.7.6 and earlier, the **Role Templates** page is labeled **Roles**.
 1. Click the **Cluster** or **Project/Namespaces** tab.
 1. Find the custom or individual role that you want to use as default. Then edit the role by selecting **⋮ > Edit Config**.
 1. In the **Cluster Creator Default** or **Project Creator Default** section, enable the role as the default.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/custom-roles.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/custom-roles.md
@@ -31,7 +31,8 @@ While Rancher comes out-of-the-box with a set of default user roles, you can als
 The steps to add custom roles differ depending on the version of Rancher.
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**. 
+    * In Rancher v2.7.6 and earlier, the **Role Templates** page is labeled **Roles**.
 1.  Select a tab to determine the scope of the role you're adding. The tabs are:
 
   - **Global:** The role is valid for allowing members to manage global scoped resources.
@@ -65,7 +66,8 @@ The custom role can then be assigned to a user or group so that the role takes e
 To create a custom role based on an existing role,
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**. 
+    * In Rancher v2.7.6 and earlier, the **Role Templates** page is labeled **Roles**.
 1. Click the **Cluster** or **Project/Namespaces** tab. Click **Create Cluster Role** or **Create Project/Namespaces Role** depending on the scope. Note: Only cluster roles and project/namespace roles can inherit from another role.
 1. Enter a name for the role.
 1. In the **Inherit From** tab, select the role(s) that the custom role will inherit permissions from.
@@ -86,9 +88,10 @@ Custom roles can be deleted, but built-in roles cannot be deleted.
 To delete a custom role,
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
-2. Go to the custom global role that should be deleted and click **⋮ (…) > Delete**.
-3. Click **Delete**.
+1. In the left navigation bar, click **Role Templates**. 
+    * In Rancher v2.7.6 and earlier, the **Role Templates** page is labeled **Roles**.
+1. Go to the custom global role that should be deleted and click **⋮ (…) > Delete**.
+1. Click **Delete**.
 
 ## Assigning a Custom Role to a Group
 

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions.md
@@ -102,8 +102,9 @@ When you create a new local user, you assign them a global permission as you com
 To see the default permissions for new users,
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
-1. The **Roles** page has tabs for roles grouped by scope. Each table lists the roles in that scope. In the **Global** tab, in the **New User Default** column, the permissions given to new users by default are indicated with a checkmark.
+1. In the left navigation bar, click **Role Templates**. 
+    * In Rancher v2.7.6 and earlier, the **Role Templates** page is labeled **Roles**.
+1. The **Role Templates** page has tabs for roles grouped by scope. Each table lists the roles in that scope. In the **Global** tab, in the **New User Default** column, the permissions given to new users by default are indicated with a checkmark.
 
 You can [change the default global permissions to meet your needs.](#configuring-default-global-permissions)
 
@@ -114,8 +115,9 @@ When a user logs into Rancher using an external authentication provider for the 
 To see the default permissions for new users,
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
-1. The **Roles** page has tabs for roles grouped by scope. Each table lists the roles in that scope. In the **New User Default** column on each page, the permissions given to new users by default are indicated with a checkmark.
+1. In the left navigation bar, click **Role Templates**. 
+    * In Rancher v2.7.6 and earlier, the **Role Templates** page is labeled **Roles**.
+1. The **Role Templates** page has tabs for roles grouped by scope. Each table lists the roles in that scope. In the **New User Default** column on each page, the permissions given to new users by default are indicated with a checkmark.
 
 You can [change the default permissions to meet your needs.](#configuring-default-global-permissions)
 
@@ -161,7 +163,8 @@ The following table lists each custom global permission available and whether it
 For details on which Kubernetes resources correspond to each global permission,
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**. 
+    * In Rancher v2.7.6 and earlier, the **Role Templates** page is labeled **Roles**.
 1.  If you click the name of an individual role, a table shows all of the operations and resources that are permitted by the role.
 
 :::note Notes:
@@ -184,7 +187,8 @@ Default roles are only assigned to users added from an external authentication p
 To change the default global permissions that are assigned to external users upon their first log in, follow these steps:
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**. On the **Roles** page, make sure the **Global** tab is selected.
+1. In the left navigation bar, click **Roles**. On the **Role Templates** page, make sure the **Global** tab is selected.
+    * In Rancher v2.7.6 and earlier, the **Role Templates** page is labeled **Roles**.
 1. Find the permissions set that you want to add or remove as a default. Then edit the permission by selecting **⋮ > Edit Config**.
 1. If you want to add the permission as a default, Select **Yes: Default role for new users** and then click **Save**. If you want to remove a default permission, edit the permission and select **No**.
 
@@ -197,7 +201,8 @@ To configure permission for a user,
 1. In the upper left corner, click **☰ > Users & Authentication**.
 1. In the left navigation bar, click **Users**.
 1. Go to the user whose access level you want to change and click **⋮ > Edit Config**.
-1. In the **Global Permissions** and **Built-in** sections, check the boxes for each permission you want the user to have. If you have created roles from the **Roles** page, they will appear in the **Custom** section and you can choose from them as well.
+1. In the **Global Permissions** and **Built-in** sections, check the boxes for each permission you want the user to have. If you have created roles from the **Role Templates** page, they will appear in the **Custom** section and you can choose from them as well.
+    * In Rancher v2.7.6 and earlier, the **Role Templates** page is labeled **Roles**.
 1. Click **Save**.
 
 **Result:** The user's global permissions have been updated.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/locked-roles.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/locked-roles.md
@@ -36,7 +36,8 @@ You can lock roles in two contexts:
 Cluster roles and project/namespace roles can be locked, but global roles cannot.
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**. 
+    * In Rancher v2.7.6 and earlier, the **Role Templates** page is labeled **Roles**.
 1. Go to the **Cluster** tab or the **Project/Namespaces** tab.
 1. From the role that you want to lock (or unlock), select **⋮ > Edit Config**.
 1. From the **Locked** option, choose the **Yes** or **No** radio button. Then click **Save**.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/creator-permissions.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/creator-permissions.md
@@ -41,7 +41,7 @@ Alternatively, the administrator can give all new users the default permission t
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
 1. In the left navigation bar, click **Role Templates**.
-1. Go to the role named **Create new RKE Cluster Templates and click **⋮ > Edit Config**.
+1. Select **Create new RKE Cluster Templates** and click **⋮ > Edit Config**.
 1. Select the option **Yes: Default role for new users**.
 1. Click **Save**.
 1. If you would like new users to also be able to create RKE template revisions, enable that role as default as well.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/creator-permissions.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/creator-permissions.md
@@ -40,7 +40,7 @@ An administrator can individually grant the role **Create RKE Templates** to any
 Alternatively, the administrator can give all new users the default permission to create RKE templates by following the following steps. This will not affect the permissions of existing users.
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**.
 1. Go to the role named **Create new RKE Cluster Templates and click **⋮ > Edit Config**.
 1. Select the option **Yes: Default role for new users**.
 1. Click **Save**.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/cluster-and-project-roles.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/cluster-and-project-roles.md
@@ -11,7 +11,7 @@ Cluster and project roles define user authorization inside a cluster or project.
 To manage these roles,
 
 1. Click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles** and go to the **Cluster** or **Project/Namespaces** tab.
+1. In the left navigation bar, click **Role Templates** and go to the **Cluster** or **Project/Namespaces** tab.
 
 ### Membership and Role Assignment
 
@@ -73,7 +73,7 @@ The following table lists the permissions available for the `Manage Nodes` role 
 For details on how each cluster role can access Kubernetes resources, you can look them up in the Rancher UI:
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**.
 1. Click the **Cluster** tab.
 1. Click the name of an individual role. The table shows all of the operations and resources that are permitted by the role.
 
@@ -220,7 +220,7 @@ There are two methods for changing default cluster/project roles:
 You can change the cluster or project role(s) that are automatically assigned to the creating user.
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**.
 1. Click the **Cluster** or **Project/Namespaces** tab.
 1. Find the custom or individual role that you want to use as default. Then edit the role by selecting **⋮ > Edit Config**.
 1. In the **Cluster Creator Default** or **Project Creator Default** section, enable the role as the default.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/custom-roles.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/custom-roles.md
@@ -31,7 +31,7 @@ While Rancher comes out-of-the-box with a set of default user roles, you can als
 The steps to add custom roles differ depending on the version of Rancher.
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**.
 1.  Select a tab to determine the scope of the role you're adding. The tabs are:
 
   - **Global:** The role is valid for allowing members to manage global scoped resources.
@@ -65,7 +65,7 @@ The custom role can then be assigned to a user or group so that the role takes e
 To create a custom role based on an existing role,
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**.
 1. Click the **Cluster** or **Project/Namespaces** tab. Click **Create Cluster Role** or **Create Project/Namespaces Role** depending on the scope. Note: Only cluster roles and project/namespace roles can inherit from another role.
 1. Enter a name for the role.
 1. In the **Inherit From** tab, select the role(s) that the custom role will inherit permissions from.
@@ -86,7 +86,7 @@ Custom roles can be deleted, but built-in roles cannot be deleted.
 To delete a custom role,
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**.
 2. Go to the custom global role that should be deleted and click **⋮ (…) > Delete**.
 3. Click **Delete**.
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions.md
@@ -31,8 +31,8 @@ When you create a new local user, you assign them a global permission as you com
 To see the default permissions for new users,
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
-1. The **Roles** page has tabs for roles grouped by scope. Each table lists the roles in that scope. In the **Global** tab, in the **New User Default** column, the permissions given to new users by default are indicated with a checkmark.
+1. In the left navigation bar, click **Role Templates**.
+1. The **Role Templates** page has tabs for roles grouped by scope. Each table lists the roles in that scope. In the **Global** tab, in the **New User Default** column, the permissions given to new users by default are indicated with a checkmark.
 
 You can [change the default global permissions to meet your needs.](#configuring-default-global-permissions)
 
@@ -43,8 +43,8 @@ When a user logs into Rancher using an external authentication provider for the 
 To see the default permissions for new users,
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
-1. The **Roles** page has tabs for roles grouped by scope. Each table lists the roles in that scope. In the **New User Default** column on each page, the permissions given to new users by default are indicated with a checkmark.
+1. In the left navigation bar, click **Role Templates**.
+1. The **Role Templates** page has tabs for roles grouped by scope. Each table lists the roles in that scope. In the **New User Default** column on each page, the permissions given to new users by default are indicated with a checkmark.
 
 You can [change the default permissions to meet your needs.](#configuring-default-global-permissions)
 
@@ -92,7 +92,7 @@ The following table lists each built-in global permission and whether it is incl
 For details on which Kubernetes resources correspond to each global permission,
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**.
 1.  If you click the name of an individual role, a table shows all of the operations and resources that are permitted by the role.
 
 :::note Notes:
@@ -221,7 +221,7 @@ Default roles are only assigned to users added from an external authentication p
 To change the default global permissions that are assigned to external users upon their first log in, follow these steps:
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**. On the **Roles** page, make sure the **Global** tab is selected.
+1. In the left navigation bar, click **Role Templates**. On the **Role Templates** page, make sure the **Global** tab is selected.
 1. Find the permissions set that you want to add or remove as a default. Then edit the permission by selecting **⋮ > Edit Config**.
 1. If you want to add the permission as a default, Select **Yes: Default role for new users** and then click **Save**. If you want to remove a default permission, edit the permission and select **No**.
 
@@ -234,7 +234,7 @@ To configure permission for a user,
 1. In the upper left corner, click **☰ > Users & Authentication**.
 1. In the left navigation bar, click **Users**.
 1. Go to the user whose access level you want to change and click **⋮ > Edit Config**.
-1. In the **Global Permissions** and **Built-in** sections, check the boxes for each permission you want the user to have. If you have created roles from the **Roles** page, they will appear in the **Custom** section and you can choose from them as well.
+1. In the **Global Permissions** and **Built-in** sections, check the boxes for each permission you want the user to have. If you have created roles from the **Role Templates** page, they will appear in the **Custom** section and you can choose from them as well.
 1. Click **Save**.
 
 **Result:** The user's global permissions have been updated.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/locked-roles.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/locked-roles.md
@@ -36,7 +36,7 @@ You can lock roles in two contexts:
 Cluster roles and project/namespace roles can be locked, but global roles cannot.
 
 1. In the upper left corner, click **☰ > Users & Authentication**.
-1. In the left navigation bar, click **Roles**.
+1. In the left navigation bar, click **Role Templates**.
 1. Go to the **Cluster** tab or the **Project/Namespaces** tab.
 1. From the role that you want to lock (or unlock), select **⋮ > Edit Config**.
 1. From the **Locked** option, choose the **Yes** or **No** radio button. Then click **Save**.


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #743

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

In https://github.com/rancher/dashboard/pull/9244, the UI was updated such that the section **Users & Authentication > Roles** was retitled **Users & Authentication > Role Templates**.

![image](https://github.com/rancher/rancher-docs/assets/19174201/58ceac16-06bf-471c-a6de-b17779f23fb4)

This updates instructions to reflect the change. 

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->

Docs for v2.7 were a little tricky, as earlier versions of v2.7 retain the old title. I opted to include this information in a bullet point within the instructions, rather than in an admonition or by creating tabs. An admonition would break up the flow of these brief instructions, and a tab would add a large amount of text/markup to the source file just to address a minor change.