### PR TITLE
When using AzureAD authentication provider the rancher URL gets redirected back to the primary URL instead of staying at an alternate.

### DIFF
--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-azure-ad.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-azure-ad.md
@@ -225,10 +225,9 @@ To complete configuration, enter information about your AD instance in the Ranch
 
 **Result:** Azure Active Directory authentication is configured.
 
+#### (Optional) Configure Authentication with Multiple Rancher Domains
 
-#### (Optional) Configure Authentication with Multiple Domains
-
-If you wish to use multiple domain names to manage Rancher, you must manually edit the Azure AD configuration. You can only enter one redirect URI through the Rancher UI, but you can manually configure Azure AD so that alternative domains redirect correctly after authentication suceeds. If you don't manually edit the Azure AD configuration, any domains you wish to use will automatically redirect to the **Redirect URI** value you entered when you registered the app. 
+If you wish to manage Rancher by using multiple domain names, you must manually edit the Azure AD configuration file, `azuread`. This allows you to adjust the redirect URI as needed for your domains. If you don't manually edit `azuread`, then upon a successful login attempt, any Rancher domains will automatically redirect to the **Redirect URI** value you entered when you registered the app in [Step 1. Register Rancher with Azure](#1-register-rancher-with-azure). For example, if you have two domains, _rancher.primary-site.io_ and _rancher.alt-site.io_, you must manually edit `azuread` to prevent a user logging in to _rancher.alt-site.org_ from being redirected to _rancher.primary-site.org_ when authentication suceeds.
 
 ### Migrating from Azure AD Graph API to Microsoft Graph API
 

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-azure-ad.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-azure-ad.md
@@ -8,9 +8,9 @@ title: Configure Azure AD
 
 ## Microsoft Graph API
 
-Azure AD is set up through Microsoft Graph API. Learn how to [set up](#new-user-setup) Azure AD with a new instance or [migrate](#migrating-from-azure-ad-graph-api-to-microsoft-graph-api) an existing instance from Azure AD Graph API to Microsoft Graph API.
+Microsoft Graph API is now the flow through which you will set up Azure AD. The below sections will assist [new users](#new-user-setup) in configuring Azure AD with a new instance as well as assist existing Azure app owners in [migrating to the new flow](#migrating-from-azure-ad-graph-api-to-microsoft-graph-api).
 
-The Microsoft Graph API flow in Rancher is constantly evolving, and is still in active development. Use the latest patched version available to receive new features and improvements.
+The Microsoft Graph API flow in Rancher is constantly evolving. We recommend that you use the latest patched version of 2.7, as it is still in active development and will continue to receive new features and improvements.
 
 ### New User Setup
 
@@ -319,7 +319,7 @@ Token Endpoint   | https://login.partner.microsoftonline.cn/{tenantID}/oauth2/v2
 
 >**Important:**
 >
-> The [Azure AD Graph API](https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-overview) is deprecated and will be retired by Microsoft at any time after June 30, 2023, without advance notice. We will update our docs to advise the community when it is retired. Rancher now uses the [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/use-the-api) as the new flow to set up Azure AD as the external auth provider.
+>- The [Azure AD Graph API](https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-overview) is deprecated and will be retired by Microsoft at any time after June 30, 2023, without advance notice. We will update our docs to advise the community when it is retired. Rancher now uses the [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/use-the-api) as the new flow to set up Azure AD as the external auth provider.
 >
 >
 >- If you're a new user, or wish to migrate, refer to the new flow instructions for <a href="#microsoft-graph-api/" target="_blank">Rancher v2.7.0+</a>.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-azure-ad.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-azure-ad.md
@@ -8,9 +8,9 @@ title: Configure Azure AD
 
 ## Microsoft Graph API
 
-Microsoft Graph API is now the flow through which you will set up Azure AD. The below sections will assist [new users](#new-user-setup) in configuring Azure AD with a new instance as well as assist existing Azure app owners in [migrating to the new flow](#migrating-from-azure-ad-graph-api-to-microsoft-graph-api).
+Azure AD is set up through Microsoft Graph API. Learn how to [set up](#new-user-setup) Azure AD with a new instance or [migrate](#migrating-from-azure-ad-graph-api-to-microsoft-graph-api) an existing instance from Azure AD Graph API to Microsoft Graph API.
 
-The Microsoft Graph API flow in Rancher is constantly evolving. We recommend that you use the latest patched version of 2.7, as it is still in active development and will continue to receive new features and improvements.
+The Microsoft Graph API flow in Rancher is constantly evolving, and is still in active development. Use the latest patched version available to receive new features and improvements.
 
 ### New User Setup
 
@@ -226,6 +226,10 @@ To complete configuration, enter information about your AD instance in the Ranch
 **Result:** Azure Active Directory authentication is configured.
 
 
+#### (Optional) Configure Authentication with Multiple Domains
+
+If you wish to use multiple domain names to manage Rancher, you must manually edit the Azure AD configuration. You can only enter one redirect URI through the Rancher UI, but you can manually configure Azure AD so that alternative domains redirect correctly after authentication suceeds. If you don't manually edit the Azure AD configuration, any domains you wish to use will automatically redirect to the **Redirect URI** value you entered when you registered the app. 
+
 ### Migrating from Azure AD Graph API to Microsoft Graph API
 
 Since the [Azure AD Graph API](https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-overview) is deprecated and slated to retire in June 2023, admins should update their Azure AD App to use the [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/use-the-api) in Rancher.
@@ -316,7 +320,7 @@ Token Endpoint   | https://login.partner.microsoftonline.cn/{tenantID}/oauth2/v2
 
 >**Important:**
 >
->- The [Azure AD Graph API](https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-overview) is deprecated and will be retired by Microsoft at any time after June 30, 2023, without advance notice. We will update our docs to advise the community when it is retired. Rancher now uses the [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/use-the-api) as the new flow to set up Azure AD as the external auth provider.
+> The [Azure AD Graph API](https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-overview) is deprecated and will be retired by Microsoft at any time after June 30, 2023, without advance notice. We will update our docs to advise the community when it is retired. Rancher now uses the [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/use-the-api) as the new flow to set up Azure AD as the external auth provider.
 >
 >
 >- If you're a new user, or wish to migrate, refer to the new flow instructions for <a href="#microsoft-graph-api/" target="_blank">Rancher v2.7.0+</a>.


### PR DESCRIPTION


<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes SURE-7746

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

From ticket:

> When they go to rancher.alt.com and authenticate with AzureAD the URL in the browser is redirected to the main rancher URL rancher.primary.io.
> [...]
> > we should just document that "it's not possible to have different redirect URLs for both domains automatically" and that "you can manually edit the azuread configuration and change the redirect URL as needed." 

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->