### PR TITLE
Update v2.8.3 Prime status

### DIFF
--- a/docs/reference-guides/rancher-webhook.md
+++ b/docs/reference-guides/rancher-webhook.md
@@ -19,7 +19,7 @@ Each Rancher version is designed to be compatible with a single version of the w
 
 | Rancher Version | Webhook Version | Availability in Prime | Availability in Community |
 |-----------------|-----------------|-----------------------|---------------------------|
-| v2.8.3          |     v0.4.3      | &cross;               | &check;                   |
+| v2.8.3          |     v0.4.3      | &check;               | &check;                   |
 | v2.8.2          |     v0.4.2      | &check;               | &check;                   |
 | v2.8.1          |     v0.4.2      | &check;               | &check;                   |
 | v2.8.0          |     v0.4.2      | &cross;               | &check;                   |

--- a/src/pages/versions.md
+++ b/src/pages/versions.md
@@ -22,7 +22,7 @@ Here you can find links to supporting documentation for the current released ver
     <td><a href="https://ranchermanager.docs.rancher.com/v2.8">Documentation</a></td>
     <td><a href="https://github.com/rancher/rancher/releases/tag/v2.8.3">Release Notes</a></td>
     <td><center>N/A</center></td>
-    <td><center>N/A</center></td>
+    <td><center>&#10003;</center></td>
     <td><center>&#10003;</center></td>
   </tr>
 </table>

--- a/versioned_docs/version-2.8/reference-guides/rancher-webhook.md
+++ b/versioned_docs/version-2.8/reference-guides/rancher-webhook.md
@@ -20,7 +20,7 @@ Each Rancher version is designed to be compatible with a single version of the w
 
 | Rancher Version | Webhook Version | Availability in Prime | Availability in Community |
 |-----------------|-----------------|-----------------------|---------------------------|
-| v2.8.3          |     v0.4.3      | &cross;               | &check;                   |
+| v2.8.3          |     v0.4.3      | &check;               | &check;                   |
 | v2.8.2          |     v0.4.2      | &check;               | &check;                   |
 | v2.8.1          |     v0.4.2      | &check;               | &check;                   |
 | v2.8.0          |     v0.4.2      | &cross;               | &check;                   |


### PR DESCRIPTION
## Description

Rancher v2.8.3 is now available on Prime. Update references we have on its Prime status.