### PR TITLE
update missing Chinese translation for v2.6

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/faq/deprecated-features.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/faq/deprecated-features.md
@@ -1,0 +1,37 @@
+---
+title: Rancher 中已弃用的功能
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/faq/deprecated-features"/>
+</head>
+
+### Rancher 的弃用策略是什么？
+
+我们已经在支持的[服务条款](https://rancher.com/support-maintenance-terms)中发布了官方的弃用策略。
+
+### 在哪里可以了解 Rancher 中已弃用哪些功能？
+
+Rancher 将在 GitHub 上发布的 Rancher 的[发版说明](https://github.com/rancher/rancher/releases)中发布已弃用的功能。有关已弃用的功能，请参阅以下的补丁版本：
+
+| 补丁版本                                                          | 发布日期            |
+| ----------------------------------------------------------------- | ------------------- |
+| [2.6.14](https://github.com/rancher/rancher/releases/tag/v2.6.14) | 2024 年 2 月 8 日   |
+| [2.6.13](https://github.com/rancher/rancher/releases/tag/v2.6.13) | 2023 年 5 月 31 日  |
+| [2.6.12](https://github.com/rancher/rancher/releases/tag/v2.6.12) | 2023 年 4 月 27 日  |
+| [2.6.11](https://github.com/rancher/rancher/releases/tag/v2.6.11) | 2023 年 3 月 8 日   |
+| [2.6.10](https://github.com/rancher/rancher/releases/tag/v2.6.10) | 2023 年 1 月 24 日  |
+| [2.6.9](https://github.com/rancher/rancher/releases/tag/v2.6.9)   | 2022 年 10 月 18 日 |
+| [2.6.8](https://github.com/rancher/rancher/releases/tag/v2.6.8)   | 2022 年 8 月 29 日  |
+| [2.6.7](https://github.com/rancher/rancher/releases/tag/v2.6.7)   | 2022 年 8 月 18 日  |
+| [2.6.6](https://github.com/rancher/rancher/releases/tag/v2.6.6)   | 2022 年 6 月 30 日  |
+| [2.6.5](https://github.com/rancher/rancher/releases/tag/v2.6.5)   | 2022 年 5 月 12 日  |
+| [2.6.4](https://github.com/rancher/rancher/releases/tag/v2.6.4)   | 2022 年 3 月 31 日  |
+| [2.6.3](https://github.com/rancher/rancher/releases/tag/v2.6.3)   | 2021 年 12 月 21 日 |
+| [2.6.2](https://github.com/rancher/rancher/releases/tag/v2.6.2)   | 2021 年 10 月 19 日 |
+| [2.6.1](https://github.com/rancher/rancher/releases/tag/v2.6.1)   | 2021 年 10 月 11 日 |
+| [2.6.0](https://github.com/rancher/rancher/releases/tag/v2.6.0)   | 2021 年 8 月 31 日  |
+
+### 当一个功能被标记为弃用我可以得到什么样的预期？
+
+当功能被标记为“已弃用”时，它依然可用并得到支持，允许按照常规的流程进行升级。一旦升级完成，用户/管理员应开始计划在升级到标记为已移除的版本之前放弃使用已弃用的功能。对于新的部署，建议不要使用已弃用的功能。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/faq/general-faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/faq/general-faq.md
@@ -2,68 +2,50 @@
 title: 一般常见问题解答
 ---
 
-本文包含了用户常见的 Rancher 2.x 问题。
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/faq/general-faq"/>
+</head>
+
+此常见问题解答是一项正在进行的工作，旨在回答有关 Rancher v2.x 最常见的问题。
 
 有关常见技术问题，请参阅[常见技术问题解答](technical-items.md)。
 
-<br/>
+## Rancher v2.x 是否支持 Docker Swarm 和 Mesos 作为环境类型?
 
-**Rancher 2.x 支持 Docker Swarm 和 Mesos 作为环境类型吗？**
+在 Rancher v2.x 中创建新环境时，Swarm 和 Mesos 不再是可选择的选项。但是，Swarm 和 Mesos 将继续作为你可以部署的目录应用程序提供。这是一个艰难的决定，但最终归结为采用。例如，在 15,000 多个集群中，只有大约 200 个在运行 Swarm。
 
-如果你在 Rancher 2.x 中创建环境，Swarm 和 Mesos 将不再是可选的标准选项。但是，Swarm 和 Mesos 还能继续作为可以部署的商店应用程序。这是一个艰难的决定，但这是大势所趋。比如说，15,000 多个集群可能只有大约 200 个在运行 Swarm。
+## 可以使用 Rancher v2.x 管理 Azure Kubernetes 服务吗?
 
-<br/>
+是的。请参阅我们的[集群管理](../how-to-guides/new-user-guides/manage-clusters/manage-clusters.md)指南，了解 AKS 上可用的 Rancher 功能，以及[有关 AKS 的文档](../getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.md)。
 
-**是否可以使用 Rancher 2.x 管理 Azure Kubernetes 服务？**
+## Rancher 是否支持 Windows?
 
-是的。
+是的。Rancher 支持 Windows Server 1809 containers。有关如何使用 Windows worker 节点设置集群的详细信息，请参阅[为 Windows 配置自定义集群](../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/use-windows-clusters.md)部分。
 
-<br/>
+## Rancher 是否支持 Istio?
 
-**Rancher 是否支持 Windows？**
+是的。Rancher 支持 [Istio](../integrations-in-rancher/istio/istio.md).
 
-从 Rancher 2.3.0 开始，我们支持 Windows Server 1809 容器。有关如何使用 Windows Worker 节点设置集群的详细信息，请参阅[为 Windows 配置自定义集群](../pages-for-subheaders/use-windows-clusters.md)。
+## Rancher v2.x 会支持 Hashicorp 的 Vault 来存储 secrets 吗?
 
-<br/>
+Secrets 管理已在我们的 roadmap 上，但我们尚未将其分配给特定版本。
 
-**Rancher 是否支持 Istio？**
-
-从 Rancher 2.3.0 开始，我们支持 [Istio.](../pages-for-subheaders/istio.md)
-
-此外，Istio 是在我们的微型 PaaS “Rio” 中实现的，它可以运行在 Rancher 2.x 以及任何符合 CNCF 的 Kubernetes 集群上。详情请参阅[这里](https://rio.io/)。
-
-<br/>
-
-**Rancher 2.x 是否支持使用 Hashicorp 的 Vault 来存储密文？**
-
-密文管理已在我们的 roadmap 上，但我们尚未将该功能分配给特定版本。
-
-<br/>
-
-**Rancher 2.x 是否也支持 RKT 容器？**
+## Rancher v2.x 是否也支持 RKT containers?
 
 目前，我们只支持 Docker。
 
-<br/>
+## Rancher v2.x 是否支持 Calico、Contiv、Contrail、Flannel、Weave net 等嵌入式和注册的 Kubernetes？
 
-**Rancher 2.x 是否支持将 Calico、Contiv、Contrail、Flannel、Weave net 等网络插件用于嵌入和已注册的 Kubernetes？**
+Rancher 开箱即用，为 Kubernetes 集群提供了以下 CNI 网络提供商：Canal、Flannel、Calico 和 Weave。请务必参考 [Rancher 支持矩阵](https://rancher.com/support-maintenance-terms/)了解官方支持的内容。
 
-Rancher 开箱即用地为 Kubernetes 集群提供了几个 CNI 网络插件，分别是 Canal、Flannel、Calico 和 Weave。有关官方支持的详细信息，请参阅 [Rancher 支持矩阵](https://rancher.com/support-maintenance-terms/)。
+## 你是否计划为现有设置支持 Traefik?
 
-<br/>
+我们目前不打算提供嵌入式 Traefik 支持，但我们仍在探索负载均衡方法。
 
-**Rancher 是否计划支持 Traefik？**
+## 我可以将 OpenShift Kubernetes 集群导入 v2.x 吗?
 
-目前，我们不打算提供嵌入式 Traefik 支持，但我们仍在探索负载均衡方案。
+我们的目标是运行任何 Kubernetes 集群。因此，Rancher v2.x 应该可以与 OpenShift 配合使用，但我们还没有测试过。
 
-<br/>
+## Longhorn 是否与 Rancher 集成?
 
-**我可以将 OpenShift Kubernetes 集群导入 2.x 吗？**
-
-我们的目标是运行任何上游 Kubernetes 集群。因此，Rancher 2.x 应该可以与 OpenShift 一起使用，但我们尚未对此进行测试。
-
-<br/>
-
-**Rancher 会集成 Longhorn 吗？**
-
-是的。Longhorn 已集成到 Rancher 2.5+ 中。
+是的。 Longhorn 与 Rancher v2.5 及更高版本集成。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/about-the-api/about-the-api.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/about-the-api/about-the-api.md
@@ -1,0 +1,84 @@
+---
+title: API
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/about-the-api"/>
+</head>
+
+## 如何使用 API
+
+API 有自己的用户界面，你可以从 Web 浏览器访问它。这是查看资源、执行操作以及查看等效 cURL 或 HTTP 请求和响应的一种简单的方法。要访问它：
+
+<Tabs>
+<TabItem value="Rancher v2.6.4+">
+
+1. 单击右上角的用户头像。
+1. 单击**账号 & API 密钥**。
+1. 在 **API 密钥**下，找到 **API 端点**字段并单击链接。该链接类似于 `https://<RANCHER_FQDN>/v3`，其中 `<RANCHER_FQDN>` 是 Rancher deployment 的完全限定域名。
+
+</TabItem>
+<TabItem value="Rancher 版本低于 v2.6.4">
+
+转到位于 `https://<RANCHER_FQDN>/v3` 的 URL 端点，其中 `<RANCHER_FQDN>` 是你的 Rancher deployment 的完全限定域名。
+
+</TabItem>
+</Tabs>
+
+## 认证
+
+API 请求必须包含认证信息。认证是通过 [API 密钥](../user-settings/api-keys.md)使用 HTTP 基本认证完成的。API 密钥可以创建新集群并通过 `/v3/clusters/` 访问多个集群。[集群和项目角色](../../how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/cluster-and-project-roles.md)会应用于这些键，并限制账号可以查看的集群和项目以及可以执行的操作。
+
+默认情况下，某些集群级别的 API 令牌是使用无限期 TTL（`ttl=0`）生成的。换言之，除非你让令牌失效，否则 `ttl=0` 的 API 令牌永远不会过期。有关如何使 API 令牌失效的详细信息，请参阅 [API 令牌](api-tokens.md)。
+
+## 发出请求
+
+该 API 通常是 RESTful 的，但是还具有多种功能。这些功能可以使客户端发现所有内容，因此可以编写通用客户端，而不必为每种资源编写特定代码。有关通用 API 规范的详细信息，请参阅[此处](https://github.com/rancher/api-spec/blob/master/specification.md)。
+
+- 每种类型都有一个 Schema，这个 Schema 描述了以下内容：
+   - 用于获取此类资源集合的 URL
+   - 资源可以具有的每个字段及其类型、基本验证规则、是必填还是可选字段等
+   - 在此类资源上可以执行的每个操作，以及它们的输入和输出（也作为 schema）
+   - 允许过滤的每个字段
+   - 集合本身或集合中的单个资源可以使用的 HTTP 操作方法
+
+
+- 因此，你可以只加载 schema 列表并了解 API 的所有信息。实际上，这是 API 的 UI 工作方式，它不包含特定于 Rancher 本身的代码。每个 HTTP 响应中的 `X-Api-Schemas` 标头都会发送获取 Schemas 的 URL。你可以按照每个 schema 上的 `collection` 链接了解要在哪里列出资源，并在返回资源中的其他 `links` 中获取其他信息。
+
+- 在实践中，你可能只想构造 URL 字符串。我们强烈建议将此限制为在顶层列出的集合 (`/v3/<type>`)，或获取特定资源 (`/v3/<type>/<id>`)。除此之外的任何内容都可能在将来的版本中发生更改。
+
+- 资源之间相互之间有联系，称为链接（links）。每个资源都包含一个 `links` 映射，其中包含链接名称和用于检索该信息的 URL。同样，你应该 `GET` 资源并遵循 `links` 映射中的 URL，而不是自己构造这些字符串。
+
+- 大多数资源都有操作（action），表示可以执行某个操作或改变资源的状态。要使用操作，请将 HTTP `POST` 请求发送到 `actions` 映射中你想要的操作的 URL。某些操作需要输入或生成输出，请参阅每种类型的独立文档或 schema 以获取具体信息。
+
+- 要编辑资源，请将 HTTP `PUT` 请求发送到资源上的 `links.update` 链接，其中包含要更改的字段。如果链接丢失，则你无权更新资源。未知字段和不可编辑的字段将被忽略。
+
+- 要删除资源，请将 HTTP `DELETE` 请求发送到资源上的 `links.remove` 链接。如果链接丢失，则你无权更新资源。
+
+- 要创建新资源，HTTP `POST` 到 schema（即 `/v3/<type>`）中的集合 URL。
+
+## 过滤
+
+你可以使用 HTTP 查询参数的公共字段在服务器端过滤大多数集合。`filters` 映射显示了可以过滤的字段，以及过滤后的值在你发起的请求中是什么。API UI 具有设置过滤和显示适当请求的控件。对于简单的 "equals" 匹配，它只是 `field=value`。你可以将修饰符添加到字段名称，例如 `field_gt=42` 表示“字段大于 42”。详情请参阅 [API 规范](https://github.com/rancher/api-spec/blob/master/specification.md#filtering)。
+
+## 排序
+
+你可以使用 HTTP 查询参数的公共字段在服务器端排序大多数集合。`sortLinks` 映射显示了可用的排序，以及用于获取遵循该排序的集合的 URL。它还包括当前响排序依据的信息（如果指定）。
+
+## 分页
+
+默认情况下，API 响应以每页 100 个资源的限制进行分页。你可以通过 `limit` 查询参数进行更改，最大为 1000，例如 `/v3/pods?limit=1000`。集合响应中的 `pagination` 映射能让你知道你是否拥有完整的结果集，如果没有，则会指向下一页的链接。
+
+## 捕获 Rancher API 调用
+
+你可以使用浏览器开发人员工具来捕获 Rancher API 的调用方式。例如，你可以按照以下步骤使用 Chrome 开发人员工具来获取用于配置 RKE 集群的 API 调用：
+
+1. 在 Rancher UI 中，转到**集群管理**并单击**创建**。
+1. 单击某个集群类型。此示例使用 Digital Ocean。
+1. 使用集群名称和节点模板填写表单，但不要单击**创建**。
+1. 在创建集群之前，你需要打开开发人员工具才能看到正在记录的 API 调用。要打开工具，右键单击 Rancher UI，然后单击**检查**。
+1. 在开发者工具中，单击 **Network** 选项卡。
+1. 在 **Network** 选项卡上，确保选择了 **Fetch/XHR**。
+1. 在 Rancher UI 中，单击**创建**。在开发者工具中，你应该会看到一个名为 `cluster?_replace=true` 的新网络请求。
+1. 右键单击 `cluster?_replace=true` 并单击**复制 > 复制为 cURL**。
+1. 将结果粘贴到文本编辑器中。你将能够看到 POST 请求，包括被发送到的 URL、所有标头以及请求的完整正文。此命令可用于从命令行创建集群。请注意，请求包含凭证，因此请将请求存储在安全的地方。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/about-the-api/api-tokens.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/about-the-api/api-tokens.md
@@ -2,6 +2,10 @@
 title: API 令牌
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/about-the-api/api-tokens"/>
+</head>
+
 默认情况下，某些集群级别的 API 令牌是使用无限期 TTL（`ttl=0`）生成的。换言之，除非你让令牌失效，否则 `ttl=0` 的 API 令牌永远不会过期。令牌不会因为更改密码而失效。
 
 要停用 API 令牌，你可以删除令牌或停用用户账号。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cli-with-rancher/cli-with-rancher.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cli-with-rancher/cli-with-rancher.md
@@ -1,0 +1,9 @@
+---
+title: Rancher CLI
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/cli-with-rancher"/>
+</head>
+
+Rancher CLI 是一个命令行工具，用于在工作站中与 Rancher 进行交互。以下文档将描述 [Rancher CLI](rancher-cli.md) 和 [kubectl实用程序](kubectl-utility.md)。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cli-with-rancher/kubectl-utility.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cli-with-rancher/kubectl-utility.md
@@ -2,6 +2,10 @@
 title: kubectl 实用程序
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/cli-with-rancher/kubectl-utility"/>
+</head>
+
 ## kubectl
 
 kubectl 用于与 Rancher 进行交互。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cli-with-rancher/rancher-cli.md
@@ -3,6 +3,10 @@ title: Rancher CLI
 description: Rancher CLI 是一个命令行工具，用于在工作站中与 Rancher 进行交互。
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/cli-with-rancher/rancher-cli"/>
+</head>
+
 Rancher CLI（命令行界面）是一个命令行工具，可用于与 Rancher 进行交互。使用此工具，你可以使用命令行而不用通过 GUI 来操作 Rancher。
 
 ### 下载 Rancher CLI

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/pipelines/pipelines.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/pipelines/pipelines.md
@@ -1,0 +1,278 @@
+---
+title: 流水线
+---
+
+:::note 备注
+
+- 从 Rancher v2.5 开始，基于 Git 部署的流水线现已弃用。我们建议使用由 [Fleet](../../how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md) 提供支持的 Rancher Continuous Delivery 来处理流水线。要访问 Rancher 中的 Fleet，请点击 <b>☰ > 持续交付</b>。
+
+- 流水线在 Kubernetes 1.21+ 中不再支持。
+
+- Fleet 不会取代 Rancher 流水线，区别在于 Rancher 流水线现在由 Fleet 提供支持。
+
+:::
+
+Rancher 的流水线提供了简单的 CI/CD 体验，但它不能替代企业级 Jenkins 或团队使用的其他 CI 工具，也不能提供全部的功能和灵活性。
+
+设置流水线可以帮助开发人员尽可能快速高效地交付新软件。使用 Rancher，可以与 GitHub 存储库集成以设置持续集成（CI）流水线。
+
+配置 Rancher 和 GitHub 后，你可以部署运行 Jenkins 的容器来自动执行流水线：
+
+- 使用代码构建应用程序镜像。
+- 验证你的构建。
+- 将构建镜像部署到集群。
+- 运行单元测试。
+- 运行回归测试。
+
+:::note
+
+Rancher 的流水线提供了简单的 CI/CD 体验，但它不能替代企业级 Jenkins 或团队使用的其他 CI 工具，也不能提供全部的功能和灵活性。
+
+:::
+
+## 概念
+
+有关本节中使用的概念和术语的解释，请参阅[本页。](concepts.md)
+
+## 流水线如何工作
+
+在项目中开启流水线后，可以在每个项目中配置多个流水线。每个流水线都是唯一的，可以独立配置。
+
+流水线是根据签入源代码存储库的一组文件配置的。用户可以通过 Rancher UI 或在仓库中添加 `.rancher-pipeline.yml` 来配置他们的流水线。
+
+在配置流水线之前，你需要配置对版本控制提供程序（例如 GitHub、GitLab、Bitbucket）的认证。如果尚未配置版本控制提供程序，则始终可以使用 [Rancher 的示例存储库](example-repositories.md)查看一些常见的流水线部署。
+
+在其中一个项目中配置流水线时，将自动创建专门用于流水线的命名空间。将以下组件部署到其中：
+
+- **Jenkins:**
+
+  流水线的构建引擎。由于项目用户不直接与 Jenkins 交互，因此它是托管和锁定的。
+
+  :::note
+
+  无法使用现有 Jenkins deployments 作为流水线引擎。
+
+  :::
+
+- **Docker Registry:**
+
+  开箱即用，生成-发布步骤的默认目标是内部 Docker Registry。但是，你可以进行配置以推送到远程 registry。内部 Docker Registry 只能从集群节点访问，用户无法直接访问。镜像不会在流水线的生存期之后保留，并且只能在流水线运行中使用。如果需要在流水线运行之外访问镜像，请推送到外部 registry。
+
+- **Minio:**
+
+  Minio 存储用于存储流水线执行的日志。
+
+:::note
+
+托管的 Jenkins 实例以无状态方式工作，因此无需担心其数据持久性。默认情况下，Docker Registry 和 Minio 实例使用临时卷，这对于大多数用例来说都很好。如果要确保流水线日志能够在节点故障后继续运行，可以为它们配置持久卷，如[流水线组件的数据持久性](configure-persistent-data.md)中所述。
+
+:::
+
+## 流水线基于角色的访问控制
+
+如果可以访问项目，则可以使存储库开始构建流水线。
+
+仅[管理员](../../how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions.md)，[集群所有者或成员](../../how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/cluster-and-project-roles.md#cluster-roles)，或[项目成员](../../how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/cluster-and-project-roles.md#project-roles)可以配置版本控制提供程序并管理全局流水线执行设置。
+
+项目成员只能配置存储库和流水线。
+
+## 设置流水线
+
+### 先决条件
+
+:::note legacy 功能标志：
+
+由于流水线应用程序已被弃用，取而代之的是 Fleet，因此你需要在使用流水线之前打开 legacy 功能的功能标志。 请注意，Kubernetes 1.21+ 中不再支持流水线。
+
+1. 点击左上角 **☰ > 全局设置**。
+1. 点击 **功能开关**。
+1. 转到 `legacy` 功能标志并点击 **⋮ > 激活**。
+
+:::
+
+1. [配置版本控制提供程序](#1-配置版本控制提供程序)
+2. [配置存储库](#2-配置存储库)
+3. [配置流水线](#3-配置流水线)
+
+### 1. 配置版本控制提供程序
+
+在开始为存储库配置流水线之前，你必须配置并授权版本控制提供程序：
+
+- GitHub
+- GitLab
+- Bitbucket
+
+选择下面你的提供商的选项卡并按照说明进行操作。
+
+<Tabs>
+<TabItem value="GitHub">
+
+1. 点击左上角 **☰ > 集群管理**。
+1. 进入要配置流水线的集群，然后点击 **浏览**。
+1. 在顶部导航栏的下拉菜单中，选择要配置流水线的项目。
+1. 在左侧导航栏中，点击 **Legacy > Project >流水线**。
+1. 点击 **配置** 选项卡。
+1. 按照显示的说明 **设置 Github 应用程序**。Rancher 会重定向到 Github，在 Github 中设置 OAuth 应用。
+1. 在 GitHub 中，复制 **Client ID** 和 **Client Secret**。将它们粘贴到 Rancher 中。
+1. 如果你使用的是 GitHub 企业版，请选择 **使用私有 github 企业版安装**。输入 GitHub 安装的主机地址。
+1. 点击 **认证**。
+
+</TabItem>
+<TabItem value="GitLab">
+
+1. 点击左上角 **☰ > 集群管理**。
+1. 进入要配置流水线的集群，然后点击 **浏览**。
+1. 在顶部导航栏的下拉菜单中，选择要配置流水线的项目。
+1. 在左侧导航栏中，点击 **Legacy > Project >流水线**。
+1. 点击 **配置** 选项卡。
+1. 点击 **GitLab**。
+1. 按照显示的说明 **设置 GitLab 应用程序**。Rancher 会重定向到 GitLab。
+1. 从 GitLab 中复制 **Application ID** 和 **Secret**。将它们粘贴到 Rancher 中。
+1. 如果你使用的是 GitLab 企业版，请选择 **使用私有 gitlab 企业版安装**。输入 GitLab 安装的主机地址。
+1. 点击 **认证**。
+
+:::note 备注：
+
+1.流水线使用 Gitlab [v4 API](https://docs.gitlab.com/ee/api/v3_to_v4.html)，支持的 Gitlab 版本为 9.0+。 2. 如果你使用的是 GitLab 10.7+，并且你的 Rancher 设置位于本地网络中，请在 GitLab 管理员设置中启用 **允许从钩子和服务向本地网络发出请求** 选项。
+
+:::
+
+</TabItem>
+<TabItem value="Bitbucket Cloud">
+
+1. 点击左上角 **☰ > 集群管理**。
+1. 进入要配置流水线的集群，然后点击 **浏览**。
+1. 在顶部导航栏的下拉菜单中，选择要配置流水线的项目。
+1. 在左侧导航栏中，点击 **Legacy > Project >流水线**。
+1. 点击 **配置** 选项卡。
+1. 点击 **Bitbucket** 并默认选中 **使用 Bitbucket Cloud**。
+1. 按照显示的说明进行 **设置 Bitbucket Cloud 应用程序**。Rancher 会重定向到 Bitbucket，以便在 Bitbucket 中设置 OAuth 使用者。
+1. 从 Bitbucket 中，复制使用者 **Key** 和 **Secret**。将它们粘贴到 Rancher 中。
+1. 点击 **认证**。
+
+</TabItem>
+<TabItem value="Bitbucket Server">
+
+1. 点击左上角 **☰ > 集群管理**。
+1. 进入要配置流水线的集群，然后点击 **浏览**。
+1. 在顶部导航栏的下拉菜单中，选择要配置流水线的项目。
+1. 在左侧导航栏中，点击 **Legacy > Project >流水线**。
+1. 点击 **配置** 选项卡。
+1. 点击 **Bitbucket** 并选择 **使用私有 Bitbucket Server 设置** 选项。
+1. 按照显示的说明进行 **设置 Bitbucket Server 应用程序**。
+1. 输入 Bitbucket Server 安装的主机地址。
+1. 点击 **认证**。
+
+:::note
+
+Bitbucket server 在向 Rancher 发送 Webhook 时需要进行 SSL 验证。请确保 Rancher server 的证书是 Bitbucket server 信任的。有两种选择：
+
+1. 使用来自受信任 CA 的证书设置 Rancher server。
+1. 如果你使用的是自签名证书，请将 Rancher server 的证书导入 Bitbucket server。有关说明，请参阅[配置自签名证书](https://confluence.atlassian.com/bitbucketserver/if-you-use-self-signed-certificates-938028692.html)的 Bitbucket server 文档。
+
+:::
+
+</TabItem>
+</Tabs>
+
+**结果:** 对版本控制提供程序进行认证后，系统将自动重定向到开始配置要开始与流水线一起使用的存储库。
+
+### 2. 配置存储库
+
+在对版本控制提供程序进行授权后，系统会自动将你重定向到开始配置要开始使用流水线的存储库。即使其他人设置了版本控制提供程序，你也会看到他们的存储库，并可以生成流水线。
+
+1. 点击左上角 **☰ > 集群管理**。
+1. 进入要配置流水线的集群，然后点击 **浏览**。
+1. 在顶部导航栏的下拉菜单中，选择要配置流水线的项目。
+1. 在左侧导航栏中，点击 **Legacy > Project >流水线**。
+1. 点击 **配置** 选项卡。
+
+1. 将显示存储库列表。如果你是第一次配置存储库，请单击 **授权并获取你自己的存储库** 来获取存储库列表。
+
+1. 对于要设置流水线的每个存储库，单击 **启用**。
+
+1. 完成所有存储库的启用后，点击 **完成**。
+
+**结果:** 你有一个存储库列表，可以开始为其配置流水线。
+
+### 3. 配置流水线
+
+现在，存储库已添加到你的项目中，你可以通过添加自动化阶段和步骤来开始配置流水线。为方便起见，有多种内置步骤类型用于专用任务。
+
+1. 点击左上角 **☰ > 集群管理**。
+1. 进入要配置流水线的集群，然后点击 **浏览**。
+1. 在顶部导航栏的下拉菜单中，选择要配置流水线的项目。
+1. 在左侧导航栏中，点击 **Legacy > Project >流水线**。
+1. 找到要为其设置流水线的存储库。
+1. 通过 UI 或使用仓库中的 yaml 文件配置流水线，即 `.rancher-pipeline.yml` 或 `.rancher-pipeline.yaml`。流水线配置分为多个阶段和步骤。在进入下一阶段之前，阶段必须完全完成，但阶段中的步骤会同时运行。对于每个阶段，你可以添加不同的步骤类型。注意：在构建每个步骤时，根据步骤类型有不同的高级选项。高级选项包括触发规则、环境变量和密文。有关通过 UI 或 YAML 文件配置流水线的详细信息，请参阅[流水线配置参考。](pipeline-configuration.md)
+
+   - 如果要使用 UI，请选择 **⋮ > 编辑配置** 以使用 UI 配置流水线。配置流水线后，必须查看 YAML 文件并将其推送到存储库。
+   - 如果要使用 YAML 文件，请选择 **⋮ > 查看/编辑 YAML** 来配置流水线。如果选择使用 YAML 文件，则需要在进行任何更改后将其推送到存储库，以便在存储库中更新它。编辑流水线配置时，Rancher 需要一些时间来检查现有的流水线配置。
+
+1. 从分支列表中选择要使用的`分支`。
+
+1. 可选：设置通知。
+
+1. 设置流水线的触发规则。
+
+1. 输入流水线的 **超时**。
+
+1. 配置完所有阶段和步骤后，单击 **完成**。
+
+**结果:** 你的流水线已经配置完毕，可以运行了。
+
+## 流水线配置参考
+
+有关如何将流水线配置为以下的详细信息，请参阅[此页面](pipeline-configuration.md)：
+
+- 运行脚本
+- 构建和发布镜像
+- 发布 catalog 模板
+- 部署 YAML
+- 部署 catalog app
+
+配置参考还介绍了如何配置：
+
+- 通知
+- 超时
+- 触发流水线的规则
+- 环境变量
+- 密文
+
+## 运行流水线
+
+首次运行流水线。找到流水线并选择 **⋮ > Run**。
+
+在此初始运行期间，将测试流水线，并将以下流水线组件作为专用于流水线的新命名空间中的工作负载部署到项目中：
+
+- `docker-registry`
+- `jenkins`
+- `minio`
+
+此过程需要几分钟时间。完成后，可以从项目 **Workloads** 选项卡查看每个流水线组件。
+
+## 触发流水线
+
+启用存储库后，会在版本控制提供程序中自动设置 Webhook。默认情况下，流水线由存储库的 **push** 事件触发，但你可以修改触发运行流水线的事件。
+
+可用事件：
+
+- **Push**: 每当提交推送到仓库中的分支时，都会触发流水线。
+- **Pull Request**: 每当向仓库发出拉取请求时，都会触发流水线。
+- **Tag**: 在仓库中创建标签时，会触发流水线。
+
+:::note
+
+Rancher 的[示例存储库](example-repositories.md)不存在此选项。
+
+:::
+
+### 修改存储库的事件触发器
+
+1. 点击左上角 **☰ > 集群管理**。
+1. 进入要配置流水线的集群，然后点击 **浏览**。
+1. 在顶部导航栏的下拉菜单中，选择要配置流水线的项目。
+1. 在左侧导航栏中，点击 **Legacy > Project >流水线**。
+1. 找到要修改事件触发器的存储库。选择 **⋮ > Setting**.
+1. 选择要为存储库触发的事件 (**Push**, **Pull Request** 或 **Tag**)。
+1. 点击 **保存**.

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/rancher-security/kubernetes-security-best-practices.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/rancher-security/kubernetes-security-best-practices.md
@@ -2,6 +2,10 @@
 title: Kubernetes 安全最佳实践
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/rancher-security/kubernetes-security-best-practices"/>
+</head>
+
 ### 限制云元数据 API 访问
 
 AWS、Azure、DigitalOcean 或 GCP 等云提供商通常会在本地向实例公开元数据服务。默认情况下，此端点可被运行在云实例上的 pod 访问，包括在托管的 Kubernetes（如 EKS、AKS、DigitalOcean Kubernetes 或 GKE）中的 pod，并且可以包含该节点的云凭证、配置数据（如 kubelet 凭证）以及其他敏感数据。为了降低在云平台上运行的这种风险，请遵循 [Kubernetes 安全建议](https://kubernetes.io/docs/tasks/administer-cluster/securing-a-cluster/#restricting-cloud-metadata-api-access)，即限制授予实例凭证的权限，使用网络策略限制 pod 对元数据 API 的访问，并避免使用配置数据来传递密文。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/rancher-security/rancher-security.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/rancher-security/rancher-security.md
@@ -1,0 +1,87 @@
+---
+title: Rancher 安全指南
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/rancher-security"/>
+</head>
+
+<table width="100%">
+<tr style={{verticalAlign: 'top'}}>
+<td width="30%" style={{border: 'none'}}>
+<h4>安全策略</h4>
+<p style={{padding: '8px'}}>Rancher Labs 会负责任地披露问题，并致力于在合理的时间内解决所有问题。 </p>
+</td>
+<td width="30%" style={{border: 'none'}}>
+<h4>报告流程</h4>
+<p style={{padding: '8px'}}>请将安全问题发送至 <a href="mailto:security-rancher@suse.com">security-rancher@suse.com</a>。</p>
+</td>
+<td width="30%" style={{border: 'none'}}>
+<h4>公告</h4>
+<p style={{padding:'8px'}}>订阅 <a href="https://forums.rancher.com/c/announcements">Rancher 公告论坛</a>以获取版本更新。</p>
+</td>
+</tr>
+</table>
+
+安全是 Rancher 全部功能的基础。Rancher 集成了全部主流认证工具和服务，并提供了企业级的 [RBAC 功能](../../how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.md)，让你的 Kubernetes 集群更加安全。
+
+本文介绍了安全相关的文档以及资源，让你的 Rancher 安装和下游 Kubernetes 集群更加安全。
+
+### NeuVector 与 Rancher 的集成
+
+_v2.6.5 中的新功能_
+
+NeuVector 是一个开源的、以容器为中心的安全应用程序，现已集成到 Rancher 中。NeuVector 提供生产安全、DevOps 漏洞保护和容器防火墙等功能。请参阅 [Rancher 文档](../../integrations-in-rancher/neuvector.md) 和 [NeuVector 文档](https://open-docs.neuvector.com/)了解更多信息。
+
+### 在 Kubernetes 集群上运行 CIS 安全扫描
+
+Rancher 使用 [kube-bench](https://github.com/aquasecurity/kube-bench) 来运行安全扫描，从而检查 Kubernetes 是否按照 [CIS](https://www.cisecurity.org/cis-benchmarks/)（Center for Internet Security，互联网安全中心）Kubernetes Benchmark 中定义的安全最佳实践进行部署。
+
+CIS Kubernetes Benchmark 是一个参考文档，用于为 Kubernetes 建立安全配置基线。
+
+CIS 是一个 501(c\)(3) 非营利组织，成立于 2000 年 10 月，其使命是识别、开发、验证、促进和维持网络防御的最佳实践方案，并建立和指导社区，以在网络空间中营造信任的环境。
+
+CIS Benchmark 是目标系统安全配置的最佳实践。CIS Benchmark 是由安全专家、技术供应商、公开和私人社区成员，以及 CIS Benchmark 开发团队共同志愿开发的。
+
+Benchmark 提供两种类型的建议，分别是自动（Automated）和手动（Manual）。我们只运行 Automated 相关的测试。
+
+Rancher 在集群上运行 CIS 安全扫描时会生成一份报告，该报告会显示每个测试的结果，包括测试概要以及 `passed`、`skipped` 和 `failed` 的测试数量。报告还包括失败测试的修正步骤。
+
+有关详细信息，请参阅[安全扫描](../../how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md)。
+
+### SELinux RPM
+
+[安全增强型 Linux (SELinux)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) 是对 Linux 的安全增强。被政府机构使用之后，SELinux 已成为行业标准，并在 CentOS 7 和 8 上默认启用。
+
+我们提供了 `rancher-selinux` 和 `rke2-selinux` 两个 RPM（Red Hat 软件包），让 Rancher 产品能够在 SELinux 主机上正常运行。有关详细信息，请参阅[此页面](selinux-rpm/selinux-rpm.md)。
+
+### Rancher 加固指南
+
+Rancher 加固指南基于 <a href="https://www.cisecurity.org/benchmark/kubernetes/" target="_blank">CIS Kubernetes Benchmark</a>。
+
+加固指南为加固 Rancher 的生产安装提供了说明性指导。有关安全管控的完整列表，请参阅 Rancher 的 [CIS Kubernetes Benchmark 自我评估](#cis-benchmark-和自我评估)指南。
+
+> 加固指南描述了如何保护集群中的节点，建议在安装 Kubernetes 之前参考加固指南中的步骤。
+
+每个加固指南版本都针对特定的 CIS Kubernetes Benchmark、Kubernetes 和 Rancher 版本。
+
+### CIS Benchmark 和自我评估
+
+Benchmark 自我评估是 Rancher 安全加固指南的辅助。加固指南展示了如何加固集群，而 Benchmark 指南旨在帮助你评估加固集群的安全级别。
+
+由于 Rancher 和 RKE 将 Kubernetes 服务安装为 Docker 容器，因此 CIS Kubernetes Benchmark 中的许多管控验证检查都不适用。本指南将介绍各种 controls，并提供更新的示例命令来审计 Rancher 创建的集群的合规性。你可以前往 [CIS 网站](https://www.cisecurity.org/benchmark/kubernetes/)下载原始的 Benchmark 文档。
+
+Rancher 自我评估指南的每个版本都对应于强化指南、Rancher、Kubernetes 和 CIS Benchmark 的特定版本。
+
+### 第三方渗透测试报告
+
+Rancher 会定期聘请第三方对 Rancher 2.x 软件栈进行安全审计和渗透测试。被测环境遵循 Rancher 在测试时提供的强化指南。以前的渗透测试报告如下。
+
+结果：
+
+- [Cure53 渗透测试 - 2019 年 7 月](https://releases.rancher.com/documents/security/pen-tests/2019/RAN-01-cure53-report.final.pdf)
+- [Untamed Theory 渗透测试 - 2019 年 3 月](https://releases.rancher.com/documents/security/pen-tests/2019/UntamedTheory-Rancher_SecurityAssessment-20190712_v5.pdf)
+
+### Rancher 安全公告和 CVE
+
+Rancher 致力于向社区通报我们产品中的安全问题。有关我们已解决的问题的 CVE（常见漏洞和暴露）列表，请参阅[此页](security-advisories-and-cves.md)。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/rancher-security/rancher-v2.6-hardening-guides/rancher-v2.6-hardening-guides.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/rancher-security/rancher-v2.6-hardening-guides/rancher-v2.6-hardening-guides.md
@@ -1,0 +1,50 @@
+---
+title: Rancher v2.6 的自我评估和强化指南
+---
+
+Rancher 为每个受支持的 Rancher 的 Kubernetes 发行版提供了特定的安全强化指南。
+
+## Rancher Kubernetes 发行版
+
+Rancher 使用以下 Kubernetes 发行版：
+
+- [**RKE**](https://rancher.com/docs/rke/latest/en/), Rancher Kubernetes Engine 是一个经过 CNCF 认证的 Kubernetes 发行版，完全在 Docker 容器中运行。
+- [**RKE2**](https://docs.rke2.io/) 是一个完全符合的 Kubernetes 发行版，专注于安全性和合规性。
+- [**K3s**](https://rancher.com/docs/k3s/latest/en/) 是一个完全合规的，轻量级 Kubernetes 发行版。它易于安装，内存需求只有上游 Kubernetes 的一半，所有组件都在一个小于 100 MB 的二进制文件中。
+
+要加固运行未列出的发行版的 Kubernetes 集群，请参阅 Kubernetes 提供商文档。
+
+## 强化指南和 Benchmark 版本
+
+这些指南已经与 Rancher v2.6 版本一起进行了测试。每个自我评估指南都附有强化指南，并在特定的 Kubernetes 版本和 CIS 基准版本上进行了测试。如果 CIS 基准尚未针对你的 Kubernetes 版本进行验证，你可以选择使用现有指南，直到添加更新版本。
+
+### RKE 指南
+
+| Kubernetes 版本           | CIS Benchmark 版本 | 自我评估指南                                                  | 强化指南                                                |
+| ------------------------- | ------------------ | ------------------------------------------------------------- | ------------------------------------------------------- |
+| Kubernetes v1.18 至 v1.23 | CIS v1.6           | [链接](rke1-self-assessment-guide-with-cis-v1.6-benchmark.md) | [链接](rke1-hardening-guide-with-cis-v1.6-benchmark.md) |
+
+:::note
+
+- Kubernetes v1.19 和 v1.20 的 CIS v1.20 Benchmark 测试版本尚未作为 Rancher 的 CIS Benchmark chart 中的配置文件发布。
+
+:::
+
+### RKE2 指南
+
+| 类型                             | Kubernetes 版本           | CIS Benchmark 版本 | 自我评估指南                                                  | 强化指南                                                |
+| -------------------------------- | ------------------------- | ------------------ | ------------------------------------------------------------- | ------------------------------------------------------- |
+| Rancher provisioned RKE2 cluster | Kubernetes v1.21 至 v1.23 | CIS v1.6           | [链接](rke2-self-assessment-guide-with-cis-v1.6-benchmark.md) | [链接](rke2-hardening-guide-with-cis-v1.6-benchmark.md) |
+| Standalone RKE2                  | Kubernetes v1.21 至 v1.23 | CIS v1.6           | [链接](https://docs.rke2.io/security/cis_self_assessment16)   | [链接](https://docs.rke2.io/security/hardening_guide)   |
+
+### K3s 指南
+
+| Kubernetes 版本           | CIS Benchmark 版本 | 自我评估指南                                                             | 强化指南                                                                 |
+| ------------------------- | ------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| Kubernetes v1.21 和 v1.22 | CIS v1.6           | [链接](https://rancher.com/docs/k3s/latest/en/security/self_assessment/) | [链接](https://rancher.com/docs/k3s/latest/en/security/hardening_guide/) |
+
+## 在 SELinux 上使用 Rancher
+
+[Security-Enhanced Linux (SELinux)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) 是对 Linux 的安全性增强。SELinux 在历史上被政府机构使用后，现在是行业标准，并且在 RHEL 和 CentOS 上默认启用。
+
+要将 Rancher 与 SELinux 结合使用，我们建议按照[此页面](../selinux-rpm/about-rancher-selinux.md#installing-the-rancher-selinux-rpm)上的说明安装 `rancher-selinux`。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/rancher-security/security-advisories-and-cves.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/rancher-security/security-advisories-and-cves.md
@@ -2,10 +2,18 @@
 title: 安全公告和 CVE
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/rancher-security/security-advisories-and-cves"/>
+</head>
+
 Rancher 致力于向社区披露我们产品的安全问题。我们会针对已解决的问题发布安全公告和 CVE（Common Vulnerabilities and Exposures，通用漏洞披露）。Rancher GitHub 上的[安全页面](https://github.com/rancher/rancher/security/advisories)也会发布新的安全公告。
 
 | ID | 描述 | 日期 | 解决 |
 |----|-------------|------|------------|
+| [CVE-2023-32193](https://github.com/rancher/norman/security/advisories/GHSA-r8f4-hv23-6qp6) | 在 Rancher 2.6.13、2.7.9 和 2.8.1 及之前的版本中发现了一个问题。多个 Cross-Site Scripting (XSS) 漏洞可通过 Rancher UI (Norman) 进行利用。 | 2024 年 2 月 8 日 | Rancher [v2.8.2](https://github.com/rancher/rancher/releases/tag/v2.8.2)、[v2.7.10](https://github.com/rancher/rancher/releases/tag/v2.7.10) 和 [v2.6.14](https://github.com/rancher/rancher/releases/tag/v2.6.14) |
+| [CVE-2023-32192](https://github.com/rancher/apiserver/security/advisories/GHSA-833m-37f7-jq55) | 在 Rancher 2.6.13、2.7.9 和 2.8.1 及之前的版本中发现了一个问题。多个 Cross-Site Scripting (XSS) 漏洞，可以通过 Rancher UI (Apiserver) 进行利用 | 2024 年 2 月 8 日 | Rancher [v2.8.2](https://github.com/rancher/rancher/releases/tag/v2.8.2)、[v2.7.10](https://github.com/rancher/rancher/releases/tag/v2.7.10) 和 [v2.6.14](https://github.com/rancher/rancher/releases/tag/v2.6.14) |
+| [CVE-2023-22649](https://github.com/rancher/rancher/security/advisories/GHSA-xfj7-qf8w-2gcr) | 在 Rancher 2.6.13、2.7.9 和 2.8.1 及之前的版本中发现了一个问题。敏感数据可能会泄漏到 Rancher 的审计日志中。 | 2024 年 2 月 8 日 | Rancher [v2.8.2](https://github.com/rancher/rancher/releases/tag/v2.8.2)、[v2.7.10](https://github.com/rancher/rancher/releases/tag/v2.7.10) 和 [v2.6.14](https://github.com/rancher/rancher/releases/tag/v2.6.14) |
+| [CVE-2023-32194](https://github.com/rancher/rancher/security/advisories/GHSA-c85r-fwc7-45vc) | 在 Rancher 2.6.13、2.7.9 和 2.8.1 及之前的版本中发现了一个问题。当为 “namespace” 资源类型授予 `create` 或 `*` 全局角色时，任何 API 组中拥有权限的用户可以管理核心 API 组中的 namespace。 | 2024 年 2 月 8 日 | Rancher [v2.8.2](https://github.com/rancher/rancher/releases/tag/v2.8.2)、[v2.7.10](https://github.com/rancher/rancher/releases/tag/v2.7.10) 和 [v2.6.14](https://github.com/rancher/rancher/releases/tag/v2.6.14) |
 | [CVE-2023-22648](https://github.com/rancher/rancher/security/advisories/GHSA-vf6j-6739-78m8) | 在 Rancher 2.6.12 和 2.7.3 及之前的版本中发现了一个问题。在用户注销并重新登录到 Rancher UI 之前，Azure AD 中的权限更改不会反映给用户。 | 2023 年 5 月 31 日 | Rancher [v2.6.13](https://github.com/rancher/rancher/releases/tag/v2.6.13) |
 | [CVE-2022-43760](https://github.com/rancher/rancher/security/advisories/GHSA-46v3-ggjg-qq3x) | 在 Rancher 2.6.12 和 2.7.3 及之前的版本中发现了一个问题。攻击者可以通过 Rancher UI 利用多个跨站脚本 (XSS) 漏洞。 | 2023 年 5 月 31 日 | Rancher [v2.6.13](https://github.com/rancher/rancher/releases/tag/v2.6.13) |
 | [CVE-2020-10676](https://github.com/rancher/rancher/security/advisories/GHSA-8vhc-hwhc-cpj4) | 在 Rancher 2.6.12 和 2.7.3 及之前的版本中发现了一个问题。具有更新命名空间权限的用户可以将该命名空间移动到他们无权访问的项目中。 | 2023 年 5 月 31 日 | Rancher [v2.6.13](https://github.com/rancher/rancher/releases/tag/v2.6.13) |

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/rancher-security/selinux-rpm/selinux-rpm.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/rancher-security/selinux-rpm/selinux-rpm.md
@@ -1,0 +1,20 @@
+---
+title: SELinux RPM
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/rancher-security/selinux-rpm"/>
+</head>
+
+[安全增强型 Linux (SELinux)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) 是对 Linux 的安全增强。
+
+它由 Red Hat 开发，是 Linux 上 MAC（mandatory access controls，强制访问控制）的实现。系统管理员可以使用 MAC 设置应用程序和用户是如何访问不同资源的，例如文件、设备、网络和进程间的通信。SELinux 还通过默认限制操作系统来增强安全性。
+
+被政府机构使用之后，SELinux 已成为行业标准，并在 CentOS 7 和 8 上默认启用。要检查 SELinux 是否在你的系统上启用和执行，请使用 `getenforce`：
+
+```
+# getenforce
+Enforcing
+```
+
+我们提供了 [`rancher-selinux`](about-rancher-selinux.md) 和 [`rke2-selinux`](about-rke2-selinux.md) 两个 RPM（Red Hat 软件包），让 Rancher 产品能够在 SELinux 主机上正常运行。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/user-settings/user-settings.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/user-settings/user-settings.md
@@ -1,0 +1,19 @@
+---
+title: 用户设置
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/user-settings"/>
+</head>
+
+在 Rancher 中，每个用户都有很多与登录相关的设置，例如个人偏好、API 密钥等。你可以从**用户设置**菜单中配置这些设置。你可以单击主菜单中的头像来打开此菜单。
+
+![用户设置菜单](/img/user-settings.png)
+
+可用的用户设置包括：
+
+- [API & 密钥](api-keys.md)：如果你想以编程方式与 Rancher 交互，你需要一个 API 密钥。你可以按照本节中的说明获取密钥。
+- [云凭证](manage-cloud-credentials.md)：管理[节点模板](../../how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider.md#节点模板)使用的云凭证，从而[为集群配置节点](../../how-to-guides/new-user-guides/launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md)。
+- [节点模板](manage-node-templates.md)：管理 [Rancher 用来为集群配置节点](../../how-to-guides/new-user-guides/launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md)的模板。
+- [偏好设置](user-preferences.md)：设置 Rancher UI 的表面首选项。
+- 登出：结束你的用户会话。


### PR DESCRIPTION
Updated the following documentation for v2.6:

- reference-guides/pipeline/pipeline.md
- reference-guides/cli-with-rancher/cli-with-rancher.md
- reference-guides/about-the-api/about-the-api.md
- reference-guides/user-settings/user-settings.md
- reference-guides/rancher-security/rancher-security.md
- reference-guides/rancher-security/rancher-v2.6-hardening-guides/rancher-v2.6-hardening-guides.md
- reference-guides/rancher-security/selinux-rpm/selinux-rpm.md
- reference-guides/rancher-security/security-advisories-and-cves.md
- faq/general-faq.md
- faq/deprecated-features.md