### PR TITLE
Updating CAPI Overview - Prereqs Section/Additional Links

### DIFF
--- a/docs/integrations-in-rancher/cluster-api/cluster-api.md
+++ b/docs/integrations-in-rancher/cluster-api/cluster-api.md
@@ -9,6 +9,6 @@ title: Cluster API (CAPI) with Rancher Turtles
 [Rancher Turtles](https://turtles.docs.rancher.com/) is a [Rancher extension](../rancher-extensions.md) that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
 
 - Import CAPI clusters into Rancher, by installing the Rancher Cluster Agent in CAPI provisioned clusters.
-- Configure the [CAPI Operator](https://turtles.docs.rancher.com/docs/reference-guides/rancher-turtles-chart/values#cluster-api-operator-values).
+- Configure the [CAPI Operator](https://turtles.docs.rancher.com/reference-guides/rancher-turtles-chart/values#cluster-api-operator-values).
 
 The [Overview](./overview.md) section outlines installation options, Rancher Turtles architecture, and a brief demo. For more details, see the [Rancher Turtles documentation](https://turtles.docs.rancher.com/).

--- a/docs/integrations-in-rancher/cluster-api/overview.md
+++ b/docs/integrations-in-rancher/cluster-api/overview.md
@@ -32,10 +32,10 @@ These webhooks can be removed through the Rancher UI as well:
 1. In the upper left corner, click **☰** > **Cluster Management**.
 1. Select your local cluster.
 1. In the left-hand navigation menu, select **More Resources** > **Admission**.
-1. From the dropdown you will see the Resource pages for `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration`, click through both pages to remove the necessary webhooks.
-1. On the respective Resource pages, click the **⋮** that are attached to the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks to select the **Delete** option. Once deleted, you should see the webhooks removed immediately.
+1. From the dropdown, select the Resource pages for `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration`.
+1. On the respective Resource pages, click the **⋮** that are attached to the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks and select the **Delete** option.
 
-They can also be accessed by entering the names of the webhooks into the **Resource Search** field.
+The webhooks can also be accessed by entering the names of the webhooks into the **Resource Search** field.
 
 The following `kubectl` commands can manually remove the necessary webhooks:
 

--- a/docs/integrations-in-rancher/cluster-api/overview.md
+++ b/docs/integrations-in-rancher/cluster-api/overview.md
@@ -12,6 +12,12 @@ Below is a visual representation of the key components of Rancher Turtles and th
 
 ![overview](/img/30000ft_view.png)
 
+## Security
+
+[SLSA](https://slsa.dev/spec/v1.0/about) is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA’s guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
+
+Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements for appropriate build platform, consistent build process, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/docs/security/slsa) document.
+
 ## Prerequisites
 
 Before installing Rancher Turtles in your Rancher environment, you must disable Rancher's `embedded-cluster-api` functionality. This also includes cleaning up Rancher-specific webhooks that otherwise would conflict with CAPI ones.
@@ -20,6 +26,35 @@ To simplify setting up Rancher for installing Rancher Turtles, the official Ranc
 
 - Disables the `embedded-cluster-api` feature in Rancher.
 - Deletes the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks, as they are no longer needed.
+
+The above webhooks can be removed through the Rancher UI as well and are accessed from the left-hand navigation from your local cluster under the **More Resources** > **Admission** section or found by using the **Resource Search** field and inputting the webhook names. Additionally, the following `kubectl` commands can also be used to remove the necessary webhooks:
+
+```console
+kubectl delete mutatingwebhookconfiguration.admissionregistration.k8s.io mutating-webhook-configuration
+```
+
+```console
+kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io validating-webhook-configuration
+```
+
+Use the following example to disable the `embedded-cluster-api` feature from the console:
+
+1. Create a `feature.yaml` file, with `embedded-cluster-api` set to false:
+
+```yaml title="feature.yaml"
+apiVersion: management.cattle.io/v3
+kind: Feature
+metadata:
+  name: embedded-cluster-api
+spec:
+  value: false
+```
+
+2. Use `kubectl` to apply the `feature.yaml` file to the cluster:
+
+```bash
+kubectl apply -f feature.yaml
+```
 
 ## Installing the Rancher Turtles Operator
 
@@ -63,14 +98,14 @@ This demo illustrates how to use the Rancher UI to install Rancher Turtles, crea
 
 ### Installing via Helm
 
-There are two ways to install Rancher Turtles with Helm, depending on whether you include the CAPI operator as a dependency:
+There are two ways to install Rancher Turtles with Helm, depending on whether you include the [CAPI Operator](https://github.com/kubernetes-sigs/cluster-api-operator) as a dependency:
 
 - [Install Rancher Turtles with CAPI Operator as a dependency](#installing-rancher-turtles-with-cluster-api-capi-operator-as-a-helm-dependency).
 - [Install Rancher Turtles without CAPI Operator](#installing-rancher-turtles-without-cluster-api-capi-operator-as-a-helm-dependency).
 
 The CAPI Operator is required for installing Rancher Turtles. You can choose whether you want to take care of this dependency yourself or let the Rancher Turtles Helm chart manage it for you. [Installing Turtles as a dependency](#installing-rancher-turtles-with-cluster-api-capi-operator-as-a-helm-dependency) is simpler, but your best option depends on your specific configuration.
 
-The CAPI Operator allows for handling the lifecycle of CAPI providers using a declarative approach, extending the capabilities of `clusterctl`. If you want to learn more about it, you can refer to [Cluster API Operator book](https://cluster-api-operator.sigs.k8s.io/).
+The CAPI Operator allows for handling the lifecycle of [CAPI providers](https://turtles.docs.rancher.com/tasks/capi-operator/installing_core_provider) using a declarative approach, extending the capabilities of `clusterctl`. If you want to learn more about it, you can refer to [Cluster API Operator book](https://cluster-api-operator.sigs.k8s.io/).
 
 #### Installing Rancher Turtles with `Cluster API (CAPI) Operator` as a Helm dependency
 
@@ -213,9 +248,3 @@ spec:
 ```bash
 kubectl apply -f feature.yaml
 ```
-
-## Security
-
-[SLSA](https://slsa.dev/spec/v1.0/about) is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA’s guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
-
-Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements for appropriate build platform, consistent build process, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/docs/security/slsa) document.

--- a/docs/integrations-in-rancher/cluster-api/overview.md
+++ b/docs/integrations-in-rancher/cluster-api/overview.md
@@ -16,7 +16,7 @@ Below is a visual representation of the key components of Rancher Turtles and th
 
 [SLSA](https://slsa.dev/spec/v1.0/about) is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA’s guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
 
-Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements for appropriate build platform, consistent build process, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/docs/security/slsa) document.
+Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements for appropriate build platform, consistent build process, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/security/slsa) document.
 
 ## Prerequisites
 

--- a/docs/integrations-in-rancher/cluster-api/overview.md
+++ b/docs/integrations-in-rancher/cluster-api/overview.md
@@ -14,9 +14,9 @@ Below is a visual representation of the key components of Rancher Turtles and th
 
 ## Security
 
-[SLSA](https://slsa.dev/spec/v1.0/about) is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA’s guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
+As defined by [Supply-chain Levels for Software Artifacts (SLSA)](https://slsa.dev/spec/v1.0/about), SLSA is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA’s guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
 
-Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements for appropriate build platform, consistent build process, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/security/slsa) document.
+Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements as an appropriate hardened build platform, with consistent build processes, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/security/slsa) document.
 
 ## Prerequisites
 
@@ -27,7 +27,17 @@ To simplify setting up Rancher for installing Rancher Turtles, the official Ranc
 - Disables the `embedded-cluster-api` feature in Rancher.
 - Deletes the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks, as they are no longer needed.
 
-The above webhooks can be removed through the Rancher UI as well and are accessed from the left-hand navigation from your local cluster under the **More Resources** > **Admission** section or found by using the **Resource Search** field and inputting the webhook names. Additionally, the following `kubectl` commands can also be used to remove the necessary webhooks:
+These webhooks can be removed through the Rancher UI as well:
+
+1. In the upper left corner, click **☰** > **Cluster Management**.
+1. Select your local cluster.
+1. In the left-hand navigation menu, select **More Resources** > **Admission**.
+1. From the dropdown you will see the Resource pages for `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration`, click through both pages to remove the necessary webhooks.
+1. On the respective Resource pages, click the **⋮** that are attached to the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks to select the **Delete** option. Once deleted, you should see the webhooks removed immediately.
+
+They can also be accessed by entering the names of the webhooks into the **Resource Search** field.
+
+The following `kubectl` commands can manually remove the necessary webhooks:
 
 ```console
 kubectl delete mutatingwebhookconfiguration.admissionregistration.k8s.io mutating-webhook-configuration

--- a/docs/integrations-in-rancher/cluster-api/overview.md
+++ b/docs/integrations-in-rancher/cluster-api/overview.md
@@ -92,7 +92,7 @@ By adding the Turtles repository via the Rancher UI, Rancher can process the ins
 1. Click **Rancher Turtles - the Cluster API Extension**.
 1. Click **Install > Next > Install**.
 
-This process uses the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from the Rancher UI or you can [manually install the chart via Helm](#installing-via-helm). For details about available values, see the Rancher Turtles [Helm chart reference guide](https://turtles.docs.rancher.com/docs/reference-guides/rancher-turtles-chart/values).
+This process uses the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from the Rancher UI or you can [manually install the chart via Helm](#installing-via-helm). For details about available values, see the Rancher Turtles [Helm chart reference guide](https://turtles.docs.rancher.com/reference-guides/rancher-turtles-chart/values).
 
 The installation may take a few minutes and after completing you can see the following new deployments in the cluster:
 
@@ -177,7 +177,7 @@ stringData:
 
 :::info
 
-For detailed information on the values supported by the chart and their usage, refer to [Helm chart options](https://turtles.docs.rancher.com/docs/reference-guides/rancher-turtles-chart/values)
+For detailed information on the values supported by the chart and their usage, refer to [Helm chart options](https://turtles.docs.rancher.com/reference-guides/rancher-turtles-chart/values)
 
 :::
 
@@ -185,7 +185,7 @@ For detailed information on the values supported by the chart and their usage, r
 
 :::note
 
-Remember that if you opt for this installation option, you must manage the CAPI Operator installation yourself. You can follow the [CAPI Operator guide](https://turtles.docs.rancher.com/docs/tasks/capi-operator/intro) in the Rancher Turtles documentation for assistance.
+Remember that if you opt for this installation option, you must manage the CAPI Operator installation yourself. You can follow the [CAPI Operator guide](https://turtles.docs.rancher.com/tasks/capi-operator/intro) in the Rancher Turtles documentation for assistance.
 
 :::
 

--- a/versioned_docs/version-2.7/integrations-in-rancher/cluster-api/cluster-api.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cluster-api/cluster-api.md
@@ -9,6 +9,6 @@ title: Cluster API (CAPI) with Rancher Turtles
 [Rancher Turtles](https://turtles.docs.rancher.com/) is a [Rancher extension](../rancher-extensions.md) that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
 
 - Import CAPI clusters into Rancher, by installing the Rancher Cluster Agent in CAPI provisioned clusters.
-- Configure the [CAPI Operator](https://turtles.docs.rancher.com/docs/reference-guides/rancher-turtles-chart/values#cluster-api-operator-values).
+- Configure the [CAPI Operator](https://turtles.docs.rancher.com/reference-guides/rancher-turtles-chart/values#cluster-api-operator-values).
 
 The [Overview](./overview.md) section outlines installation options, Rancher Turtles architecture, and a brief demo. For more details, see the [Rancher Turtles documentation](https://turtles.docs.rancher.com/).

--- a/versioned_docs/version-2.7/integrations-in-rancher/cluster-api/overview.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cluster-api/overview.md
@@ -32,10 +32,10 @@ These webhooks can be removed through the Rancher UI as well:
 1. In the upper left corner, click **☰** > **Cluster Management**.
 1. Select your local cluster.
 1. In the left-hand navigation menu, select **More Resources** > **Admission**.
-1. From the dropdown you will see the Resource pages for `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration`, click through both pages to remove the necessary webhooks.
-1. On the respective Resource pages, click the **⋮** that are attached to the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks to select the **Delete** option. Once deleted, you should see the webhooks removed immediately.
+1. From the dropdown, select the Resource pages for `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration`.
+1. On the respective Resource pages, click the **⋮** that are attached to the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks and select the **Delete** option.
 
-They can also be accessed by entering the names of the webhooks into the **Resource Search** field.
+The webhooks can also be accessed by entering the names of the webhooks into the **Resource Search** field.
 
 The following `kubectl` commands can manually remove the necessary webhooks:
 

--- a/versioned_docs/version-2.7/integrations-in-rancher/cluster-api/overview.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cluster-api/overview.md
@@ -12,6 +12,12 @@ Below is a visual representation of the key components of Rancher Turtles and th
 
 ![overview](/img/30000ft_view.png)
 
+## Security
+
+[SLSA](https://slsa.dev/spec/v1.0/about) is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA’s guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
+
+Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements for appropriate build platform, consistent build process, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/docs/security/slsa) document.
+
 ## Prerequisites
 
 Before installing Rancher Turtles in your Rancher environment, you must disable Rancher's `embedded-cluster-api` functionality. This also includes cleaning up Rancher-specific webhooks that otherwise would conflict with CAPI ones.
@@ -20,6 +26,35 @@ To simplify setting up Rancher for installing Rancher Turtles, the official Ranc
 
 - Disables the `embedded-cluster-api` feature in Rancher.
 - Deletes the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks, as they are no longer needed.
+
+The above webhooks can be removed through the Rancher UI as well and are accessed from the left-hand navigation from your local cluster under the **More Resources** > **Admission** section or found by using the **Resource Search** field and inputting the webhook names. Additionally, the following `kubectl` commands can also be used to remove the necessary webhooks:
+
+```console
+kubectl delete mutatingwebhookconfiguration.admissionregistration.k8s.io mutating-webhook-configuration
+```
+
+```console
+kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io validating-webhook-configuration
+```
+
+Use the following example to disable the `embedded-cluster-api` feature from the console:
+
+1. Create a `feature.yaml` file, with `embedded-cluster-api` set to false:
+
+```yaml title="feature.yaml"
+apiVersion: management.cattle.io/v3
+kind: Feature
+metadata:
+  name: embedded-cluster-api
+spec:
+  value: false
+```
+
+2. Use `kubectl` to apply the `feature.yaml` file to the cluster:
+
+```bash
+kubectl apply -f feature.yaml
+```
 
 ## Installing the Rancher Turtles Operator
 
@@ -63,14 +98,14 @@ This demo illustrates how to use the Rancher UI to install Rancher Turtles, crea
 
 ### Installing via Helm
 
-There are two ways to install Rancher Turtles with Helm, depending on whether you include the CAPI operator as a dependency:
+There are two ways to install Rancher Turtles with Helm, depending on whether you include the [CAPI Operator](https://github.com/kubernetes-sigs/cluster-api-operator) as a dependency:
 
 - [Install Rancher Turtles with CAPI Operator as a dependency](#installing-rancher-turtles-with-cluster-api-capi-operator-as-a-helm-dependency).
 - [Install Rancher Turtles without CAPI Operator](#installing-rancher-turtles-without-cluster-api-capi-operator-as-a-helm-dependency).
 
 The CAPI Operator is required for installing Rancher Turtles. You can choose whether you want to take care of this dependency yourself or let the Rancher Turtles Helm chart manage it for you. [Installing Turtles as a dependency](#installing-rancher-turtles-with-cluster-api-capi-operator-as-a-helm-dependency) is simpler, but your best option depends on your specific configuration.
 
-The CAPI Operator allows for handling the lifecycle of CAPI providers using a declarative approach, extending the capabilities of `clusterctl`. If you want to learn more about it, you can refer to [Cluster API Operator book](https://cluster-api-operator.sigs.k8s.io/).
+The CAPI Operator allows for handling the lifecycle of [CAPI providers](https://turtles.docs.rancher.com/tasks/capi-operator/installing_core_provider) using a declarative approach, extending the capabilities of `clusterctl`. If you want to learn more about it, you can refer to [Cluster API Operator book](https://cluster-api-operator.sigs.k8s.io/).
 
 #### Installing Rancher Turtles with `Cluster API (CAPI) Operator` as a Helm dependency
 
@@ -213,9 +248,3 @@ spec:
 ```bash
 kubectl apply -f feature.yaml
 ```
-
-## Security
-
-[SLSA](https://slsa.dev/spec/v1.0/about) is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA’s guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
-
-Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements for appropriate build platform, consistent build process, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/docs/security/slsa) document.

--- a/versioned_docs/version-2.7/integrations-in-rancher/cluster-api/overview.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cluster-api/overview.md
@@ -16,7 +16,7 @@ Below is a visual representation of the key components of Rancher Turtles and th
 
 [SLSA](https://slsa.dev/spec/v1.0/about) is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA’s guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
 
-Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements for appropriate build platform, consistent build process, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/docs/security/slsa) document.
+Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements for appropriate build platform, consistent build process, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/security/slsa) document.
 
 ## Prerequisites
 

--- a/versioned_docs/version-2.7/integrations-in-rancher/cluster-api/overview.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cluster-api/overview.md
@@ -14,9 +14,9 @@ Below is a visual representation of the key components of Rancher Turtles and th
 
 ## Security
 
-[SLSA](https://slsa.dev/spec/v1.0/about) is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA’s guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
+As defined by [Supply-chain Levels for Software Artifacts (SLSA)](https://slsa.dev/spec/v1.0/about), SLSA is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA’s guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
 
-Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements for appropriate build platform, consistent build process, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/security/slsa) document.
+Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements as an appropriate hardened build platform, with consistent build processes, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/security/slsa) document.
 
 ## Prerequisites
 
@@ -27,7 +27,17 @@ To simplify setting up Rancher for installing Rancher Turtles, the official Ranc
 - Disables the `embedded-cluster-api` feature in Rancher.
 - Deletes the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks, as they are no longer needed.
 
-The above webhooks can be removed through the Rancher UI as well and are accessed from the left-hand navigation from your local cluster under the **More Resources** > **Admission** section or found by using the **Resource Search** field and inputting the webhook names. Additionally, the following `kubectl` commands can also be used to remove the necessary webhooks:
+These webhooks can be removed through the Rancher UI as well:
+
+1. In the upper left corner, click **☰** > **Cluster Management**.
+1. Select your local cluster.
+1. In the left-hand navigation menu, select **More Resources** > **Admission**.
+1. From the dropdown you will see the Resource pages for `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration`, click through both pages to remove the necessary webhooks.
+1. On the respective Resource pages, click the **⋮** that are attached to the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks to select the **Delete** option. Once deleted, you should see the webhooks removed immediately.
+
+They can also be accessed by entering the names of the webhooks into the **Resource Search** field.
+
+The following `kubectl` commands can manually remove the necessary webhooks:
 
 ```console
 kubectl delete mutatingwebhookconfiguration.admissionregistration.k8s.io mutating-webhook-configuration

--- a/versioned_docs/version-2.7/integrations-in-rancher/cluster-api/overview.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cluster-api/overview.md
@@ -92,7 +92,7 @@ By adding the Turtles repository via the Rancher UI, Rancher can process the ins
 1. Click **Rancher Turtles - the Cluster API Extension**.
 1. Click **Install > Next > Install**.
 
-This process uses the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from the Rancher UI or you can [manually install the chart via Helm](#installing-via-helm). For details about available values, see the Rancher Turtles [Helm chart reference guide](https://turtles.docs.rancher.com/docs/reference-guides/rancher-turtles-chart/values).
+This process uses the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from the Rancher UI or you can [manually install the chart via Helm](#installing-via-helm). For details about available values, see the Rancher Turtles [Helm chart reference guide](https://turtles.docs.rancher.com/reference-guides/rancher-turtles-chart/values).
 
 The installation may take a few minutes and after completing you can see the following new deployments in the cluster:
 
@@ -177,7 +177,7 @@ stringData:
 
 :::info
 
-For detailed information on the values supported by the chart and their usage, refer to [Helm chart options](https://turtles.docs.rancher.com/docs/reference-guides/rancher-turtles-chart/values)
+For detailed information on the values supported by the chart and their usage, refer to [Helm chart options](https://turtles.docs.rancher.com/reference-guides/rancher-turtles-chart/values)
 
 :::
 
@@ -185,7 +185,7 @@ For detailed information on the values supported by the chart and their usage, r
 
 :::note
 
-Remember that if you opt for this installation option, you must manage the CAPI Operator installation yourself. You can follow the [CAPI Operator guide](https://turtles.docs.rancher.com/docs/tasks/capi-operator/intro) in the Rancher Turtles documentation for assistance.
+Remember that if you opt for this installation option, you must manage the CAPI Operator installation yourself. You can follow the [CAPI Operator guide](https://turtles.docs.rancher.com/tasks/capi-operator/intro) in the Rancher Turtles documentation for assistance.
 
 :::
 

--- a/versioned_docs/version-2.8/integrations-in-rancher/cluster-api/cluster-api.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/cluster-api/cluster-api.md
@@ -9,6 +9,6 @@ title: Cluster API (CAPI) with Rancher Turtles
 [Rancher Turtles](https://turtles.docs.rancher.com/) is a [Rancher extension](../rancher-extensions.md) that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
 
 - Import CAPI clusters into Rancher, by installing the Rancher Cluster Agent in CAPI provisioned clusters.
-- Configure the [CAPI Operator](https://turtles.docs.rancher.com/docs/reference-guides/rancher-turtles-chart/values#cluster-api-operator-values).
+- Configure the [CAPI Operator](https://turtles.docs.rancher.com/reference-guides/rancher-turtles-chart/values#cluster-api-operator-values).
 
 The [Overview](./overview.md) section outlines installation options, Rancher Turtles architecture, and a brief demo. For more details, see the [Rancher Turtles documentation](https://turtles.docs.rancher.com/).

--- a/versioned_docs/version-2.8/integrations-in-rancher/cluster-api/overview.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/cluster-api/overview.md
@@ -32,10 +32,10 @@ These webhooks can be removed through the Rancher UI as well:
 1. In the upper left corner, click **☰** > **Cluster Management**.
 1. Select your local cluster.
 1. In the left-hand navigation menu, select **More Resources** > **Admission**.
-1. From the dropdown you will see the Resource pages for `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration`, click through both pages to remove the necessary webhooks.
-1. On the respective Resource pages, click the **⋮** that are attached to the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks to select the **Delete** option. Once deleted, you should see the webhooks removed immediately.
+1. From the dropdown, select the Resource pages for `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration`.
+1. On the respective Resource pages, click the **⋮** that are attached to the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks and select the **Delete** option.
 
-They can also be accessed by entering the names of the webhooks into the **Resource Search** field.
+The webhooks can also be accessed by entering the names of the webhooks into the **Resource Search** field.
 
 The following `kubectl` commands can manually remove the necessary webhooks:
 

--- a/versioned_docs/version-2.8/integrations-in-rancher/cluster-api/overview.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/cluster-api/overview.md
@@ -12,6 +12,12 @@ Below is a visual representation of the key components of Rancher Turtles and th
 
 ![overview](/img/30000ft_view.png)
 
+## Security
+
+[SLSA](https://slsa.dev/spec/v1.0/about) is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA’s guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
+
+Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements for appropriate build platform, consistent build process, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/docs/security/slsa) document.
+
 ## Prerequisites
 
 Before installing Rancher Turtles in your Rancher environment, you must disable Rancher's `embedded-cluster-api` functionality. This also includes cleaning up Rancher-specific webhooks that otherwise would conflict with CAPI ones.
@@ -20,6 +26,35 @@ To simplify setting up Rancher for installing Rancher Turtles, the official Ranc
 
 - Disables the `embedded-cluster-api` feature in Rancher.
 - Deletes the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks, as they are no longer needed.
+
+The above webhooks can be removed through the Rancher UI as well and are accessed from the left-hand navigation from your local cluster under the **More Resources** > **Admission** section or found by using the **Resource Search** field and inputting the webhook names. Additionally, the following `kubectl` commands can also be used to remove the necessary webhooks:
+
+```console
+kubectl delete mutatingwebhookconfiguration.admissionregistration.k8s.io mutating-webhook-configuration
+```
+
+```console
+kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io validating-webhook-configuration
+```
+
+Use the following example to disable the `embedded-cluster-api` feature from the console:
+
+1. Create a `feature.yaml` file, with `embedded-cluster-api` set to false:
+
+```yaml title="feature.yaml"
+apiVersion: management.cattle.io/v3
+kind: Feature
+metadata:
+  name: embedded-cluster-api
+spec:
+  value: false
+```
+
+2. Use `kubectl` to apply the `feature.yaml` file to the cluster:
+
+```bash
+kubectl apply -f feature.yaml
+```
 
 ## Installing the Rancher Turtles Operator
 
@@ -63,14 +98,14 @@ This demo illustrates how to use the Rancher UI to install Rancher Turtles, crea
 
 ### Installing via Helm
 
-There are two ways to install Rancher Turtles with Helm, depending on whether you include the CAPI operator as a dependency:
+There are two ways to install Rancher Turtles with Helm, depending on whether you include the [CAPI Operator](https://github.com/kubernetes-sigs/cluster-api-operator) as a dependency:
 
 - [Install Rancher Turtles with CAPI Operator as a dependency](#installing-rancher-turtles-with-cluster-api-capi-operator-as-a-helm-dependency).
 - [Install Rancher Turtles without CAPI Operator](#installing-rancher-turtles-without-cluster-api-capi-operator-as-a-helm-dependency).
 
 The CAPI Operator is required for installing Rancher Turtles. You can choose whether you want to take care of this dependency yourself or let the Rancher Turtles Helm chart manage it for you. [Installing Turtles as a dependency](#installing-rancher-turtles-with-cluster-api-capi-operator-as-a-helm-dependency) is simpler, but your best option depends on your specific configuration.
 
-The CAPI Operator allows for handling the lifecycle of CAPI providers using a declarative approach, extending the capabilities of `clusterctl`. If you want to learn more about it, you can refer to [Cluster API Operator book](https://cluster-api-operator.sigs.k8s.io/).
+The CAPI Operator allows for handling the lifecycle of [CAPI providers](https://turtles.docs.rancher.com/tasks/capi-operator/installing_core_provider) using a declarative approach, extending the capabilities of `clusterctl`. If you want to learn more about it, you can refer to [Cluster API Operator book](https://cluster-api-operator.sigs.k8s.io/).
 
 #### Installing Rancher Turtles with `Cluster API (CAPI) Operator` as a Helm dependency
 
@@ -213,9 +248,3 @@ spec:
 ```bash
 kubectl apply -f feature.yaml
 ```
-
-## Security
-
-[SLSA](https://slsa.dev/spec/v1.0/about) is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA’s guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
-
-Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements for appropriate build platform, consistent build process, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/docs/security/slsa) document.

--- a/versioned_docs/version-2.8/integrations-in-rancher/cluster-api/overview.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/cluster-api/overview.md
@@ -16,7 +16,7 @@ Below is a visual representation of the key components of Rancher Turtles and th
 
 [SLSA](https://slsa.dev/spec/v1.0/about) is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA’s guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
 
-Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements for appropriate build platform, consistent build process, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/docs/security/slsa) document.
+Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements for appropriate build platform, consistent build process, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/security/slsa) document.
 
 ## Prerequisites
 

--- a/versioned_docs/version-2.8/integrations-in-rancher/cluster-api/overview.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/cluster-api/overview.md
@@ -14,9 +14,9 @@ Below is a visual representation of the key components of Rancher Turtles and th
 
 ## Security
 
-[SLSA](https://slsa.dev/spec/v1.0/about) is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA’s guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
+As defined by [Supply-chain Levels for Software Artifacts (SLSA)](https://slsa.dev/spec/v1.0/about), SLSA is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA’s guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
 
-Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements for appropriate build platform, consistent build process, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/security/slsa) document.
+Rancher Turtles meets [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) requirements as an appropriate hardened build platform, with consistent build processes, and provenance distribution. For more information, visit the [Rancher Turtles Security](https://turtles.docs.rancher.com/security/slsa) document.
 
 ## Prerequisites
 
@@ -27,7 +27,17 @@ To simplify setting up Rancher for installing Rancher Turtles, the official Ranc
 - Disables the `embedded-cluster-api` feature in Rancher.
 - Deletes the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks, as they are no longer needed.
 
-The above webhooks can be removed through the Rancher UI as well and are accessed from the left-hand navigation from your local cluster under the **More Resources** > **Admission** section or found by using the **Resource Search** field and inputting the webhook names. Additionally, the following `kubectl` commands can also be used to remove the necessary webhooks:
+These webhooks can be removed through the Rancher UI as well:
+
+1. In the upper left corner, click **☰** > **Cluster Management**.
+1. Select your local cluster.
+1. In the left-hand navigation menu, select **More Resources** > **Admission**.
+1. From the dropdown you will see the Resource pages for `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration`, click through both pages to remove the necessary webhooks.
+1. On the respective Resource pages, click the **⋮** that are attached to the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks to select the **Delete** option. Once deleted, you should see the webhooks removed immediately.
+
+They can also be accessed by entering the names of the webhooks into the **Resource Search** field.
+
+The following `kubectl` commands can manually remove the necessary webhooks:
 
 ```console
 kubectl delete mutatingwebhookconfiguration.admissionregistration.k8s.io mutating-webhook-configuration

--- a/versioned_docs/version-2.8/integrations-in-rancher/cluster-api/overview.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/cluster-api/overview.md
@@ -92,7 +92,7 @@ By adding the Turtles repository via the Rancher UI, Rancher can process the ins
 1. Click **Rancher Turtles - the Cluster API Extension**.
 1. Click **Install > Next > Install**.
 
-This process uses the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from the Rancher UI or you can [manually install the chart via Helm](#installing-via-helm). For details about available values, see the Rancher Turtles [Helm chart reference guide](https://turtles.docs.rancher.com/docs/reference-guides/rancher-turtles-chart/values).
+This process uses the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from the Rancher UI or you can [manually install the chart via Helm](#installing-via-helm). For details about available values, see the Rancher Turtles [Helm chart reference guide](https://turtles.docs.rancher.com/reference-guides/rancher-turtles-chart/values).
 
 The installation may take a few minutes and after completing you can see the following new deployments in the cluster:
 
@@ -177,7 +177,7 @@ stringData:
 
 :::info
 
-For detailed information on the values supported by the chart and their usage, refer to [Helm chart options](https://turtles.docs.rancher.com/docs/reference-guides/rancher-turtles-chart/values)
+For detailed information on the values supported by the chart and their usage, refer to [Helm chart options](https://turtles.docs.rancher.com/reference-guides/rancher-turtles-chart/values)
 
 :::
 
@@ -185,7 +185,7 @@ For detailed information on the values supported by the chart and their usage, r
 
 :::note
 
-Remember that if you opt for this installation option, you must manage the CAPI Operator installation yourself. You can follow the [CAPI Operator guide](https://turtles.docs.rancher.com/docs/tasks/capi-operator/intro) in the Rancher Turtles documentation for assistance.
+Remember that if you opt for this installation option, you must manage the CAPI Operator installation yourself. You can follow the [CAPI Operator guide](https://turtles.docs.rancher.com/tasks/capi-operator/intro) in the Rancher Turtles documentation for assistance.
 
 :::
 


### PR DESCRIPTION
Adding an update to the CAPI Overview page "Prerequisites" section specifying where to disable and remove webhooks and the embedded-cluster-api, as well as adding links to the CAPI site on CAPI provider information.