### PR TITLE
Added redirects for AWS PAYG integration 

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1330,6 +1330,10 @@ module.exports = {
             from: '/v2.7/pages-for-subheaders/aws-marketplace-payg-integration'
           },
           {
+            to: `/2.7/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration`,
+            from: '/v2.7/pages-for-subheaders/azure-marketplace-payg-integration'
+          },
+          {
             to: '/v2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates',
             from: '/v2.7/pages-for-subheaders/about-rke1-templates'
           },
@@ -1686,6 +1690,10 @@ module.exports = {
             from: '/v2.8/pages-for-subheaders/aws-marketplace-payg-integration'
           },
           {
+            to: `/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration`,
+            from: '/pages-for-subheaders/azure-marketplace-payg-integration'
+          },
+          {
             to: '/v2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates',
             from: '/v2.8/pages-for-subheaders/about-rke1-templates'
           },
@@ -2036,6 +2044,10 @@ module.exports = {
           {
             to: `/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace`,
             from: '/pages-for-subheaders/aws-marketplace-payg-integration'
+          },
+          {
+            to: `/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration`,
+            from: '/pages-for-subheaders/azure-marketplace-payg-integration'
           },
           {
             to: '/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1330,7 +1330,7 @@ module.exports = {
             from: '/v2.7/pages-for-subheaders/aws-marketplace-payg-integration'
           }, // Redirect for aws pages-for-subheader removal
           {
-            to: '/v2.7/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration`,
+            to: '/v2.7/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration',
             from: '/v2.7/pages-for-subheaders/azure-marketplace-payg-integration'
           }, // Redirect for azure pages-for-subheader removal
           {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1326,7 +1326,7 @@ module.exports = {
             from: '/v2.7/pages-for-subheaders/about-provisioning-drivers'
           },
           {
-            to: '/v2.7/integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration`,
+            to: '/v2.7/integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration',
             from: '/v2.7/pages-for-subheaders/aws-marketplace-payg-integration'
           }, // Redirect for aws pages-for-subheader removal
           {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1326,13 +1326,13 @@ module.exports = {
             from: '/v2.7/pages-for-subheaders/about-provisioning-drivers'
           },
           {
-            to: `/v2.7/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace`,
+            to: '/v2.7/integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration`,
             from: '/v2.7/pages-for-subheaders/aws-marketplace-payg-integration'
-          },
+          }, // Redirect for aws pages-for-subheader removal
           {
-            to: `/2.7/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration`,
+            to: '/v2.7/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration`,
             from: '/v2.7/pages-for-subheaders/azure-marketplace-payg-integration'
-          },
+          }, // Redirect for azure pages-for-subheader removal
           {
             to: '/v2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates',
             from: '/v2.7/pages-for-subheaders/about-rke1-templates'

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1326,6 +1326,10 @@ module.exports = {
             from: '/v2.7/pages-for-subheaders/about-provisioning-drivers'
           },
           {
+            to: `/v2.7/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace`,
+            from: '/v2.7/pages-for-subheaders/aws-marketplace-payg-integration'
+          },
+          {
             to: '/v2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates',
             from: '/v2.7/pages-for-subheaders/about-rke1-templates'
           },
@@ -1678,6 +1682,10 @@ module.exports = {
             from: '/v2.8/pages-for-subheaders/about-provisioning-drivers'
           },
           {
+            to: `/v2.8/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace`,
+            from: '/v2.8/pages-for-subheaders/aws-marketplace-payg-integration'
+          },
+          {
             to: '/v2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates',
             from: '/v2.8/pages-for-subheaders/about-rke1-templates'
           },
@@ -2024,6 +2032,10 @@ module.exports = {
           { // Redirects for pages-for-subheaders removal [latest]
             to: '/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers',
             from: '/pages-for-subheaders/about-provisioning-drivers'
+          },
+          {
+            to: `/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace`,
+            from: '/pages-for-subheaders/aws-marketplace-payg-integration'
           },
           {
             to: '/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1686,14 +1686,6 @@ module.exports = {
             from: '/v2.8/pages-for-subheaders/about-provisioning-drivers'
           },
           {
-            to: `/v2.8/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace`,
-            from: '/v2.8/pages-for-subheaders/aws-marketplace-payg-integration'
-          },
-          {
-            to: `/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration`,
-            from: '/pages-for-subheaders/azure-marketplace-payg-integration'
-          },
-          {
             to: '/v2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates',
             from: '/v2.8/pages-for-subheaders/about-rke1-templates'
           },
@@ -2040,14 +2032,6 @@ module.exports = {
           { // Redirects for pages-for-subheaders removal [latest]
             to: '/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers',
             from: '/pages-for-subheaders/about-provisioning-drivers'
-          },
-          {
-            to: `/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace`,
-            from: '/pages-for-subheaders/aws-marketplace-payg-integration'
-          },
-          {
-            to: `/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration`,
-            from: '/pages-for-subheaders/azure-marketplace-payg-integration'
           },
           {
             to: '/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates',


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #[issue_number]

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

From Slack:

> Hi Rancher doc team, just letting you know that we just got flagged by Azure that our Rancher 2.7 PAYG offering has a broken doc link https://ranchermanager.docs.rancher.com/v2.7/pages-for-subheaders/aws-marketplace-payg-integration. The same link is being used in AWS as well so it'll be just matter of time before we get flagged by AWS as well. After a quick huddle with Jeremy and Aaron, we've decided to update it to https://ranchermanager.docs.rancher.com/v2.7/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration for Azure. We'll update to an equivalent one for AWS as well. However, it would be nice to have an immutable link for the official Rancher Prime 2.7 documentation so we don't have having constantly updating it. For the public cloud providers, publishing will be blocked for any broken links. This means automation will required manual intervention for cases like these.

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->

We do have an open PR updating the PAYG pages but in the meantime, we need to address the problem with the broken links.