### PR TITLE
Warn users that Rancher in Docker isn't supported part 2

### DIFF
--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
@@ -8,7 +8,7 @@ title: Troubleshooting Certificates
 
 <DockerSupportWarning />
 
-### How Do I Know if My Certificates are in PEM Format?
+## How Do I Know if My Certificates are in PEM Format?
 
 You can recognize the PEM format by the following traits:
 
@@ -50,7 +50,7 @@ VWQqljhfacYPgp8KJUJENQ9h5hZ2nSCrI+W00Jcw4QcEdCI8HL5wmg==
 -----END PRIVATE KEY-----
 ```
 
-### Converting a Certificate Key From PKCS8 to PKCS1
+## Converting a Certificate Key From PKCS8 to PKCS1
 
 If you are using a PKCS8 certificate key file, Rancher will log the following line:
 
@@ -66,7 +66,7 @@ openssl rsa -in key.pem -out convertedkey.pem
 
 You can now use `convertedkey.pem` as certificate key file for Rancher.
 
-### What is the Order of Certificates if I Want to Add My Intermediate(s)?
+## What is the Order of Certificates if I Want to Add My Intermediate(s)?
 
 The order of adding certificates is as follows:
 
@@ -79,7 +79,7 @@ The order of adding certificates is as follows:
 -----END CERTIFICATE-----
 ```
 
-### How Do I Validate My Certificate Chain?
+## How Do I Validate My Certificate Chain?
 
 You can validate the certificate chain by using the `openssl` binary. If the output of the command (see the command example below) ends with `Verify return code: 0 (ok)`, your certificate chain is valid. The `ca.pem` file must be the same as you added to the `rancher/rancher` container.
 

--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
@@ -6,6 +6,8 @@ title: Troubleshooting Certificates
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting"/>
 </head>
 
+<DockerSupportWarning />
+
 ### How Do I Know if My Certificates are in PEM Format?
 
 You can recognize the PEM format by the following traits:

--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
@@ -3,15 +3,11 @@ title: Installing Rancher on a Single Node Using Docker
 description: For development and testing environments only, use a Docker install. Install Docker on a single Linux host, and deploy Rancher with a single Docker container.
 ---
 
-:::caution
-
-Docker installs are not supported in production environments. These instructions are provided for testing and development purposes only. Please don't use this method to install Rancher in production environments.
-
-:::
-
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker"/>
 </head>
+
+<DockerSupportWarning />
 
 Rancher can be installed by running a single Docker container.
 

--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher.md
@@ -6,6 +6,8 @@ title: Rolling Back Rancher Installed with Docker
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher"/>
 </head>
 
+<DockerSupportWarning />
+
 If a Rancher upgrade does not complete successfully, you'll have to roll back to your Rancher setup that you were using before [Docker Upgrade](upgrade-docker-installed-rancher.md). Rolling back restores:
 
 - Your previous version of Rancher.

--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/upgrade-docker-installed-rancher.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/upgrade-docker-installed-rancher.md
@@ -6,13 +6,9 @@ title: Upgrading Rancher Installed with Docker
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/upgrade-docker-installed-rancher"/>
 </head>
 
+<DockerSupportWarning />
+
 The following instructions will guide you through upgrading a Rancher server that was installed with Docker.
-
-:::caution
-
-**Docker installs are not supported in production environments.** These instructions are provided for testing and development purposes only. If you have already deployed a Docker install in production and need to upgrade to a new Rancher version, we recommend [migrating to the Helm chart install](../../../../how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md) before upgrading.
-
-:::
 
 ## Prerequisites
 

--- a/shared-files/_docker-support-warning.md
+++ b/shared-files/_docker-support-warning.md
@@ -1,5 +1,5 @@
 :::warning
 
-Docker installs are not supported in production environments. These instructions are provided for testing and development purposes only. Please don't use this method to install Rancher in production environments.
+**Docker installs are not supported in production environments.** These instructions are provided for testing and development purposes only. Please don't use this method to install Rancher in production environments.
 
 :::

--- a/shared-files/_docker-support-warning.md
+++ b/shared-files/_docker-support-warning.md
@@ -1,0 +1,5 @@
+:::warning
+
+Docker installs are not supported in production environments. These instructions are provided for testing and development purposes only. Please don't use this method to install Rancher in production environments.
+
+:::

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -10,6 +10,7 @@ import CNIPopularityTable from '/shared-files/_cni-popularity.md';
 import DeprecationOPAGatekeeper from '/shared-files/_deprecation-opa-gatekeeper.md';
 import DeprecationWeave from '/shared-files/_deprecation-weave.md';
 import DeprecationHelm2 from '/shared-files/_deprecation-helm2.md';
