### PR TITLE
Update missing Chinese translation 2.7 and 2.6

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6.json
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6.json
@@ -124,32 +124,36 @@
     "description": "The label for category Infrastructure Setup in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.Kubernetes Clusters in Rancher Setup": {
-    "message": "Rancher 设置中的 Kubernetes 集群",
+    "message": "Rancher 中的 Kubernetes 集群设置",
     "description": "The label for category Kubernetes Clusters in Rancher Setup in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.Checklist for Production-Ready Clusters": {
     "message": "生产就绪集群检查清单",
     "description": "The label for category Checklist for Production-Ready Clusters in sidebar tutorialSidebar"
   },
-  "sidebar.tutorialSidebar.category.Set Up Clusters from Hosted Kubernetes Providers": {
+  "sidebar.tutorialSidebar.category.Setting up Clusters from Hosted Kubernetes Providers": {
     "message": "通过托管 Kubernetes 提供商设置集群",
-    "description": "The label for category Set Up Clusters from Hosted Kubernetes Providers in sidebar tutorialSidebar"
+    "description": "The label for category Setting up Clusters from Hosted Kubernetes Providers in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Launching Kubernetes on Windows Clusters": {
+    "message": "在 Windows 集群上启动 Kubernetes",
+    "description": "The label for category Launching Kubernetes on Windows Clusters in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.Use Windows Clusters": {
     "message": "使用 Windows 集群",
     "description": "The label for category Use Windows Clusters in sidebar tutorialSidebar"
   },
-  "sidebar.tutorialSidebar.category.Set Up Cloud Providers": {
+  "sidebar.tutorialSidebar.category.Setting up Cloud Providers": {
     "message": "设置 Cloud Provider",
-    "description": "The label for category Set Up Cloud Providers in sidebar tutorialSidebar"
+    "description": "The label for category Setting up Cloud Providers in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.Launch Kubernetes with Rancher": {
     "message": "使用 Rancher 启动 Kubernetes",
     "description": "The label for category Launch Kubernetes with Rancher in sidebar tutorialSidebar"
   },
-  "sidebar.tutorialSidebar.category.Use New Nodes in an Infra Provider": {
+  "sidebar.tutorialSidebar.category.Launching New Nodes in an Infra Provider": {
     "message": "在基础设施提供商中使用新节点",
-    "description": "The label for category Use New Nodes in an Infra Provider in sidebar tutorialSidebar"
+    "description": "The label for category Launching New Nodes in an Infra Provider in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.vSphere": {
     "message": "vSphere",

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/about-provisioning-drivers.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/about-provisioning-drivers.md
@@ -1,0 +1,51 @@
+---
+title: 配置驱动
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers"/>
+</head>
+
+使用 Rancher 中的驱动，你可以管理可以使用哪些供应商来部署[托管的 Kubernetes 集群](../../kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md)或[云服务器节点](../../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider.md)，以允许 Rancher 部署和管理 Kubernetes。
+
+###  Rancher 驱动
+
+你可以启用或禁用 Rancher 中内置的驱动。如果相关驱动 Rancher 尚未实现，你可以添加自己的驱动。
+
+Rancher 中有两种类型的驱动：
+
+* [集群驱动](#集群驱动)
+* [主机驱动](#主机驱动)
+
+### 集群驱动
+
+集群驱动用于配置[托管的 Kubernetes 集群](../../kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md)，例如 GKE、EKS、AKS 等。创建集群时可以显示的集群驱动，是由集群驱动的状态定义的。只有 `active` 集群驱动将显示为为托管 Kubernetes 集群创建集群的选项。默认情况下，Rancher 与几个现有的集群驱动打包在一起，但你也可以创建自定义集群驱动并添加到 Rancher。
+
+默认情况下，Rancher 已激活多个托管 Kubernetes 云提供商，包括：
+
+*  [Amazon EKS](../../kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/eks.md)
+*  [Google GKE](../../kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/gke.md)
+*  [Azure AKS](../../kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/aks.md)
+
+还有几个托管的 Kubernetes 云提供商是默认禁用的，但也打包在 Rancher 中：
+
+* [Alibaba ACK](../../kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/alibaba.md)
+* [Huawei CCE](../../kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/huawei.md)
+* [Tencent](../../kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/tencent.md)
+
+### 主机驱动
+
+主机驱动用于配置主机，Rancher 使用这些主机启动和管理 Kubernetes 集群。主机驱动与 [Docker Machine 驱动](https://docs.docker.com/machine/drivers/)相同。创建主机模板时可以显示的主机驱动，是由主机驱动的状态定义的。只有 `active` 主机驱动将显示为创建节点模板的选项。默认情况下，Rancher 与许多现有的 Docker Machine 驱动打包在一起，但你也可以创建自定义主机驱动并添加到 Rancher。
+
+如果你不想向用户显示特定的主机驱动，则需要停用这些主机驱动。
+
+Rancher 支持几家主要的云提供商，但默认情况下，这些主机驱动处于 active 状态并可供部署：
+
+*   [Amazon EC2](../../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.md)
+*   [Azure](../../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-azure-cluster.md)
+*   [Digital Ocean](../../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-digitalocean-cluster.md)
+*   [vSphere](../../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md)
+
+还有其他几个默认禁用的主机驱动，但打包在 Rancher 中：
+
+*   [Harvester](../../../../integrations-in-rancher/harvester.md#harvester-主机驱动) - 在 Rancher 2.6.1 中可用

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/about-rke1-templates.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/about-rke1-templates.md
@@ -1,0 +1,130 @@
+---
+title: RKE 模板
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates"/>
+</head>
+
+RKE 模板旨在让 DevOps 和安全团队标准化和简化 Kubernetes 集群创建的流程。
+
+RKE 的全称是 [Rancher Kubernetes Engine](https://rancher.com/docs/rke/latest/en/)，它是 Rancher 用来配置 Kubernetes 集群的工具。
+
+随着 Kubernetes 越来越受欢迎，管理更多小型集群逐渐成为趋势。如果你想要创建大量集群，对集群进行一致管理尤为重要。多集群管理面临着安全和附件配置执行的挑战，在将集群移交给最终用户之前，这些配置需要标准化。
+
+RKE 模板有助于标准化这些配置。无论是使用 Rancher UI、Rancher API 还是自动化流程创建的集群，Rancher 都将保证从 RKE 集群模板创建的每个集群在生成方式上是一致的。
+
+管理员可以控制最终用户能更改的集群选项。RKE 模板还可以与特定的用户和组共享，以便管理员可以为不同的用户集创建不同的 RKE 模板。
+
+如果集群是使用 RKE 模板创建的，则不能让集群使用另一个 RKE 模板。你只能将集群更新为同一模板的新版本。
+
+你可以[将现有集群的配置保存为 RKE 模板](apply-templates.md#将现有集群转换为使用-rke-模板)。这样，只有模板更新后才能更改集群的设置。新模板还可用于启动新集群。
+
+RKE 模板的核心功能允许 DevOps 和安全团队：
+
+- 标准化集群配置并确保按照最佳实践创建 Rancher 配置的集群
+- 配置集群时，防止用户做出不明智的选择
+- 与不同的用户和组共享不同的模板
+- 将模板的所有权委托给受信任的用户进行更改
+- 控制哪些用户可以创建模板
+- 要求用户使用模板来创建集群
+
+## 可配置的设置
+
+RKE 模板可以在 Rancher UI 中创建或以 YAML 格式定义。当你使用 Rancher 从基础设施提供商配置自定义节点或一般节点时，它们可以指定为相同的参数：
+
+- 云提供商选项
+- Pod 安全选项
+- 网络提供商
+- Ingress Controller
+- 网络安全配置
+- 网络插件
+- 私有镜像仓库 URL 和凭证
+- 附加组件
+- Kubernetes 选项，包括 kube-api、kube-controller、kubelet 和服务等 Kubernetes 组件的配置
+
+RKE 模板的[附加组件](#附加组件)的功能特别强大，因为它允许多种自定义选项。
+
+## RKE 模板的范围
+
+Rancher 配置的集群支持 RKE 模板。模板可用于配置自定义集群或由基础设施提供商启动的集群。
+
+RKE 模板用于定义 Kubernetes 和 Rancher 设置。节点模板负责配置节点。有关如何将 RKE 模板与硬件结合使用的参考，请参阅 [RKE 模板和硬件](infrastructure.md).
+
+可以从头开始创建 RKE 模板来预先定义集群配置。它们可以用于启动新集群，也可以从现有的 RKE 集群导出模板。
+
+现有集群的设置可以[保存为 RKE 模板](apply-templates.md#converting-an-existing-cluster-to-use-an-rke-template)。这会创建一个新模板并将集群设置绑定到该模板。这样，集群只有在[模板更新](manage-rke1-templates.md#更新模板)的情况下才能[使用新版本的模板](manage-rke1-templates.md#升级集群以使用新的模板修订版)进行升级。新模板也可以用来创建新集群。
+
+
+## 示例场景
+如果一个组织同时拥有普通和高级 Rancher 用户，管理员可能希望为高级用户提供更多用于集群创建的选项，并限制普通用户的选项。
+
+这些[示例场景](example-use-cases.md)描述组织如何使用模板来标准化集群创建。
+
+示例场景包括：
+
+- **强制执行模板**：如果希望所有 Rancher 配置的新集群都具有某些设置，管理员可能想要[为每个用户强制执行一项或多项模板设置](example-use-cases.md#强制执行模板设置)。 
+- **与不同的用户共享不同的模板**：管理员可以为[普通用户和高级用户提供不同的模板](example-use-cases.md#普通用户和高级用户模板)。这样，普通用户会有更多限制选项，而高级用户在创建集群时可以使用更多选项。
+- **更新模板设置**：如果组织的安全和 DevOps 团队决定将最佳实践嵌入到新集群所需的设置中，这些最佳实践可能会随着时间而改变。如果最佳实践发生变化，[可以将模板更新为新版本](example-use-cases.md#更新模板和集群)，这样，使用模板创建的集群可以[升级到模板的新版本](manage-rke1-templates.md#升级集群以使用新的模板修订版)。
+- **共享模板的所有权**：当模板所有者不再想要维护模板或想要共享模板的所有权时，此方案描述了如何[共享模板所有权](example-use-cases.md#允许其他用户控制和共享模板)。
+
+## 模板管理
+
+创建 RKE 模板时，可以在 Rancher UI 中的**集群管理**下的 **RKE 模板**中使用模板。创建模板后，你将成为模板所有者，这将授予你修改和共享模板的权限。你可以与特定用户或组共享 RKE 模板，也可以公开模板。
+
+管理员可以开启模板强制执行，要求用户在创建集群时始终使用 RKE 模板。这使管理员可以保证 Rancher 总是创建指定配置的集群。
+
+RKE 模板更新通过修订系统处理。如果要更改或更新模板，请创建模板的新版本。然后，可以将使用旧版本模板创建的集群升级到新模板修订版。
+
+在 RKE 模板中，模板所有者可以限制设置的内容，也可以打开设置以供最终用户选择值。它们的差别体现在，创建模板时，Rancher UI 中的每个设置上的**允许用户覆盖**标示。
+
+对于无法覆盖的设置，最终用户将无法直接编辑它们。为了让用户使用这些设置的不同选项，RKE 模板所有者需要创建 RKE 模板的新版本，这将允许用户升级和更改该选项。
+
+本节中的文件解释了 RKE 模板管理的细节：
+
+- [获取创建模板的权限](creator-permissions.md)
+- [创建和修改模板](manage-rke1-templates.md)
+- [强制执行模板设置](enforce-templates.md#强制新集群使用-rke-模板) 
+- [覆盖模板设置](override-template-settings.md)
+- [与集群创建者共享模板](access-or-share-templates.md#与特定用户或组共享模板)
+- [共享模板的所有权](access-or-share-templates.md#共享模板所有权)
+
+你可以参见此[模板的示例 YAML 文件](../../../../reference-guides/rke1-template-example-yaml.md)作为参考。
+
+## 应用模板
+
+你可以使用你自己创建的模板来[创建集群](apply-templates.md#使用-rke-模板创建集群)，也可以使用[与你共享的模板](access-or-share-templates.md)来创建集群。
+
+如果 RKE 模板所有者创建了模板的新版本，你可以[将你的集群升级到该版本](apply-templates.md#更新使用-rke-模板创建的集群)。
+
+可以从头开始创建 RKE 模板来预先定义集群配置。它们可以用于启动新集群，也可以从现有的 RKE 集群导出模板。
+
+你可以[将现有集群的配置保存为 RKE 模板](apply-templates.md#将现有集群转换为使用-rke-模板)。这样，只有模板更新后才能更改集群的设置。
+
+## 标准化硬件
+
+RKE 模板的目的是标准化 Kubernetes 和 Rancher 设置。如果你还想标准化你的基础设施，一个选择是将 RKE 模板与[其他工具](infrastructure.md)一起使用。
+
+另一种选择是使用包含节点池配置选项，但不强制执行配置的[集群模板](../../manage-clusters/manage-cluster-templates.md)。
+
+## YAML 定制
+
+如果将 RKE 模板定义为 YAML 文件，则可以修改此[示例 RKE 模板 YAML](../../../../reference-guides/rke1-template-example-yaml.md)。RKE 模板中的 YAML 使用了 Rancher 在创建 RKE 集群时使用的相同自定义设置。但由于 YAML 要在 Rancher 配置的集群中使用，因此需要将 RKE 模板自定义项嵌套在 YAML 中的 `rancher_kubernetes_engine_config` 参数下。
+
+RKE 文档也提供[注释的](https://rancher.com/docs/rke/latest/en/example-yamls/) `cluster.yml` 文件供你参考。
+
+有关可用选项的更多信息，请参阅[集群配置](https://rancher.com/docs/rke/latest/en/config-options/)上的 RKE 文档。
+
+### 附加组件
+
+RKE 模板配置文件的附加组件部分的工作方式与[集群配置文件的附加组件部分](https://rancher.com/docs/rke/latest/en/config-options/add-ons/)相同。
+
+用户定义的附加组件指令允许你调用和下拉 Kubernetes 清单或将它们直接内联。如果这些 YAML 清单包括在 RKE 模板中，Rancher 将在集群中部署这些 YAML 文件。
+
+你可以使用附加组件执行以下操作：
+
+- 启动 Kubernetes 集群后，在集群上安装应用
+- 在使用 Kubernetes Daemonset 部署的节点上安装插件
+- 自动设置命名空间、ServiceAccount 或角色绑定
+
+RKE 模板配置必须嵌套在 `rancher_kubernetes_engine_config` 参数中。要设置附加组件，在创建模板时单击**以 YAML 文件编辑**。然后使用 `addons` 指令添加清单，或使用 `addons_include` 指令设置哪些 YAML 文件可用于附加组件。有关自定义附加组件的更多信息，请参见[用户自定义附加组件文档](https://rancher.com/docs/rke/latest/en/config-options/add-ons/user-defined-add-ons/)。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/infrastructure-setup/infrastructure-setup.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/infrastructure-setup/infrastructure-setup.md
@@ -1,0 +1,12 @@
+---
+title: Kubernetes 集群基础设施
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/how-to-guides/new-user-guides/infrastructure-setup"/>
+</head>
+
+要为具有外部数据库的高可用 K3s Kubernetes 集群设置基础设施，请参见[本页面](ha-k3s-kubernetes-cluster.md)。
+
+
+要为高可用 RKE Kubernetes 集群设置基础设施，请参见[本页面](ha-rke1-kubernetes-cluster.md)。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/kubernetes-cluster-setup.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/kubernetes-cluster-setup.md
@@ -1,0 +1,11 @@
+---
+title: 为 Rancher 服务器设置 Kubernetes 集群
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/how-to-guides/new-user-guides/kubernetes-cluster-setup"/>
+</head>
+
+本章节介绍如何安装 Kubernetes 集群，使得 Rancher Server 可以安装在该集群上。
+
+Rancher 可以在任何 Kubernetes 集群上运行。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/checklist-for-production-ready-clusters.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/checklist-for-production-ready-clusters.md
@@ -1,0 +1,52 @@
+---
+title: 生产就绪集群检查清单
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters"/>
+</head>
+
+本节将介绍创建生产就绪型 Kubernetes 集群的最佳实践。这个集群可用于运行你的应用和服务
+
+有关集群的要求（包括对 OS/Docker、硬件和网络的要求），请参阅[节点要求](../node-requirements-for-rancher-managed-clusters.md)。
+
+本文介绍了我们推荐用于所有生产集群的最佳实践的简短列表。
+
+如需获取推荐的所有最佳实践的完整列表，请参阅[最佳实践](../../../../reference-guides/best-practices/best-practices.md)。
+
+### 节点要求
+
+* 确保你的节点满足所有[节点要求](../node-requirements-for-rancher-managed-clusters.md)，包括端口要求。
+
+### 备份 etcd
+
+* 启用 etcd 快照。验证是否正在创建快照，并执行灾难恢复方案，从而验证快照是否有效。etcd 是存储集群状态的位置，丢失 etcd 数据意味着丢失集群。因此，请确保为集群配置 etcd 的定期快照，并确保快照也是存储在外部（节点外）的。
+
+### 集群架构
+
+* 节点应具有以下角色配置之一：
+  * `etcd`
+  * `controlplane`
+  * `etcd` 和 `controlplane`
+  * `worker`（不应在具有 `etcd` 或 `controlplane` 角色的节点上使用或添加 `worker` 角色）
+* 至少拥有三个角色为 `etcd` 的节点，来确保失去一个节点时仍能存活。增加 etcd 节点数量能提高容错率，而将 etcd 分散到不同可用区甚至能获取更好的容错能力。
+* 为两个或更多节点分配 `controlplane` 角色，能实现主组件的高可用性。
+* 为两个或多个节点分配 `worker` 角色，以便在节点故障时重新安排工作负载。
+
+有关每个角色的用途的更多信息，请参阅 [Kubernetes 中的节点角色](roles-for-nodes-in-kubernetes.md)。
+
+有关每个 Kubernetes 角色的节点数的详细信息，请参阅[推荐架构](../../../../reference-guides/rancher-manager-architecture/architecture-recommendations.md)。
+
+### Logging 和 Monitoring
+
+* 为 Kubernetes 组件（系统服务）配置告警/通知程序。
+* 为集群分析和事后剖析配置 Logging。
+
+### 可靠性
+
+* 在集群上执行负载测试，以验证硬件是否可以支持你的工作负载。
+
+### 网络
+
+* 最小化网络延迟。Rancher 建议尽量减少 etcd 节点之间的延迟。`heartbeat-interval` 的默认设置是 `500`，`election-timeout` 的默认设置是 `5000`。这些 [etcd 调优设置](https://coreos.com/etcd/docs/latest/tuning.html) 允许 etcd 在大多数网络（网络延迟特别高的情况下除外）中运行。
+* 集群节点应位于单个区域内。大多数云厂商在一个区域内提供多个可用区，这可以提高你集群的可用性。任何角色的节点都可以使用多个可用区。如果你使用 [Kubernetes Cloud Provider](../set-up-cloud-providers/set-up-cloud-providers.md) 资源，请查阅文档以了解限制（即区域存储限制）。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/kubernetes-clusters-in-rancher-setup.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/kubernetes-clusters-in-rancher-setup.md
@@ -1,0 +1,80 @@
+---
+title: 在 Rancher 中设置 Kubernetes 集群
+description: 配置 Kubernetes 集群
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup"/>
+</head>
+
+Rancher 允许你通过 Rancher UI 来创建集群，从而简化了集群的创建流程。Rancher 提供了多种启动集群的选项。你可以选择最适合你的用例的选项。
+
+本节默认你已对 Docker 和 Kubernetes 有一定的了解。如果你需要了解 Kubernetes 组件如何协作，请参见 [Kubernetes 概念](../../../reference-guides/kubernetes-concepts.md)。
+
+有关 Rancher Server 配置集群的方式，以及使用什么工具来创建集群的详细信息，请参阅[产品架构](../../../reference-guides/rancher-manager-architecture/rancher-manager-architecture.md)。
+
+
+
+### 不同类型集群的管理功能
+
+下表总结了每一种类型的集群和对应的可编辑的选项和设置：
+
+import ClusterCapabilitiesTable from '../../../shared-files/_cluster-capabilities-table.md';
+
+<ClusterCapabilitiesTable />
+
+## 在托管的 Kubernetes 提供商中设置集群
+
+在这种情况下，Rancher 不会配置 Kubernetes，因为它是由 Google Kubernetes Engine (GKE)、Amazon Elastic Container Service for Kubernetes 或 Azure Kubernetes Service 等提供商安装的。
+
+如果你使用 Kubernetes 提供商，例如 Google GKE，Rancher 将与对应的云 API 集成，允许你从 Rancher UI 为托管集群创建和管理 RBAC。
+
+详情请参阅[托管 Kubernetes 集群](set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md)。
+
+## 使用 Rancher 启动 Kubernetes
+
+在你自己的节点上配置 Kubernetes 时，Rancher 使用 [Rancher Kubernetes Engine (RKE)](https://rancher.com/docs/rke/latest/en/) 作为库。RKE 是 Rancher 自己的轻量级 Kubernetes 安装程序。
+
+在 RKE 集群中，Rancher 管理 Kubernetes 的部署。这些集群可以部署在任何裸机服务器、云提供商或虚拟化平台上。
+
+这些节点可以通过 Rancher 的 UI 动态配置，该 UI 调用 [Docker Machine](https://docs.docker.com/machine/) 在各种云提供商上启动节点。
+
+如果你已经有一个想要添加到 RKE 集群的节点，你可以通过在节点上运行 Rancher Agent 容器将节点添加到集群中。
+
+有关详细信息，请参阅 [RKE 集群](../launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md)。
+
+### 在基础设施提供商中启动 Kubernetes 并配置节点
+
+Rancher 可以在 Amazon EC2、DigitalOcean、Azure 或 vSphere 等基础设施提供商中动态配置节点，然后在节点上安装 Kubernetes。
+
+使用 Rancher，你可以基于[节点模板](../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider.md#节点模板)创建节点池。此模板定义了要在云提供商中启动的节点的参数。
+
+使用由基础设施提供商托管的节点的一个好处是，如果一个节点与集群失去连接，Rancher 可以自动替换它，从而维护集群配置。
+
+Rancher UI 中状态为 Active 的[主机驱动](../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider.md#主机驱动)决定了可用于创建节点模板的云提供商。
+
+如需更多信息，请参阅[基础设施提供商托管的节点](../launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider.md)。
+
+### 在现有自定义节点上启动 Kubernetes
+
+在设置这种类型的集群时，Rancher 会在现有的[自定义节点](../../../reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md)上安装 Kubernetes，从而创建一个自定义集群。
+
+你可以使用任何节点，在 Rancher 中创建一个集群。
+
+这些节点包括本地裸机服务器、云托管虚拟机或本地虚拟机。
+
+## 注册现有集群
+
+集群注册功能取代了导入集群的功能。
+
+注册 EKS 集群的优点更多。在大多数情况下，注册的 EKS 集群和在 Rancher 中创建的 EKS 集群在 Rancher UI 中的处理方式相同（除了删除）。
+
+删除在 Rancher 中创建的 EKS 集群后，该集群将被销毁。删除在 Rancher 中注册的 EKS 集群时，它与 Rancher Server 会断开连接，但它仍然存在。你仍然可以像在 Rancher 中注册之前一样访问它。
+
+详情请参见[本页面](register-existing-clusters.md)。
+
+## 以编程方式创建集群
+
+通过 Rancher 以编程方式部署 Kubernetes 集群的最常见方法是使用 Rancher 2 Terraform Provider。详情请参见[使用 Terraform 创建集群](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/cluster)。
+
+你可以使用 Terraform 创建或导入 EKS、GKE、AKS 集群和 RKE 集群。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/set-up-cloud-providers.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/set-up-cloud-providers.md
@@ -1,0 +1,47 @@
+---
+title: 设置 Cloud Provider
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers"/>
+</head>
+
+_cloud provider_ 是 Kubernetes 中的一个模块，它提供了一个用于管理节点、负载均衡器和网络路由的接口。
+
+在 Rancher 中设置 cloud provider 时，如果你使用的云提供商支持自动化，Rancher Server 可以在启动 Kubernetes 定义时自动配置新节点、负载均衡器或持久存储设备。
+
+如果你配置的节点云提供商集群不满足先决条件，集群将无法正确配置。
+
+**Cloud Provider** 选项默认设置为 `None`。
+
+可以启用的云提供商包括：
+
+* Amazon
+* Azure
+* GCE (Google Compute Engine)
+* vSphere
+
+### 设置 Amazon 云提供商
+
+有关启用 Amazon 云提供商的详细信息，请参阅[此页面](amazon.md)。
+
+### 设置 Azure 云提供商
+
+有关启用 Azure 云提供商的详细信息，请参阅[此页面](azure.md)。
+
+### 设置 GCE 云提供商
+
+有关启用 Google Compute Engine 云提供商的详细信息，请参阅[此页面](google-compute-engine.md)。
+
+### 设置 vSphere 云提供商
+
+有关启用 vSphere 云提供商的详细信息，请参阅[树内 vSphere 配置](configure-in-tree-vsphere.md) 和[树外 vSphere 配置](configure-out-of-tree-vsphere.md)。
+
+### 设置自定义云提供商
+
+任何 Kubernetes Cloud Provider 都可以通过`自定义`云提供商进行配置。
+
+对于自定义云提供商选项，你可以参考 [RKE 文档](https://rancher.com/docs/rke/latest/en/config-options/cloud-providers/)，了解如何为你的云提供商编辑 yaml 文件。特定云提供商的详细配置说明如下：
+
+* [vSphere](https://rke.docs.rancher.com/config-options/cloud-providers/vsphere)
+* [OpenStack](https://rancher.com/docs/rke/latest/en/config-options/cloud-providers/openstack/)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers.md
@@ -1,0 +1,33 @@
+---
+title: 通过托管 Kubernetes 提供商设置集群
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers"/>
+</head>
+
+在这种情况下，Rancher 不会配置 Kubernetes，因为它是由 Google Kubernetes Engine (GKE)、Amazon Elastic Container Service for Kubernetes 或 Azure Kubernetes Service 等提供商安装的。
+
+如果你使用 Kubernetes 提供商，例如 Google GKE，Rancher 将与对应的云 API 集成，允许你从 Rancher UI 为托管集群创建和管理 RBAC。
+
+在这个用例中，Rancher 使用提供商的 API 向托管提供商发送请求。然后，提供商会为你配置和托管集群。集群创建成功后，你可以像管理本地集群或云上集群一样，通过 Rancher UI 对集群进行管理。
+
+Rancher 支持以下 Kubernetes 提供商：
+
+- [Google GKE (Google Kubernetes Engine)](https://cloud.google.com/kubernetes-engine/)
+- [Amazon EKS (Amazon Elastic Container Service for Kubernetes)](https://aws.amazon.com/eks/)
+- [Microsoft AKS (Azure Kubernetes Service)](https://azure.microsoft.com/en-us/services/kubernetes-service/)
+- [Alibaba ACK (Alibaba Cloud Container Service for Kubernetes)](https://www.alibabacloud.com/product/kubernetes)
+- [Tencent TKE (Tencent Kubernetes Engine)](https://intl.cloud.tencent.com/product/tke)
+- [Huawei CCE (Huawei Cloud Container Engine)](https://www.huaweicloud.com/en-us/product/cce.html)
+
+## 托管 Kubernetes 提供商的身份验证
+
+使用 Rancher 创建由提供商托管的集群时，你需要输入身份验证信息。Rancher 会使用验证信息来访问云厂商的 API。有关如何获取此信息的详情，请参阅：
+
+- [创建 GKE 集群](gke.md)
+- [创建 EKS 集群](eks.md)
+- [创建 AKS 集群](aks.md)
+- [创建 ACK 集群](alibaba.md)
+- [创建 TKE 集群](tencent.md)
+- [创建 CCE 集群](huawei.md)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/use-windows-clusters.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/use-windows-clusters.md
@@ -1,0 +1,290 @@
+---
+title: 在 Windows 集群上启动 Kubernetes
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters"/>
+</head>
+
+使用 Rancher 配置[自定义集群](../../../../reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md)时，Rancher 通过 RKE（Rancher Kubernetes Engine）在现有节点上安装 Kubernetes。
+
+在使用 Rancher 配置的 Windows 集群中，集群必须同时包含 Linux 和 Windows 节点。Kubernetes controlplane 只能运行在 Linux 节点上，Windows 节点只能有 Worker 角色。Windows 节点只能用于部署工作负载。
+
+Windows 集群的其他要求如下：
+
+- 只有在创建集群时启用了 Windows 支持的集群才能添加 Windows 节点。无法为现有集群启用 Windows 支持。
+- 需要 Kubernetes 1.15+。
+- 必须使用 Flannel 网络提供商。
+- Windows 节点必须有 50 GB 的磁盘空间。
+
+有关完整的要求列表，请参阅[本节](#windows-集群的要求)。
+
+有关支持 Windows 的 Kubernetes 功能摘要，请参阅[在 Windows 中使用 Kubernetes 支持的功能和限制](https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#supported-functionality-and-limitations)的 Kubernetes 文档，或[在 Kubernetes 中调度 Windows 容器的指南](https://kubernetes.io/docs/setup/production-environment/windows/user-guide-windows-containers/)。
+
+
+## Rancher 2.6 变更
+
+Rancher 2.6 支持直接使用 Rancher UI 配置 [RKE2](https://docs.rke2.io/) 集群。RKE2，也称为 RKE Government，是一个完全符合标准的 Kubernetes 发行版，它专注于安全性和合规性。
+
+在 Rancher 2.6.5 中，RKE2 已经 GA。
+
+### RKE2 Windows
+
+RKE2 配置功能还包括在 Windows 集群上安装 RKE2。RKE2 的 Windows 功能包括：
+
+- 由 containerd 提供支持的使用 RKE2 的 Windows 容器
+- 直接从 Rancher UI 配置 Windows RKE2 自定义集群
+- 用于 Windows RKE2 自定义集群的 Calico CNI
+- 技术预览包含了 Windows Server 的 SAC 版本（2004 和 20H2）
+
+要使 Windows 支持 RKE2 自定义集群，请选择 Calico 作为 CNI。
+
+:::note
+
+默认情况下，Rancher 允许 Windows 工作负载 pod 部署在 Windows 和 Linux Worker 节点上。在 RKE2 中创建混合集群时，你必须编辑 Chart 中的 `nodeSelector`，从而将 Pod 放置到兼容的 Windows 节点上。有关如何使用 `nodeSelector` 将 pod 分配给节点的更多信息，请参阅 [Kubernetes 文档](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)。
+
+:::
+
+**_Rancher v2.6.7 新功能_**
+
+- Kubernetes v1.24.1 及更高版本支持 Windows RKE2 中的 HostProcess 容器。有关详细信息，请参阅[上游文档](https://kubernetes.io/docs/tasks/configure-pod-container/create-hostprocess-pod/)。
+
+## Windows 集群的要求
+
+网络、操作系统和 Docker 的一般节点要求与 [Rancher 安装](../../../../getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md)的节点要求相同。
+
+### 操作系统和 Docker 要求
+
+我们对 Windows Server 和 Windows 容器的支持与 LTSC（长期服务渠道）和 SAC（半年渠道）的 Microsoft 官方生命周期相匹配。
+
+有关 Windows Server 的支持生命周期的日期，请参阅 [Microsoft 文档](https://docs.microsoft.com/en-us/windows-server/get-started/windows-server-release-info)。
+
+### Kubernetes 版本
+
+需要 Kubernetes v1.15+。
+
+如果你在 Windows Server 20H2 Standard Core 上使用 Kubernetes v1.21，则必须在节点上安装补丁“2019-08 Servicing Stack Update for Windows Server”。
+
+### 节点要求
+
+集群中的主机至少需要：
+
+- 2 核 CPU
+- 5 GB 内存
+- 50 GB 磁盘空间
+
+Rancher 不会配置不满足要求的节点。
+
+### 网络要求
+
+在配置新集群之前，请确保你已经在接收入站网络流量的设备上安装了 Rancher。这是集群节点与 Rancher 通信所必需的。如果你尚未安装 Rancher，请在继续阅读本指南之前先参阅[安装文档](../../../../getting-started/installation-and-upgrade/installation-and-upgrade.md)进行安装。
+
+Rancher 仅支持使用 Flannel 作为网络提供商的 Windows。
+
+有两个网络选项: [**Host Gateway (L2bridge)**](https://github.com/coreos/flannel/blob/master/Documentation/backends.md#host-gw) 和 [**VXLAN (Overlay)**](https://github.com/coreos/flannel/blob/master/Documentation/backends.md#vxlan)。默认选项是 **VXLAN (Overlay)** 模式。
+
+对于 **Host Gateway (L2bridge)** 网络，最好为所有节点使用相同的第 2 层网络。否则，你需要为它们配置路由规则。有关详细信息，请参阅[配置云托管 VM 路由的文档](network-requirements-for-host-gateway.md#云托管虚拟机的路由配置)。如果你使用的是 Amazon EC2、Google GCE 或 Azure 虚拟机，你需要[禁用私有 IP 地址检查](network-requirements-for-host-gateway.md#禁用私有-ip-地址检查)。
+
+对于 **VXLAN (Overlay)** 网络，你必须安装 [KB4489899](https://support.microsoft.com/en-us/help/4489899)  修补程序。大多数云托管的 VM 已经具有此修补程序。
+
+如果你在为 AWS 虚拟私有云配置 DHCP 选项集，请注意，你只能在 `domain-name` 选项字段中指定一个域名。详情请参见 [DHCP 选项文档](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_DHCP_Options.html)。
+
+:::note
+
+一些 Linux 操作系统支持以空格分隔的多个域名。但是，其他 Linux 操作系统和 Windows 将该值视为单个域名，从而导致意外错误。如果你的 DHCP 选项集与具有多个操作系统实例的 VPC 相关联，请仅指定一个域名。
+
+:::
+
+### 带有 ESXi 6.7u2 及更高版本的 vSphere 上的 Rancher
+
+如果你在带有 ESXi 6.7u2 或更高版本的 VMware vSphere 上使用 Rancher，并使用 Red Hat Enterprise Linux 8.3、CentOS 8.3 或 SUSE Enterprise Linux 15 SP2 或更高版本，你需要禁用 `vmxnet3` 虚拟网络适配器硬件卸载功能。否则，不同集群节点上的 pod 之间的所有网络连接会因为超时错误而失败。从 Windows pod 到在 Linux 节点上运行的关键服务（例如 CoreDNS）的所有连接也将失败。外部连接也可能失败。出现这个问题的原因是 Linux 发行版在 `vmxnet3` 中启用了硬件卸载功能，而且 `vmxnet3` 硬件卸载功能中存在一个会丢弃客户覆盖流量的数据包的 bug。要解决此问题，必须禁用 `vmxnet3` 硬件卸载功能。此设置不会在重启后继续生效，因此需要在每次启动时禁用。推荐的做法是在 `/etc/systemd/system/disable_hw_offloading.service` 中创建一个 systemd 单元文件，这会在启动时禁用 `vmxnet3` 硬件卸载功能。禁用 `vmxnet3` 硬件卸载功能的示例 systemd 单元文件如下所示。注意，`<VM network interface>` 必须自定义为主机的 `vmxnet3` 网络接口，如 `ens192`：
+
+```
+[Unit]
+Description=Disable vmxnet3 hardware offloading feature
+
+[Service]
+Type=oneshot
+ExecStart=ethtool -K <VM network interface> tx-udp_tnl-segmentation off
+ExecStart=ethtool -K <VM network interface> tx-udp_tnl-csum-segmentation off
+StandardOutput=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+然后在 systemd 单元文件上设置适当的权限：
+```
+chmod 0644 /etc/systemd/system/disable_hw_offloading.service
+```
+最后，启用 systemd 服务：
+```
+systemctl enable disable_hw_offloading.service
+```
+
+### 架构要求
+
+Kubernetes 集群管理节点（`etcd` 和 `controlplane`）必须运行在 Linux 节点上。
+
+部署工作负载的 `worker` 节点通常是 Windows 节点，但必须至少有一个 `worker` 节点运行在 Linux 上，才能按顺序运行 Rancher Cluster Agent、DNS、Metrics Server 和 Ingress 相关容器。
+
+#### 推荐架构
+
+我们推荐下表中列出的三节点架构，但你始终可以添加额外的 Linux 和 Windows worker 节点来扩展集群，从而实现冗余：
+
+| 节点 | 操作系统 | Kubernetes 集群角色 | 用途 |
+| ------ | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| 节点 1 | Linux（推荐 Ubuntu Server 18.04） | Control plane, etcd, worker | 管理 Kubernetes 集群 |
+| 节点 2 | Linux（推荐 Ubuntu Server 18.04） |  Worker | 支持集群的 Rancher Cluster Agent、Metrics Server、DNS 和 Ingress |
+| 节点 3 | Windows（Windows Server 核心版本 1809 或更高版本） | Worker | 运行 Windows 容器 |
+
+### 容器要求
+
+Windows 要求容器的版本必须与部署容器的 Windows Server 的版本一致。因此，你必须在 Windows Server 核心版本 1809 或更高版本上构建容器。如果你已经使用早期的 Windows Server 核心版本构建了容器，则必须使用 Windows Server 核心版本 1809 或更高版本重新构建容器。
+
+### 云提供商要求
+
+如果你在集群中设置了 Kubernetes 云提供商，则需要进行一些额外的操作。如果你想使用云提供商的功能，例如为集群自动配置存储、负载均衡器或其他基础设施，你可能需要设置云提供商。有关如何配置满足条件的云提供商集群节点，请参阅[此页面](../set-up-cloud-providers/set-up-cloud-providers.md)。
+
+如果你的云提供商是 GCE（Google Compute Engine），则必须执行以下操作：
+
+- 按照[步骤](../set-up-cloud-providers/google-compute-engine.md)在`cluster.yml` 中启用 GCE 云提供商。
+- 在 Rancher 中配置集群时，在 Rancher UI 中选择**自定义云提供商**作为云提供商。
+
+## 教程：如何创建支持 Windows 的集群
+
+本教程描述了如何使用[推荐架构](#推荐架构)中的三个节点创建由 Rancher 配置的集群。
+
+在现有节点上使用 Rancher 配置集群时，你需要在每个节点上安装 [Rancher Agent](../../../../reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/rancher-agent-options.md) 来将节点添加到集群中。在 Rancher UI 中创建或编辑集群时，你会看到一个**自定义节点运行命令**，你可以在每台服务器上运行该命令，从而将服务器添加到集群中。
+
+要设置支持 Windows 节点和容器的集群，你需要完成以下任务：
+
+
+### 1. 配置主机
+
+要在具有 Windows 支持的现有节点上配置集群，请准备好你的主机。
+
+主机可以是：
+
+- 云托管的虚拟机
+- 虚拟化集群中的虚拟机
+- 裸金属服务器
+
+你将配置三个节点：
+
+- 一个 Linux 节点，用于管理 Kubernetes controlplane 并存储你的 `etcd`。
+- 第二个 Linux 节点，它将作为 worker 节点。
+- Windows 节点，它将作为 worker 节点运行 Windows 容器。
+
+| 节点   | 操作系统                                             |
+| ------ | ------------------------------------------------------------ |
+| 节点 1 | Linux（推荐 Ubuntu Server 18.04）                      |
+| 节点 2 | Linux（推荐 Ubuntu Server 18.04）                      |
+| 节点 3 | Windows（Windows Server 核心版本 1809 或更高版本） |
+
+如果你的节点托管在**云提供商**上，并且你需要自动化支持（例如负载均衡器或持久存储设备），你的节点还需要满足额外的配置要求。详情请参见[选择云提供商](../set-up-cloud-providers/set-up-cloud-providers.md)。
+
+### 2. 在现有节点上创建集群
+
+在现有节点上创建 Windows 集群的说明与一般[创建自定义集群的说明](../../../../reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md)非常相似，但有一些特定于 Windows 的要求。
+
+1. 在左上角，单击 **☰ > 集群管理**。
+1. 在**集群**页面上，单击**创建**。
+1. 单击**自定义**。
+1. 在**集群名称**字段中输入集群的名称。
+1. 在 **Kubernetes 版本**下拉菜单中，选择 v1.19 或更高版本。
+1. 在**网络提供商**字段中，选择 **Flannel**。
+1. 在 **Windows 支持**中，单击**启用**。
+1. 可选：启用 Windows 支持后，你将能够选择 Flannel 后端模式。有两个网络选项：[**Host Gateway (L2bridge)**](https://github.com/coreos/flannel/blob/master/Documentation/backends.md#host-gw) 和 [**VXLAN (Overlay)**](https://github.com/coreos/flannel/blob/master/Documentation/backends.md#vxlan)。默认选项是 **VXLAN (Overlay)** 模式。
+1. 点击**下一步**。
+
+:::note 重要提示：
+
+对于 <b>Host Gateway (L2bridge)</b> 网络，最好为所有节点使用相同的第 2 层网络。否则，你需要为它们配置路由规则。有关详细信息，请参阅[配置云托管 VM 路由的文档](network-requirements-for-host-gateway.md#云托管虚拟机的路由配置)。如果你使用的是 Amazon EC2、Google GCE 或 Azure 虚拟机，你需要[禁用私有 IP 地址检查](network-requirements-for-host-gateway.md#禁用私有-ip-地址检查)。
+
+:::
+
+### 3. 将节点添加到集群
+
+本节介绍如何将 Linux 和 Worker 节点注册到集群。你将在每个节点上运行一个命令，该命令将安装 Rancher Agent 并允许 Rancher 管理每个节点。
+
+#### 添加 Linux master 节点
+
+在本节中，你需要在 Rancher UI 上填写表单以获取自定义命令，从而在 Linux master 节点上安装 Rancher Agent。然后，复制该命令并在 Linux master 节点上运行命令，从而在集群中注册该节点。
+
+集群中的第一个节点应该是具有 **controlplane** 和 **etcd** 角色的 Linux 主机。至少必须为此节点启用这两个角色，并且必须先将此节点添加到集群中，然后才能添加 Windows 主机。
+
+1. 在**节点操作系统**中，单击 **Linux**。
+1. 在**节点角色**中，至少选择 **etcd** 和 **controlplane**。推荐选择所有的三个角色。
+1. 可选：如果点击**显示高级选项**，你可以自定义 [Rancher Agent](../../../../reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/rancher-agent-options.md) 和[节点标签](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)的设置。
+1. 将屏幕上显示的命令复制到剪贴板。
+1. SSH 到你的 Linux 主机，然后运行复制到剪贴板的命令。
+1. 完成配置 Linux 节点后，选择**完成**。
+
+**结果:**
+
+你已创建集群，集群的状态是**配置中**。Rancher 已在你的集群中。
+
+当集群状态变为 **Active** 后，你可访问集群。
+
+**Active** 状态的集群会分配到两个项目：
+
+- `Default`：包含 `default` 命名空间
+- `System`：包含 `cattle-system`，`ingress-nginx`，`kube-public` 和 `kube-system` 命名空间。
+
+
+节点可能需要几分钟才能注册到集群中。
+
+#### 添加 Linux Worker 节点
+
+在本节中，我们通过运行命令将 Linux Worker 节点注册到集群中。
+
+在初始配置集群之后，你的集群只有一个 Linux 主机。接下来，我们添加另一个 Linux `worker` 主机，用于支持集群的 _Rancher Cluster Agent_、_Metrics Server_、_DNS_ 和 _Ingress_。
+
+1. 在左上角，单击 **☰ > 集群管理**。
+1. 转到你创建的集群，然后单击 **⋮ > 编辑配置**。
+1. 向下滚动到**节点操作系统**。选择 **Linux**。
+1. 在**自定义节点运行命令**中，转到**节点选项**并选择 **Worker** 角色。
+1. 将屏幕上显示的命令复制到剪贴板。
+1. 使用远程终端连接登录到你的 Linux 主机。粘贴剪贴板的命令并运行。
+1. 在 **Rancher**中，单击**保存**。
+
+**结果**：**Worker** 角色已安装在你的 Linux 主机上，并且节点会向 Rancher 注册。节点可能需要几分钟才能注册到集群中。
+
+:::note
+
+Linux Worker 节点上的污点
+
+以下污点将添加集群中的 Linux Worker 节点中。将此污点添加到 Linux Worker 节点后，添加到 Windows 集群的任何工作负载都将自动调度到 Windows Worker 节点。如果想将工作负载专门调度到 Linux Worker 节点上，则需要为这些工作负载添加容忍度。
+
+| 污点键      | 污点值 | 污点效果 |
+| -------------- | ----------- | ------------ |
+| `cattle.io/os` | `linux`     | `NoSchedule` |
+
+:::
+
+#### 添加 Windows Worker 节点
+
+在本节中，我们通过运行命令将 Windows Worker 节点注册到集群中。
+
+你可以通过编辑集群并选择 **Windows** 选项，从而将 Windows 主机添加到集群中。
+
+1. 在左上角，单击 **☰ > 集群管理**。
+1. 转到你创建的集群，然后单击 **⋮ > 编辑配置**。
+1. 向下滚动到**节点操作系统**。选择 **Windows**。注意：你将看到 **worker** 角色是唯一可用的角色。
+1. 将屏幕上显示的命令复制到剪贴板。
+1. 使用你喜欢的工具（例如 [Microsoft 远程桌面](https://docs.microsoft.com/en-us/windows-server/remote/remote-desktop-services/clients/remote-desktop-clients)登录到 Windows 主机。在 **Command Prompt (CMD)** 中运行复制到剪贴板的命令。
+1. 在 Rancher 中，单击**保存**。
+1. 可选：如果要向集群添加更多 Windows 节点，请重复这些操作。
+
+**结果**：**Worker** 角色已安装在你的 Windows 主机上，并且节点会向 Rancher 注册。节点可能需要几分钟才能注册到集群中。你现在已拥有一个 Windows Kubernetes 集群。
+
+### 可选的后续步骤
+
+创建集群后，你可以通过 Rancher UI 访问集群。最佳实践建议你设置以下访问集群的备用方式：
+
+- **通过 kubectl CLI 访问你的集群**：按照[这些步骤](../../manage-clusters/access-clusters/use-kubectl-and-kubeconfig.md#在工作站使用-kubectl-访问集群)在你的工作站上使用 kubectl 访问集群。在这种情况下，你将通过 Rancher Server 的身份验证代理进行身份验证，然后 Rancher 会让你连接到下游集群。此方法允许你在没有 Rancher UI 的情况下管理集群。
+- **通过 kubectl CLI 使用授权的集群端点访问你的集群**：按照[这些步骤](../../manage-clusters/access-clusters/use-kubectl-and-kubeconfig.md#直接使用下游集群进行身份验证)直接使用 kubectl 访问集群，而无需通过 Rancher Server 进行身份验证。我们建议设置此替代方法来访问集群，以便在无法连接到 Rancher 时访问集群。
+
+## Azure 中存储类的配置
+
+如果你的节点使用 Azure VM，则可以使用 [Azure 文件](https://docs.microsoft.com/en-us/azure/aks/azure-files-dynamic-pv)作为集群的存储类（StorageClass）。详情请参见[此部分](azure-storageclass-configuration.md)。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/access-clusters/access-clusters.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/access-clusters/access-clusters.md
@@ -1,0 +1,35 @@
+---
+title: 集群访问
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/how-to-guides/new-user-guides/manage-clusters/access-clusters"/>
+</head>
+
+本节介绍可以用来访问 Rancher 管理的集群的工具。
+
+有关如何授予用户访问集群的权限的信息，请参阅[将用户添加到集群](add-users-to-clusters.md)。
+
+有关 RBAC 的更多信息，请参阅[本节](../../authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.md)。
+
+有关如何设置身份验证系统的信息，请参阅[本节](../../authentication-permissions-and-global-configuration/authentication-config/authentication-config.md)。
+
+
+### Rancher UI
+
+Rancher 提供了一个直观的用户界面来让你与集群进行交互。UI 中所有可用的选项都使用 Rancher API。因此，UI 中的任何操作都可以在 Rancher CLI 或 Rancher API 中进行。
+
+### kubectl
+
+你可以使用 Kubernetes 命令行工具 [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) 来管理你的集群。使用 kubectl 有两种选择：
+
+- **Rancher kubectl shell**：通过启动 Rancher UI 中可用的 kubectl shell 与集群交互。此选项不需要你进行任何配置操作。有关详细信息，请参阅[使用 kubectl Shell 访问集群](use-kubectl-and-kubeconfig.md)。
+- **终端远程连接**：你也可以通过在本地桌面上安装 [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) ，然后将集群的 kubeconfig 文件复制到本地 `~/.kube/config` 目录来与集群交互。有关更多信息，请参阅[使用 kubectl 和 kubeconfig 文件访问集群](use-kubectl-and-kubeconfig.md)。
+
+### Rancher CLI
+
+你可以下载 Rancher 自己的命令行工具 [Rancher CLI](../../../../reference-guides/cli-with-rancher/cli-with-rancher.md) 来控制你的集群。这个 CLI 工具可以直接与不同的集群和项目进行交互，或者向它们传递 `kubectl` 命令。
+
+### Rancher API
+
+最后，你可以通过 Rancher API 与集群进行交互。在使用 API 之前，你必须先获取 [API 密钥](../../../../reference-guides/user-settings/api-keys.md)。要查看 API 对象的不同资源字段和操作，请打开 API UI（API UI 可以通过单击 Rancher UI 对象的**在 API 中查看**访问）。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/create-kubernetes-persistent-storage.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/create-kubernetes-persistent-storage.md
@@ -1,0 +1,78 @@
+---
+title: Kubernetes 持久存储：卷和存储类
+description: "了解在 Kubernetes 中创建持久存储的两种方式：持久卷和存储类"
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage"/>
+</head>
+
+在部署需要保​​留数据的应用时，你需要创建持久存储。持久存储允许你在运行应用的 pod 之外存储应用数据。即使运行应用的 pod 发生故障，这种存储方式也能让你保留应用数据。
+
+本文假设你已了解 Kubernetes 的持久卷、持久卷声明和存储类的概念。如需更多信息，请参阅[存储的工作原理](manage-persistent-storage/about-persistent-storage.md)。
+
+### 先决条件
+
+设置持久存储需要`管理卷`的[角色](../../authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/cluster-and-project-roles.md#项目角色参考)。
+
+如果你要为云集群配置存储，则存储和集群主机必须使用相同的云提供商。
+
+要使用 Rancher 配置新存储，则必须启用云提供商。有关启用云提供商的详细信息，请参阅[此页面](../../kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/set-up-cloud-providers.md)。
+
+如果要将现有的持久存储连接到集群，则不需要启用云提供商。
+
+### 设置现有存储
+
+设置现有存储的总体流程如下：
+
+1. 设置你的持久存储。可以是云存储或你自己的存储。
+2. 添加引用持久存储的持久卷 (PV)。
+3. 添加引用 PV 的持久卷声明 (PVC)。
+4. 将 PVC 挂载为工作负载中的卷。
+
+有关详细信息和先决条件，请参阅[此页面](manage-persistent-storage/set-up-existing-storage.md)。
+
+### 在 Rancher 中动态配置新存储
+
+配置新存储的总体流程如下：
+
+1. 添加一个 StorageClass 并将它配置为使用你的存储提供商。StorageClass 可以引用云存储或你自己的存储。
+2. 添加引用存储类的持久卷声明 (PVC)。
+3. 将 PVC 挂载为工作负载的卷。
+
+有关详细信息和先决条件，请参阅[此页面](manage-persistent-storage/dynamically-provision-new-storage.md)。
+
+### Longhorn 存储
+
+[Longhorn](https://longhorn.io/) 是一个轻量级、可靠、易用的 Kubernetes 分布式块存储系统。
+
+Longhorn 是免费的开源软件。Longhorn 最初由 Rancher Labs 开发，现在正在作为云原生计算基金会的沙盒项目进行开发。它可以通过 Helm、kubectl 或 Rancher UI 安装在任何 Kubernetes 集群上。
+
+如果你有块存储池，Longhorn 可以帮助你为 Kubernetes 集群提供持久存储，而无需依赖云提供商。有关 Longhorn 功能的更多信息，请参阅[文档](https://longhorn.io/docs/latest/what-is-longhorn/)。
+
+Rancher v2.5 简化了在 Rancher 管理的集群上安装 Longhorn 的过程。详情请参见[本页面](../../../../integrations-in-rancher/longhorn.md)。
+
+### 配置存储示例
+
+我们提供了如何使用 [NFS](../provisioning-storage-examples/nfs-storage.md)、[vSphere](../provisioning-storage-examples/vsphere-storage.md) 和 [Amazon EBS](../provisioning-storage-examples/persistent-storage-in-amazon-ebs.md) 来配置存储的示例。
+
+### GlusterFS 卷
+
+在将数据存储在 GlusterFS 卷上的集群中，你可能会遇到重启 `kubelet` 后 pod 无法挂载卷的问题。有关避免此情况发生的详细信息，请参阅[此页面](manage-persistent-storage/about-glusterfs-volumes.md)。
+
+### iSCSI 卷
+
+在将数据存储在 iSCSI 卷上的 [Rancher 启动的 Kubernetes 集群](../../launch-kubernetes-with-rancher/launch-kubernetes-with-rancher.md)中，你可能会遇到 kubelet 无法自动连接 iSCSI 卷的问题。有关解决此问题的详细信息，请参阅[此页面](manage-persistent-storage/install-iscsi-volumes.md)。
+
+### hostPath 卷
+在创建 hostPath 卷之前，你需要在集群配置中设置 [extra_bind](https://rancher.com/docs/rke/latest/en/config-options/services/services-extras/#extra-binds/)。这会将路径作为卷安装在你的 kubelet 中，可用于工作负载中的 hostPath 卷。
+
+### 将 vSphere Cloud Provider 从树内迁移到树外
+
+Kubernetes 正在逐渐不在树内维护云提供商。vSphere 有一个树外云提供商，可通过安装 vSphere 云提供商和云存储插件来使用。
+
+有关如何从树内 vSphere 云提供商迁移到树外，以及如何在迁移后管理现有虚拟机，请参阅[此页面](../../kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-out-of-tree-vsphere.md)。
+
+### 相关链接
+
+- [Kubernetes 文档：存储](https://kubernetes.io/docs/concepts/storage/)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/install-cluster-autoscaler.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/install-cluster-autoscaler.md
@@ -1,0 +1,28 @@
+---
+title: Cluster Autoscaler
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler"/>
+</head>
+
+在本文中，你将学习如何使用 AWS EC2 Auto Scaling 组在 Rancher 自定义集群上安装和使用 [Kubernetes cluster-autoscaler](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/)。
+
+Cluster Autoscaler 是一个自动调整 Kubernetes 集群大小的工具。该工具在满足以下条件之一时能自动调整集群大小：
+
+* 集群中有 Pod 因资源不足而无法运行。
+* 集群中有一些节点长时间未得到充分利用，而且它们的 Pod 可以放到其他现有节点上。
+
+为防止你的 pod 被驱逐，请在你的 pod 规范中设置 `priorityClassName: system-cluster-critical` 属性。
+
+Cluster Autoscaler 运行在 Kubernetes master 节点上。它可以在 `kube-system` 命名空间中运行。Cluster Autoscaler 不会缩减运行非镜像 `kube-system` pod 的节点。
+
+你可以在 worker 节点上运行 Cluster Autoscaler 的自定义 deployment，但需要小心以保证 Cluster Autoscaler 能正常运行。
+
+## 云提供商
+
+Cluster Autoscaler 为不同的云提供商提供支持。有关详细信息，请参见 [Cluster Autoscaler 支持的云提供商](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#deployment)。
+
+### 在 Amazon 上设置 Cluster Autoscaler
+
+有关在 Amazon 上运行 Cluster Autoscaler 的详细信息，请参阅[此页面](use-aws-ec2-auto-scaling-groups.md)。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/manage-clusters.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/manage-clusters.md
@@ -1,0 +1,36 @@
+---
+title: 集群管理
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/how-to-guides/new-user-guides/manage-clusters"/>
+</head>
+
+在 Rancher 中配置集群后，你可以开始使用强大的 Kubernetes 功能在开发、测试或生产环境中部署和扩展容器化应用。
+
+:::note
+
+本节默认你已对 Docker 和 Kubernetes 有一定的了解。如果你需要了解 Kubernetes 组件如何协作，请参见 [Kubernetes 概念](../../../reference-guides/kubernetes-concepts.md)。
+
+:::
+
+## 在 Rancher 中管理集群
+
+将集群[配置到 Rancher](../kubernetes-clusters-in-rancher-setup/kubernetes-clusters-in-rancher-setup.md) 之后，[集群所有者](../authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/cluster-and-project-roles.md#集群角色)需要管理这些集群。管理集群的选项如下：
+
+import ClusterCapabilitiesTable from '../../../shared-files/_cluster-capabilities-table.md';
+
+<ClusterCapabilitiesTable />
+
+## 配置工具
+
+Rancher 包含 Kubernetes 中未包含的各种工具来协助你进行 DevOps 操作。Rancher 可以与外部服务集成，让你的集群更高效地运行。工具分为以下几类：
+
+- 告警
+- Notifiers
+- Logging
+- Monitoring
+- Istio 服务网格
+- OPA Gatekeeper
+
+你可以通过 **Apps & Marketplace**（Rancher v2.6.5 之前的版本）或 **Apps**（Rancher v2.6.5+）来安装工具。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/provisioning-storage-examples.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/provisioning-storage-examples.md
@@ -1,0 +1,15 @@
+---
+title: 配置存储示例
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples"/>
+</head>
+
+Rancher 通过各种卷插件来支持持久存储。但是，在使用这些插件将持久存储绑定到工作负载之前，无论是使用云解决方案还是你自己管理的本地解决方案，你都必须先配置存储本身。
+
+为了你的方便，Rancher 提供了配置主流存储的参考文档：
+
+- [NFS](nfs-storage.md)
+- [vSphere](vsphere-storage.md)
+- [EBS](persistent-storage-in-amazon-ebs.md)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/shared-files/_cluster-capabilities-table.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/shared-files/_cluster-capabilities-table.md
@@ -1,22 +1,22 @@
-| 操作 | Rancher 启动的 Kubernetes 集群 | EKS、GKE 和 AKS 集群<sup>1</sup> | 其他托管的 Kubernetes 集群 | 非 EKS 或 GKE 注册集群 |
+| 操作 | Rancher 启动的 Kubernetes 集群 |  EKS, GKE 和 AKS 集群<sup>1</sup> | 其他托管的 Kubernetes 集群  | 非 EKS 或 GKE 注册集群 |
 | --- | --- | ---| ---|----|
 | [使用 kubectl 和 kubeconfig 文件来访问集群](../how-to-guides/new-user-guides/manage-clusters/access-clusters/use-kubectl-and-kubeconfig.md) | ✓ | ✓ | ✓ | ✓ |
 | [管理集群成员](../how-to-guides/new-user-guides/manage-clusters/access-clusters/add-users-to-clusters.md) | ✓ | ✓ | ✓ | ✓ |
-| [编辑和升级集群](../pages-for-subheaders/cluster-configuration.md) | ✓ | ✓ | ✓ | ✓<sup>2</sup> |
+| [编辑和升级集群](../reference-guides/cluster-configuration/cluster-configuration.md) | ✓ | ✓ | ✓ | ✓<sup>2</sup> |
 | [管理节点](../how-to-guides/new-user-guides/manage-clusters/nodes-and-node-pools.md) | ✓ | ✓ | ✓ | ✓<sup>3</sup> |
-| [管理持久卷和存储类](../pages-for-subheaders/create-kubernetes-persistent-storage.md) | ✓ | ✓ | ✓ | ✓ |
+| [管理持久卷和存储类](../how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/create-kubernetes-persistent-storage.md) | ✓ | ✓ | ✓ | ✓ |
 | [管理项目、命名空间和工作负载](../how-to-guides/new-user-guides/manage-clusters/projects-and-namespaces.md) | ✓ | ✓ | ✓ | ✓ |
-| [使用应用目录](../pages-for-subheaders/helm-charts-in-rancher.md) | ✓ | ✓ | ✓ | ✓ |
-| 配置工具（[Alerts、Notifiers、Monitoring](../pages-for-subheaders/monitoring-and-alerting.md)、[Logging](../pages-for-subheaders/logging.md) 和 [Istio](../pages-for-subheaders/istio.md)） | ✓ | ✓ | ✓ | ✓ |
-| [运行安全扫描](../pages-for-subheaders/cis-scan-guides.md) | ✓ | ✓ | ✓ | ✓ |
-| [轮换证书](../how-to-guides/new-user-guides/manage-clusters/rotate-certificates.md) | ✓ | ✓ |  | |
-| [备份](../how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher-launched-kubernetes-clusters.md)和[恢复](../how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/restore-rancher-launched-kubernetes-clusters-from-backup.md) Rancher 启动的集群 | ✓ | ✓ |  | ✓<sup>4</sup> |
+| [使用应用目录](../how-to-guides/new-user-guides/helm-charts-in-rancher/helm-charts-in-rancher.md) | ✓ | ✓ | ✓ | ✓ |
+| 配置工具 ([Alerts, Notifiers, Monitoring](../integrations-in-rancher/monitoring-and-alerting/monitoring-and-alerting.md), [Logging](../integrations-in-rancher/logging/logging.md), [Istio](../integrations-in-rancher/istio/istio.md)) | ✓ | ✓ | ✓ | ✓ |
+| [运行安全扫描](../how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides.md) | ✓ | ✓ | ✓ | ✓ |
+| [轮换证书](../how-to-guides/new-user-guides/manage-clusters/rotate-certificates.md) | ✓ | ✓  |  | |
+| [备份](../how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher-launched-kubernetes-clusters.md) 和 [恢复](../how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/restore-rancher-launched-kubernetes-clusters-from-backup.md) Rancher 启动的集群 | ✓ | ✓ |  | ✓<sup>4</sup> |
 | [在 Rancher 无法访问集群时清理 Kubernetes 组件](../how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md) | ✓ | | | |
-| [配置 Pod 安全策略](../how-to-guides/new-user-guides/manage-clusters/add-a-pod-security-policy.md) | ✓ | ✓ |   |
+| [配置 Pod 安全策略](../how-to-guides/new-user-guides/manage-clusters/add-a-pod-security-policy.md) | ✓ | ✓ |  ||
 
 1. 注册的 EKS、GKE 和 AKS 集群与从 Rancher UI 创建的 EKS、GKE 和 AKS 集群的可用选项一致。不同之处是，从 Rancher UI 中删除已注册的集群后，集群不会被销毁。
 
-2. 无法编辑已注册的集群的集群配置选项（[K3s 和 RKE2 集群](../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md)除外）。
+2. 无法编辑已注册的集群的集群配置选项，[K3s 和 RKE2 集群](../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md)除外。
 
 3. Rancher UI 为已注册的集群节点提供了封锁、清空和编辑节点的功能。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/about-provisioning-drivers.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/about-provisioning-drivers.md
@@ -48,4 +48,4 @@ Rancher 支持几家主要的云提供商，但默认情况下，这些主机驱
 
 还有其他几个默认禁用的主机驱动，但打包在 Rancher 中：
 
-* [Harvester](../../../../integrations-in-rancher/harvester/overview.md#harvester-主机驱动) - 在 Rancher 2.6.1 中可用
+* [Harvester](../../../../integrations-in-rancher/harvester.md#harvester-主机驱动) - 在 Rancher 2.6.1 中可用


### PR DESCRIPTION
Update part of Chinese missing docs for the latest and version 2.8 which includes:

manage clusters
kubernetes cluster setup
infrastructure setup
kubernetes clusters in rancher setup