### PR TITLE
Update trobleshooting tips regarding leader election

### DIFF
--- a/docs/troubleshooting/other-troubleshooting-tips/rancher-ha.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/rancher-ha.md
@@ -74,10 +74,15 @@ kubectl -n ingress-nginx logs -l app=ingress-nginx
 
 ### Leader election
 
-The leader is determined by a leader election process. After the leader has been determined, the leader (`holderIdentity`) is saved in the `cattle-controllers` ConfigMap (in this example, `rancher-7dbd7875f7-qbj5k`).
+The leader is determined by a leader election process. After the leader has been determined, the leader (`holderIdentity`) is saved in the `cattle-controllers` Lease in the `kube-system` namespace (in this example, `rancher-dbc7ff869-gvg6k`).
 
 ```
-kubectl -n kube-system get configmap cattle-controllers -o jsonpath='{.metadata.annotations.control-plane\.alpha\.kubernetes\.io/leader}'
-{"holderIdentity":"rancher-7dbd7875f7-qbj5k","leaseDurationSeconds":45,"acquireTime":"2019-04-04T11:53:12Z","renewTime":"2019-04-04T12:24:08Z","leaderTransitions":0}
+kubectl -n kube-system get lease cattle-controllers
 ```
 
+Example output:
+
+```
+NAME                 HOLDER                    AGE
+cattle-controllers   rancher-dbc7ff869-gvg6k   6h10m
+```

--- a/versioned_docs/version-2.8/troubleshooting/other-troubleshooting-tips/rancher-ha.md
+++ b/versioned_docs/version-2.8/troubleshooting/other-troubleshooting-tips/rancher-ha.md
@@ -74,10 +74,15 @@ kubectl -n ingress-nginx logs -l app=ingress-nginx
 
 ### Leader election
 
-The leader is determined by a leader election process. After the leader has been determined, the leader (`holderIdentity`) is saved in the `cattle-controllers` ConfigMap (in this example, `rancher-7dbd7875f7-qbj5k`).
+The leader is determined by a leader election process. After the leader has been determined, the leader (`holderIdentity`) is saved in the `cattle-controllers` Lease in the `kube-system` namespace (in this example, `rancher-dbc7ff869-gvg6k`).
 
 ```
-kubectl -n kube-system get configmap cattle-controllers -o jsonpath='{.metadata.annotations.control-plane\.alpha\.kubernetes\.io/leader}'
-{"holderIdentity":"rancher-7dbd7875f7-qbj5k","leaseDurationSeconds":45,"acquireTime":"2019-04-04T11:53:12Z","renewTime":"2019-04-04T12:24:08Z","leaderTransitions":0}
+kubectl -n kube-system get lease cattle-controllers
 ```
 
+Example output:
+
+```
+NAME                 HOLDER                    AGE
+cattle-controllers   rancher-dbc7ff869-gvg6k   6h10m
+```


### PR DESCRIPTION
Starting on [Rancher 2.8.3](https://github.com/rancher/rancher/pull/43652) and 2.9.X, only `Lease` objects will be used as a lock for leader election. Previously, a multi-lock `ConfigMap` + `Lease` was used, so these docs changes are backward compatible.

