### PR TITLE
[skip ci] Update Algolia config reference

### DIFF
--- a/dev-resources/algolia-search/config.json
+++ b/dev-resources/algolia-search/config.json
@@ -8,7 +8,8 @@
     "lvl2": "article h2",
     "lvl3": "article h3",
     "lvl4": "article h4",
-    "lvl5": "article h5"
+    "lvl5": "article h5",
+    "lvl6": "article h6"
   },
   "custom_settings": {
     "attributesForFaceting": [


### PR DESCRIPTION
## Description

We have some terms that are not searchable (e.g. "dual-stack") due to the header containing the term being h6 and our index is configured to not include h6. I've updated the index to parse h6 headers as well and this PR updates the example Algolia config.json to reflect the change. 

@LucasSaintarbor @martyav @sunilarjun please update your local configs as well. 

