### PR TITLE
Update CNI popularity table stats

### DIFF
--- a/shared-files/_cni-popularity.md
+++ b/shared-files/_cni-popularity.md
@@ -3,8 +3,8 @@ The following table summarizes different GitHub metrics to give you an idea of e
 
 | Provider | Project | Stars | Forks | Contributors |
 | ---- | ---- | ---- | ---- | ---- |
-| Canal | https://github.com/projectcalico/canal | 708 | 100 | 20 |
-| Flannel | https://github.com/flannel-io/flannel | 8.4k | 2.9k | 231 |
-| Calico | https://github.com/projectcalico/calico | 5.4k | 1.2k | 339 |
-| Weave | https://github.com/weaveworks/weave/ | 6.6k | 661 | 87 |
-| Cilium | https://github.com/cilium/cilium | 18.2k | 2.6k | 717 |
+| Canal | https://github.com/projectcalico/canal | 712 | 100 | 20 |
+| Flannel | https://github.com/flannel-io/flannel | 8.5k | 2.9k | 235 |
+| Calico | https://github.com/projectcalico/calico | 5.5k | 1.2k | 344 |
+| Weave | https://github.com/weaveworks/weave/ | 6.6k | 662 | 87 |
+| Cilium | https://github.com/cilium/cilium | 18.6k | 2.7k | 740 |


### PR DESCRIPTION
Related to #1232.

## Description

Update the CNI popularity table with data as of May 3, 2024.