### PR TITLE
#1228 Overlay test for Windows nodes

### DIFF
--- a/docs/troubleshooting/other-troubleshooting-tips/networking.md
+++ b/docs/troubleshooting/other-troubleshooting-tips/networking.md
@@ -13,6 +13,7 @@ Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG
 ### Double check if all the required ports are opened in your (host) firewall
 
 Double check if all the [required ports](../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/node-requirements-for-rancher-managed-clusters.md#networking-requirements) are opened in your (host) firewall. The overlay network uses UDP in comparison to all other required ports which are TCP.
+
 ### Check if overlay network is functioning correctly
 
 The pod can be scheduled to any of the hosts you used for your cluster, but that means that the NGINX ingress controller needs to be able to route the request from `NODE_1` to `NODE_2`. This happens over the overlay network. If the overlay network is not functioning, you will experience intermittent TCP/HTTP connection failures due to the NGINX ingress controller not being able to route to the pod.
@@ -21,7 +22,7 @@ To test the overlay network, you can launch the following `DaemonSet` definition
 
 :::note
 
-This container [does not support ARM nodes](https://github.com/leodotcloud/swiss-army-knife/issues/18), such as a Raspberry Pi. This will be seen in the pod logs as `exec user process caused: exec format error`.
+The `swiss-army-knife` container does not support Windows nodes. It also [does not support ARM nodes](https://github.com/leodotcloud/swiss-army-knife/issues/18), such as a Raspberry Pi. When the test encounters incompatible nodes, this is recorded in the pod logs with the message, `exec user process caused: exec format error`.
 
 :::
 

--- a/versioned_docs/version-2.0-2.4/troubleshooting/other-troubleshooting-tips/networking.md
+++ b/versioned_docs/version-2.0-2.4/troubleshooting/other-troubleshooting-tips/networking.md
@@ -19,7 +19,7 @@ The pod can be scheduled to any of the hosts you used for your cluster, but that
 
 To test the overlay network, you can launch the following `DaemonSet` definition. This will run a `swiss-army-knife` container on every host (image was developed by Rancher engineers and can be found here: https://github.com/rancherlabs/swiss-army-knife), which we will use to run a `ping` test between containers on all hosts.
 
-> **Note:** This container [does not support ARM nodes](https://github.com/leodotcloud/swiss-army-knife/issues/18), such as a Raspberry Pi. This will be seen in the pod logs as `exec user process caused: exec format error`.
+> **Note:** The `swiss-army-knife` container does not support Windows nodes. It also [does not support ARM nodes](https://github.com/leodotcloud/swiss-army-knife/issues/18), such as a Raspberry Pi. When the test encounters incompatible nodes, this is recorded in the pod logs with the message, `exec user process caused: exec format error`.
 
 1. Save the following file as `overlaytest.yml`
 

--- a/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/networking.md
+++ b/versioned_docs/version-2.5/troubleshooting/other-troubleshooting-tips/networking.md
@@ -19,7 +19,7 @@ The pod can be scheduled to any of the hosts you used for your cluster, but that
 
 To test the overlay network, you can launch the following `DaemonSet` definition. This will run a `swiss-army-knife` container on every host (image was developed by Rancher engineers and can be found here: https://github.com/rancherlabs/swiss-army-knife), which we will use to run a `ping` test between containers on all hosts.
 
-> **Note:** This container [does not support ARM nodes](https://github.com/leodotcloud/swiss-army-knife/issues/18), such as a Raspberry Pi. This will be seen in the pod logs as `exec user process caused: exec format error`.
+> **Note:** The `swiss-army-knife` container does not support Windows nodes. It also [does not support ARM nodes](https://github.com/leodotcloud/swiss-army-knife/issues/18), such as a Raspberry Pi. When the test encounters incompatible nodes, this is recorded in the pod logs with the message, `exec user process caused: exec format error`.
 
 1. Save the following file as `overlaytest.yml`
 

--- a/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/networking.md
+++ b/versioned_docs/version-2.6/troubleshooting/other-troubleshooting-tips/networking.md
@@ -21,7 +21,7 @@ To test the overlay network, you can launch the following `DaemonSet` definition
 
 :::note
 
-This container [does not support ARM nodes](https://github.com/leodotcloud/swiss-army-knife/issues/18), such as a Raspberry Pi. This will be seen in the pod logs as `exec user process caused: exec format error`.
+The `swiss-army-knife` container does not support Windows nodes. It also [does not support ARM nodes](https://github.com/leodotcloud/swiss-army-knife/issues/18), such as a Raspberry Pi. When the test encounters incompatible nodes, this is recorded in the pod logs with the message, `exec user process caused: exec format error`.
 
 :::
 

--- a/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/networking.md
+++ b/versioned_docs/version-2.7/troubleshooting/other-troubleshooting-tips/networking.md
@@ -21,7 +21,7 @@ To test the overlay network, you can launch the following `DaemonSet` definition
 
 :::note
 
-This container [does not support ARM nodes](https://github.com/leodotcloud/swiss-army-knife/issues/18), such as a Raspberry Pi. This will be seen in the pod logs as `exec user process caused: exec format error`.
+The `swiss-army-knife` container does not support Windows nodes. It also [does not support ARM nodes](https://github.com/leodotcloud/swiss-army-knife/issues/18), such as a Raspberry Pi. When the test encounters incompatible nodes, this is recorded in the pod logs with the message, `exec user process caused: exec format error`.
 
 :::
 

--- a/versioned_docs/version-2.8/troubleshooting/other-troubleshooting-tips/networking.md
+++ b/versioned_docs/version-2.8/troubleshooting/other-troubleshooting-tips/networking.md
@@ -21,7 +21,7 @@ To test the overlay network, you can launch the following `DaemonSet` definition
 
 :::note
 
-This container [does not support ARM nodes](https://github.com/leodotcloud/swiss-army-knife/issues/18), such as a Raspberry Pi. This will be seen in the pod logs as `exec user process caused: exec format error`.
+The `swiss-army-knife` container does not support Windows nodes. It also [does not support ARM nodes](https://github.com/leodotcloud/swiss-army-knife/issues/18), such as a Raspberry Pi. When the test encounters incompatible nodes, this is recorded in the pod logs with the message, `exec user process caused: exec format error`.
 
 :::
 


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #1228 

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

From the issue: 

> The overlay test, https://ranchermanager.docs.rancher.com/troubleshooting/other-troubleshooting-tips/networking, only works in Linux nodes. If the clusters run Windows worker nodes, the container swiss-army-knife does not run.

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->