### PR TITLE
Deprecated features table: add entry for v2.7.13

### DIFF
--- a/versioned_docs/version-2.7/faq/deprecated-features.md
+++ b/versioned_docs/version-2.7/faq/deprecated-features.md
@@ -16,6 +16,7 @@ Rancher will publish deprecated features as part of the [release notes](https://
 
 | Patch Version |  Release Date |
 |---------------|---------------|
+| [2.7.13](https://github.com/rancher/rancher/releases/tag/v2.7.13) |  TBD  |
 | [2.7.12](https://github.com/rancher/rancher/releases/tag/v2.7.12) |  Mar 28, 2024  |
 | [2.7.11](https://github.com/rancher/rancher/releases/tag/v2.7.11) |  Mar 1, 2024  |
 | [2.7.10](https://github.com/rancher/rancher/releases/tag/v2.7.10) |  Feb 8, 2024  |


### PR DESCRIPTION
Related to #1232.

## Description

Add an entry for v2.7.13 to the deprecated features table. Marking date as TBD for now until closer to release.