### PR TITLE
Updating Prime text to improve clarity

### DIFF
--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/prime.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/prime.md
@@ -6,6 +6,6 @@ title: Rancher Prime
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/prime"/>
 </head>
 
-Rancher v2.7 introduces Rancher Prime, an evolution of the Rancher enterprise offering. Rancher Prime is a new edition of the commercial, enterprise offering built on the the same source code. Rancher’s product will therefore continue to be 100% open source with additional value coming in from security assurances, extended lifecycles, access to focused architectures and Kubernetes advisories. Rancher Prime will also offer options to get production support for innovative Rancher projects. With Rancher Prime, installation assets are hosted on a trusted registry owned and managed by Rancher.
+SUSE Rancher introduces Rancher Prime - an evolution of Rancher - from version v2.7. Rancher Prime is the new commercially available enterprise offering that is built on the same open source code. The Rancher project will continue to be 100% open source. Prime introduces additional value with greater security assurances, extended lifecycles, access to focused architectures and Kubernetes advisories. Rancher Prime will also offer options to get production support for innovative Rancher projects. With Rancher Prime, installation assets are hosted on a trusted registry owned and managed by Rancher.
 
 To get started with Rancher Prime, [go to this page](https://www.rancher.com/quick-start) and fill out the form.

--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/prime.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/prime.md
@@ -6,6 +6,6 @@ title: Rancher Prime
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/prime"/>
 </head>
 
-SUSE Rancher introduces Rancher Prime - an evolution of Rancher - from version v2.7. Rancher Prime is the new commercially available enterprise offering that is built on the same open source code. The Rancher project will continue to be 100% open source. Prime introduces additional value with greater security assurances, extended lifecycles, access to focused architectures and Kubernetes advisories. Rancher Prime will also offer options to get production support for innovative Rancher projects. With Rancher Prime, installation assets are hosted on a trusted registry owned and managed by Rancher.
+SUSE Rancher introduces Rancher Prime – an evolution of Rancher – from version v2.7. Rancher Prime is the new commercially available enterprise offering of Rancher, built on the same open source code. The Rancher project will continue to be 100% open source. Prime introduces additional value with greater security assurances, extended lifecycles, access to focused architectures and Kubernetes advisories. Rancher Prime will also offer options to get production support for innovative Rancher projects. With Rancher Prime, installation assets are hosted on a trusted registry owned and managed by Rancher.
 
 To get started with Rancher Prime, [go to this page](https://www.rancher.com/quick-start) and fill out the form.


### PR DESCRIPTION
## Description

This sentence inherently implies that there already was a commercial, enterprise offering built on the same source code - which, in essence, there wasn't. We are building Prime to be the commercial, enterprise offering and for Rancher to be the open source community. Furthermore, this edit clarifies that SUSE Rancher is introducing Rancher Prime which is widely available from v2.7, not the version 2.7 introducing Rancher Prime.

## Comments

This may need to be backported. 