### PR TITLE
Fix broken canonical links for PAYG

### DIFF
--- a/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration/aws-marketplace-payg-integration.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration/aws-marketplace-payg-integration.md
@@ -2,10 +2,6 @@
 title: AWS Marketplace Pay-as-you-go (PAYG) Integration
 ---
 
-<head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/v2.7/integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration"/>
-</head>
-
 ## Overview
 
 Rancher Prime integrates with the [AWS Marketplace](https://aws.amazon.com/marketplace) as a pay-as-you-go (PAYG) offering. This brings the value of running and managing Kubernetes environments to AWS customers, benefiting from a new pay-monthly pricing model available through the AWS Marketplace. This listing will enable you to manage any CNCF-certified Kubernetes distribution in AWS, on-prem, or at the edge. To learn more, see our non-EMEA and EMEA AWS Marketplace offerings for Rancher Prime:

--- a/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration/aws-marketplace-payg-integration.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration/aws-marketplace-payg-integration.md
@@ -3,7 +3,7 @@ title: AWS Marketplace Pay-as-you-go (PAYG) Integration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration/aws-marketplace-payg-integration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/v2.7/integrations-in-rancher/cloud-marketplace/aws-marketplace-payg-integration"/>
 </head>
 
 ## Overview

--- a/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration/azure-marketplace-payg-integration.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration/azure-marketplace-payg-integration.md
@@ -3,7 +3,7 @@ title: Azure Marketplace Pay-as-you-go (PAYG) Integration
 ---
 
 <head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration/azure-marketplace-payg-integration"/>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/v2.7/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration"/>
 </head>
 
 ## Overview

--- a/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration/azure-marketplace-payg-integration.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration/azure-marketplace-payg-integration.md
@@ -2,10 +2,6 @@
 title: Azure Marketplace Pay-as-you-go (PAYG) Integration
 ---
 
-<head>
-  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/v2.7/integrations-in-rancher/cloud-marketplace/azure-marketplace-payg-integration"/>
-</head>
-
 ## Overview
 
 Rancher Prime integrates with the [Azure Marketplace](https://azuremarketplace.microsoft.com) as a pay-as-you-go (PAYG) offering. This brings the value of running and managing Kubernetes environments to Azure customers, benefiting from a new pay-monthly pricing model available through the Azure Marketplace. This listing will enable you to manage any CNCF-certified Kubernetes distribution in Azure, on-prem, or at the edge. To learn more, see our non-EMEMA and EMEA Azure Marketplace offerings for Rancher Prime:


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #[issue_number]

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

I noticed that the canonical links on these files didn't lead anywhere, so I updated them to point to the correct URLs.

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->

- PAYG is for v2.7.9, so we don't have corresponding files yet in `/docs` or `version-2.8`.

- The other pages in these two subdirectories don't have manual canonical links yet. We add manual canonical links to override the default Docusaurus behavior, which is to have each file's canonical link point to the URL for that file's webpage. Example: Docusaurus makes the canonical link for v2.5 pages point to `https://ranchermanager.docs.rancher.com/v2.5/`. 

- Since the other files in the PAYG subdirectories don't have any corresponding versioned files yet, Docusaurus currently generates, correctly, canonical links that point to the files' webpages in `https://ranchermanager.docs.rancher.com/v2.7/` 

- The alternative way to fix the broken links on these pages is by removing lines 5-7 and not setting manual canonical links until we have to add versioned files for `v2.8` and `/docs`. What do you think?