### PR TITLE
Deprecated features table: add entry for v2.8.4

### DIFF
--- a/docs/faq/deprecated-features.md
+++ b/docs/faq/deprecated-features.md
@@ -16,6 +16,7 @@ Rancher will publish deprecated features as part of the [release notes](https://
 
 | Patch Version |  Release Date |
 |---------------|---------------|
+| [2.8.4](https://github.com/rancher/rancher/releases/tag/v2.8.4) | TBD |
 | [2.8.3](https://github.com/rancher/rancher/releases/tag/v2.8.3) | Mar 28, 2024 |
 | [2.8.2](https://github.com/rancher/rancher/releases/tag/v2.8.2) | Feb 8, 2024 |
 | [2.8.1](https://github.com/rancher/rancher/releases/tag/v2.8.1) | Jan 22, 2024 |

--- a/versioned_docs/version-2.8/faq/deprecated-features.md
+++ b/versioned_docs/version-2.8/faq/deprecated-features.md
@@ -16,6 +16,7 @@ Rancher will publish deprecated features as part of the [release notes](https://
 
 | Patch Version |  Release Date |
 |---------------|---------------|
+| [2.8.4](https://github.com/rancher/rancher/releases/tag/v2.8.4) | TBD |
 | [2.8.3](https://github.com/rancher/rancher/releases/tag/v2.8.3) | Mar 28, 2024 |
 | [2.8.2](https://github.com/rancher/rancher/releases/tag/v2.8.2) | Feb 8, 2024 |
 | [2.8.1](https://github.com/rancher/rancher/releases/tag/v2.8.1) | Jan 22, 2024 |


### PR DESCRIPTION
Related to #1233.

## Description

Add an entry for v2.8.4 to the deprecated features table. Marking date as TBD for now until closer to release.