+import DockerSupportWarning from '/shared-files/_docker-support-warning.md';
 
 export default {
   // Re-use the default mapping
@@ -25,4 +26,5 @@ export default {
   DeprecationOPAGatekeeper,
   DeprecationWeave,
   DeprecationHelm2,
+  DockerSupportWarning,
 };

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
@@ -8,7 +8,7 @@ title: Troubleshooting Certificates
 
 <DockerSupportWarning />
 
-### How Do I Know if My Certificates are in PEM Format?
+## How Do I Know if My Certificates are in PEM Format?
 
 You can recognize the PEM format by the following traits:
 
@@ -50,7 +50,7 @@ VWQqljhfacYPgp8KJUJENQ9h5hZ2nSCrI+W00Jcw4QcEdCI8HL5wmg==
 -----END PRIVATE KEY-----
 ```
 
-### Converting a Certificate Key From PKCS8 to PKCS1
+## Converting a Certificate Key From PKCS8 to PKCS1
 
 If you are using a PKCS8 certificate key file, Rancher will log the following line:
 
@@ -66,7 +66,7 @@ openssl rsa -in key.pem -out convertedkey.pem
 
 You can now use `convertedkey.pem` as certificate key file for Rancher.
 
-### What is the Order of Certificates if I Want to Add My Intermediate(s)?
+## What is the Order of Certificates if I Want to Add My Intermediate(s)?
 
 The order of adding certificates is as follows:
 
@@ -79,7 +79,7 @@ The order of adding certificates is as follows:
 -----END CERTIFICATE-----
 ```
 
-### How Do I Validate My Certificate Chain?
+## How Do I Validate My Certificate Chain?
 
 You can validate the certificate chain by using the `openssl` binary. If the output of the command (see the command example below) ends with `Verify return code: 0 (ok)`, your certificate chain is valid. The `ca.pem` file must be the same as you added to the `rancher/rancher` container.
 

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
@@ -6,6 +6,8 @@ title: Troubleshooting Certificates
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting"/>
 </head>
 
+<DockerSupportWarning />
+
 ### How Do I Know if My Certificates are in PEM Format?
 
 You can recognize the PEM format by the following traits:

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
@@ -3,15 +3,11 @@ title: Installing Rancher on a Single Node Using Docker
 description: For development and testing environments only, use a Docker install. Install Docker on a single Linux host, and deploy Rancher with a single Docker container.
 ---
 
-:::caution
-
-Docker installs are not supported in production environments. These instructions are provided for testing and development purposes only. Please don't use this method to install Rancher in production environments.
-
-:::
-
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker"/>
 </head>
+
+<DockerSupportWarning />
 
 Rancher can be installed by running a single Docker container.
 

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher.md
@@ -6,6 +6,8 @@ title: Rolling Back Rancher Installed with Docker
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher"/>
 </head>
 
+<DockerSupportWarning />
+
 If a Rancher upgrade does not complete successfully, you'll have to roll back to your Rancher setup that you were using before [Docker Upgrade](./upgrade-docker-installed-rancher.md). Rolling back restores:
 
 - Your previous version of Rancher.

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/upgrade-docker-installed-rancher.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/upgrade-docker-installed-rancher.md
@@ -8,6 +8,8 @@ title: Upgrading Rancher Installed with Docker
 
 The following instructions will guide you through upgrading a Rancher server that was installed with Docker.
 
+<DockerSupportWarning />
+
 ## Prerequisites
 
 - **Review the [known upgrade issues](../../install-upgrade-on-a-kubernetes-cluster/upgrades/upgrades.md#known-upgrade-issues) in the Rancher documentation for the most noteworthy issues to consider when upgrading Rancher. A more complete list of known issues for each Rancher version can be found in the release notes on [GitHub](https://github.com/rancher/rancher/releases) and on the [Rancher forums.](https://forums.rancher.com/c/announcements/12) Note that upgrades to or from any chart in the [rancher-alpha repository](../../resources/choose-a-rancher-version.md#helm-chart-repositories) aren’t supported.

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
@@ -8,7 +8,7 @@ title: Troubleshooting Certificates
 
 <DockerSupportWarning />
 
-### How Do I Know if My Certificates are in PEM Format?
+## How Do I Know if My Certificates are in PEM Format?
 
 You can recognize the PEM format by the following traits:
 
@@ -50,7 +50,7 @@ VWQqljhfacYPgp8KJUJENQ9h5hZ2nSCrI+W00Jcw4QcEdCI8HL5wmg==
 -----END PRIVATE KEY-----
 ```
 
-### Converting a Certificate Key From PKCS8 to PKCS1
+## Converting a Certificate Key From PKCS8 to PKCS1
 
 If you are using a PKCS8 certificate key file, Rancher will log the following line:
 
@@ -66,7 +66,7 @@ openssl rsa -in key.pem -out convertedkey.pem
 
 You can now use `convertedkey.pem` as certificate key file for Rancher.
 
-### What is the Order of Certificates if I Want to Add My Intermediate(s)?
+## What is the Order of Certificates if I Want to Add My Intermediate(s)?
 
 The order of adding certificates is as follows:
 
@@ -79,7 +79,7 @@ The order of adding certificates is as follows:
 -----END CERTIFICATE-----
 ```
 
-### How Do I Validate My Certificate Chain?
+## How Do I Validate My Certificate Chain?
 
 You can validate the certificate chain by using the `openssl` binary. If the output of the command (see the command example below) ends with `Verify return code: 0 (ok)`, your certificate chain is valid. The `ca.pem` file must be the same as you added to the `rancher/rancher` container.
 

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
@@ -6,6 +6,8 @@ title: Troubleshooting Certificates
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting"/>
 </head>
 
+<DockerSupportWarning />
+
 ### How Do I Know if My Certificates are in PEM Format?
 
 You can recognize the PEM format by the following traits:

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
@@ -3,15 +3,11 @@ title: Installing Rancher on a Single Node Using Docker
 description: For development and testing environments only, use a Docker install. Install Docker on a single Linux host, and deploy Rancher with a single Docker container.
 ---
 
-:::caution
-
-Docker installs are not supported in production environments. These instructions are provided for testing and development purposes only. Please don't use this method to install Rancher in production environments.
-
-:::
-
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker"/>
 </head>
+
+<DockerSupportWarning />
 
 Rancher can be installed by running a single Docker container.
 

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher.md
@@ -6,6 +6,8 @@ title: Rolling Back Rancher Installed with Docker
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher"/>
 </head>
 
+<DockerSupportWarning />
+
 If a Rancher upgrade does not complete successfully, you'll have to roll back to your Rancher setup that you were using before [Docker Upgrade](upgrade-docker-installed-rancher.md). Rolling back restores:
 
 - Your previous version of Rancher.

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/upgrade-docker-installed-rancher.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/upgrade-docker-installed-rancher.md
@@ -8,6 +8,8 @@ title: Upgrading Rancher Installed with Docker
 
 The following instructions will guide you through upgrading a Rancher server that was installed with Docker.
 
+<DockerSupportWarning />
+
 ## Prerequisites
 
 - **Review the [known upgrade issues](../../install-upgrade-on-a-kubernetes-cluster/upgrades.md#known-upgrade-issues) in the Rancher documentation for the most noteworthy issues to consider when upgrading Rancher. A more complete list of known issues for each Rancher version can be found in the release notes on [GitHub](https://github.com/rancher/rancher/releases) and on the [Rancher forums.](https://forums.rancher.com/c/announcements/12) Note that upgrades to or from any chart in the [rancher-alpha repository](../../resources/choose-a-rancher-version.md#helm-chart-repositories) aren’t supported.

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
@@ -8,7 +8,7 @@ title: Troubleshooting Certificates
 
 <DockerSupportWarning />
 
-### How Do I Know if My Certificates are in PEM Format?
+## How Do I Know if My Certificates are in PEM Format?
 
 You can recognize the PEM format by the following traits:
 
@@ -50,7 +50,7 @@ VWQqljhfacYPgp8KJUJENQ9h5hZ2nSCrI+W00Jcw4QcEdCI8HL5wmg==
 -----END PRIVATE KEY-----
 ```
 
-### Converting a Certificate Key From PKCS8 to PKCS1
+## Converting a Certificate Key From PKCS8 to PKCS1
 
 If you are using a PKCS8 certificate key file, Rancher will log the following line:
 
@@ -66,7 +66,7 @@ openssl rsa -in key.pem -out convertedkey.pem
 
 You can now use `convertedkey.pem` as certificate key file for Rancher.
 
-### What is the Order of Certificates if I Want to Add My Intermediate(s)?
+## What is the Order of Certificates if I Want to Add My Intermediate(s)?
 
 The order of adding certificates is as follows:
 
@@ -79,7 +79,7 @@ The order of adding certificates is as follows:
 -----END CERTIFICATE-----
 ```
 
-### How Do I Validate My Certificate Chain?
+## How Do I Validate My Certificate Chain?
 
 You can validate the certificate chain by using the `openssl` binary. If the output of the command (see the command example below) ends with `Verify return code: 0 (ok)`, your certificate chain is valid. The `ca.pem` file must be the same as you added to the `rancher/rancher` container.
 

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
@@ -6,6 +6,8 @@ title: Troubleshooting Certificates
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting"/>
 </head>
 
+<DockerSupportWarning />
+
 ### How Do I Know if My Certificates are in PEM Format?
 
 You can recognize the PEM format by the following traits:

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
@@ -3,15 +3,11 @@ title: Installing Rancher on a Single Node Using Docker
 description: For development and testing environments only, use a Docker install. Install Docker on a single Linux host, and deploy Rancher with a single Docker container.
 ---
 
-:::caution
-
-Docker installs are not supported in production environments. These instructions are provided for testing and development purposes only. Please don't use this method to install Rancher in production environments.
-
-:::
-
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker"/>
 </head>
+
+<DockerSupportWarning />
 
 Rancher can be installed by running a single Docker container.
 

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher.md
@@ -6,6 +6,8 @@ title: Rolling Back Rancher Installed with Docker
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher"/>
 </head>
 
+<DockerSupportWarning />
+
 If a Rancher upgrade does not complete successfully, you'll have to roll back to your Rancher setup that you were using before [Docker Upgrade](upgrade-docker-installed-rancher.md). Rolling back restores:
 
 - Your previous version of Rancher.

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/upgrade-docker-installed-rancher.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/upgrade-docker-installed-rancher.md
@@ -8,11 +8,7 @@ title: Upgrading Rancher Installed with Docker
 
 The following instructions will guide you through upgrading a Rancher server that was installed with Docker.
 
-:::caution
-
-**Docker installs are not supported in production environments.** These instructions are provided for testing and development purposes only. If you have already deployed a Docker install in production and need to upgrade to a new Rancher version, we recommend [migrating to the Helm chart install](../../../../how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md) before upgrading.
-
-:::
+<DockerSupportWarning />
 
 ## Prerequisites
 

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
@@ -8,7 +8,7 @@ title: Troubleshooting Certificates
 
 <DockerSupportWarning />
 
-### How Do I Know if My Certificates are in PEM Format?
+## How Do I Know if My Certificates are in PEM Format?
 
 You can recognize the PEM format by the following traits:
 
@@ -50,7 +50,7 @@ VWQqljhfacYPgp8KJUJENQ9h5hZ2nSCrI+W00Jcw4QcEdCI8HL5wmg==
 -----END PRIVATE KEY-----
 ```
 
-### Converting a Certificate Key From PKCS8 to PKCS1
+## Converting a Certificate Key From PKCS8 to PKCS1
 
 If you are using a PKCS8 certificate key file, Rancher will log the following line:
 
@@ -66,7 +66,7 @@ openssl rsa -in key.pem -out convertedkey.pem
 
 You can now use `convertedkey.pem` as certificate key file for Rancher.
 
-### What is the Order of Certificates if I Want to Add My Intermediate(s)?
+## What is the Order of Certificates if I Want to Add My Intermediate(s)?
 
 The order of adding certificates is as follows:
 
@@ -79,7 +79,7 @@ The order of adding certificates is as follows:
 -----END CERTIFICATE-----
 ```
 
-### How Do I Validate My Certificate Chain?
+## How Do I Validate My Certificate Chain?
 
 You can validate the certificate chain by using the `openssl` binary. If the output of the command (see the command example below) ends with `Verify return code: 0 (ok)`, your certificate chain is valid. The `ca.pem` file must be the same as you added to the `rancher/rancher` container.
 

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
@@ -6,6 +6,8 @@ title: Troubleshooting Certificates
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting"/>
 </head>
 
+<DockerSupportWarning />
+
 ### How Do I Know if My Certificates are in PEM Format?
 
 You can recognize the PEM format by the following traits:

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
@@ -3,15 +3,11 @@ title: Installing Rancher on a Single Node Using Docker
 description: For development and testing environments only, use a Docker install. Install Docker on a single Linux host, and deploy Rancher with a single Docker container.
 ---
 
-:::caution
-
-Docker installs are not supported in production environments. These instructions are provided for testing and development purposes only. Please don't use this method to install Rancher in production environments.
-
-:::
-
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker"/>
 </head>
+
+<DockerSupportWarning />
 
 Rancher can be installed by running a single Docker container.
 

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher.md
@@ -6,6 +6,8 @@ title: Rolling Back Rancher Installed with Docker
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher"/>
 </head>
 
+<DockerSupportWarning />
+
 If a Rancher upgrade does not complete successfully, you'll have to roll back to your Rancher setup that you were using before [Docker Upgrade](upgrade-docker-installed-rancher.md). Rolling back restores:
 
 - Your previous version of Rancher.

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/upgrade-docker-installed-rancher.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/upgrade-docker-installed-rancher.md
@@ -8,11 +8,7 @@ title: Upgrading Rancher Installed with Docker
 
 The following instructions will guide you through upgrading a Rancher server that was installed with Docker.
 
-:::caution
-
-**Docker installs are not supported in production environments.** These instructions are provided for testing and development purposes only. If you have already deployed a Docker install in production and need to upgrade to a new Rancher version, we recommend [migrating to the Helm chart install](../../../../how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md) before upgrading.
-
-:::
+<DockerSupportWarning />
 
 ## Prerequisites
 

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
@@ -8,7 +8,7 @@ title: Troubleshooting Certificates
 
 <DockerSupportWarning />
 
-### How Do I Know if My Certificates are in PEM Format?
+## How Do I Know if My Certificates are in PEM Format?
 
 You can recognize the PEM format by the following traits:
 
@@ -50,7 +50,7 @@ VWQqljhfacYPgp8KJUJENQ9h5hZ2nSCrI+W00Jcw4QcEdCI8HL5wmg==
 -----END PRIVATE KEY-----
 ```
 
-### Converting a Certificate Key From PKCS8 to PKCS1
+## Converting a Certificate Key From PKCS8 to PKCS1
 
 If you are using a PKCS8 certificate key file, Rancher will log the following line:
 
@@ -66,7 +66,7 @@ openssl rsa -in key.pem -out convertedkey.pem
 
 You can now use `convertedkey.pem` as certificate key file for Rancher.
 
-### What is the Order of Certificates if I Want to Add My Intermediate(s)?
+## What is the Order of Certificates if I Want to Add My Intermediate(s)?
 
 The order of adding certificates is as follows:
 
@@ -79,7 +79,7 @@ The order of adding certificates is as follows:
 -----END CERTIFICATE-----
 ```
 
-### How Do I Validate My Certificate Chain?
+## How Do I Validate My Certificate Chain?
 
 You can validate the certificate chain by using the `openssl` binary. If the output of the command (see the command example below) ends with `Verify return code: 0 (ok)`, your certificate chain is valid. The `ca.pem` file must be the same as you added to the `rancher/rancher` container.
 

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting.md
@@ -6,6 +6,8 @@ title: Troubleshooting Certificates
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/certificate-troubleshooting"/>
 </head>
 
+<DockerSupportWarning />
+
 ### How Do I Know if My Certificates are in PEM Format?
 
 You can recognize the PEM format by the following traits:

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/rancher-on-a-single-node-with-docker.md
@@ -3,15 +3,11 @@ title: Installing Rancher on a Single Node Using Docker
 description: For development and testing environments only, use a Docker install. Install Docker on a single Linux host, and deploy Rancher with a single Docker container.
 ---
 
-:::caution
-
-Docker installs are not supported in production environments. These instructions are provided for testing and development purposes only. Please don't use this method to install Rancher in production environments.
-
-:::
-
 <head>
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker"/>
 </head>
+
+<DockerSupportWarning />
 
 Rancher can be installed by running a single Docker container.
 

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher.md
@@ -6,6 +6,8 @@ title: Rolling Back Rancher Installed with Docker
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/roll-back-docker-installed-rancher"/>
 </head>
 
+<DockerSupportWarning />
+
 If a Rancher upgrade does not complete successfully, you'll have to roll back to your Rancher setup that you were using before [Docker Upgrade](upgrade-docker-installed-rancher.md). Rolling back restores:
 
 - Your previous version of Rancher.

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/upgrade-docker-installed-rancher.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/upgrade-docker-installed-rancher.md
@@ -8,11 +8,7 @@ title: Upgrading Rancher Installed with Docker
 
 The following instructions will guide you through upgrading a Rancher server that was installed with Docker.
 
-:::caution
-
-**Docker installs are not supported in production environments.** These instructions are provided for testing and development purposes only. If you have already deployed a Docker install in production and need to upgrade to a new Rancher version, we recommend [migrating to the Helm chart install](../../../../how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md) before upgrading.
-
-:::
+<DockerSupportWarning />
 
 ## Prerequisites
 


### PR DESCRIPTION
## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

This is a follow-up to #1166.

- Refactor changes from #1166 to follow the DRY principle and fixes placement so it comes after page metadata.
- Convert existing warnings to match.
- Adds the warning to other pages in the same part of the site hierarchy.

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->