### PR TITLE
Update v2.6 missing Chinese translations

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/backup-restore-configuration/backup-restore-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/backup-restore-configuration/backup-restore-configuration.md
@@ -1,0 +1,12 @@
+---
+title: Rancher 备份配置参考
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/backup-restore-configuration"/>
+</head>
+
+- [备份配置](backup-configuration.md)
+- [还原配置](restore-configuration.md)
+- [存储位置配置](storage-configuration.md)
+- [Backup 和 Restore 自定义资源示例](examples.md)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/best-practices/best-practices.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/best-practices/best-practices.md
@@ -1,0 +1,21 @@
+---
+title: 最佳实践
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/best-practices"/>
+</head>
+
+本节介绍 Rancher 实现的最佳实践，其中包括对 Kubernetes、Docker、容器等技术的使用建议。最佳实践旨在利用 Rancher 及其客户的运营经验，助你更好地实现 Rancher。
+
+如果你对用例的实际应用有任何疑问，请联系客户成功经理或支持中心。
+
+你可以在左侧导航栏快速找到管理和部署 Rancher Server 的最佳实践。
+
+如需查看更多最佳实践指南，请参见：
+
+- [安全类文档](../rancher-security/rancher-security.md)
+- [Rancher 博客](https://www.suse.com/c/rancherblog/)
+- [Rancher 论坛](https://forums.rancher.com/)
+- [Rancher 用户的 Slack 群组](https://slack.rancher.io/)
+- [B 站](https://space.bilibili.com/430496045/)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/best-practices/rancher-managed-clusters/rancher-managed-clusters.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/best-practices/rancher-managed-clusters/rancher-managed-clusters.md
@@ -1,0 +1,23 @@
+---
+title: Rancher 管理集群的最佳实践
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/best-practices/rancher-managed-clusters"/>
+</head>
+
+### Logging
+
+有关集群级别日志和应用日志的建议，请参见 [Logging 最佳实践](logging-best-practices.md)。
+
+### Monitoring
+
+配置合理的监控和告警规则对于安全、可靠地运行生产环境中的工作负载至关重要。有关更多建议，请参阅[最佳实践](monitoring-best-practices.md)。
+
+### 设置容器的技巧
+
+配置良好的容器可以极大地提高环境的整体性能和安全性。有关容器设置的建议，请参见[设置容器的技巧](tips-to-set-up-containers.md)。
+
+### Rancher 管理 vSphere 集群的最佳实践
+
+[Rancher 管理 vSphere 集群的最佳实践](rancher-managed-clusters-in-vsphere.md)概述了在 vSphere 环境中配置下游 Rancher 集群的参考架构，以及 VMware 记录的标准 vSphere 最佳实践。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/best-practices/rancher-server/rancher-server.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/best-practices/rancher-server/rancher-server.md
@@ -1,0 +1,21 @@
+---
+title: Rancher Server 的最佳实践
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/best-practices/rancher-server"/>
+</head>
+
+本指南介绍了让 Rancher 管理下游 Kubernetes 集群的 Rancher Server 运行建议。
+
+### 推荐的架构和基础设施
+
+有关在高可用 Kubernetes 集群上设置 Rancher Server 的通用建议，请参见[本指南](tips-for-running-rancher.md)。
+
+### 部署策略
+
+[本指南](rancher-deployment-strategy.md)旨在帮助你选择部署策略（区域部署/中心辐射型部署），来让 Rancher Server 更好地管理下游 Kubernetes 集群。
+
+### 在 vSphere 环境中安装 Rancher
+
+[本指南](on-premises-rancher-in-vsphere.md)介绍了在 vSphere 环境中安装 Rancher 的参考架构，以及 VMware 记录的标准 vSphere 最佳实践。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/best-practices/rancher-server/tuning-and-best-practices-for-rancher-at-scale.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/best-practices/rancher-server/tuning-and-best-practices-for-rancher-at-scale.md
@@ -1,0 +1,117 @@
+---
+title: Rancher 大规模部署的调优和最佳实践
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/best-practices/rancher-server/tuning-and-best-practices-for-rancher-at-scale"/>
+</head>
+
+本指南介绍了扩容 Rancher 相关场景的最佳实践和调优方法。随着系统规模的不断增长，性能自然会降低，但是可以采取一些步骤将 Rancher 的负载最小化，以优化 Rancher 管理较大基础设施的能力。
+
+## 优化 Rancher 性能
+
+* 及时升级 Rancher 的 Patch 更新。我们会不断的对 Rancher 进行性能增强和错误修复，最新的 Rancher 版本包含了基于开发人员和用户反馈的所有性能和稳定性的优化改进。
+* 逐渐的执行扩容操作，在操作的过程中观察并监控任何变化，在性能刚出现异常时发现问题并修复，避免其他干扰因素。
+* 尽可能地减少上游 Rancher 集群和下游集群之间的网络延时。需要注意的是，排除掉其他因素，延时与地理距离成正比，如果你的集群或节点分布在全球各地，请考虑改为安装多个 Rancher。
+
+## 最小化上游集群的负载
+
+在 Rancher 扩容时，一个典型的性能瓶颈是上游（local）Kubernetes 集群的资源增长。上游集群包含所有下游集群的数据信息，许多对下游集群的操作会在上游集群中创建新的对象，并需要在上游集群中进行计算处理。
+
+### 最大限度地减少上游集群上的第三方软件
+
+大规模运行 Rancher 可能会给内部 Kubernetes 组件（例如 `etcd` 或 `kubeapiserver`）带来大量负载。如果第三方软件干扰了这些组件或 Rancher 的性能，则可能会出现性能问题。
+
+每个第三方软件都存在干扰性能的风险。为了防止上游集群出现性能问题，你应该避免运行除 Kubernetes 系统组件和 Rancher 本身之外的任何应用程序或组件。
+
+以下类别的软件通常不会干扰 Rancher 或 Kubernetes 系统性能：
+ * Rancher 内部组件，例如 Fleet
+ * Rancher 扩展
+ * 集群 API 组件
+ * CNI 网络插件
+ * 云控制器管理器
+ * 观察和监控工具（`prometheus-rancher-exporter` 除外）
+
+除此之外，已发现以下软件会在 Rancher 扩容时影响性能：
+  * [CrossPlane](https://www.crossplane.io/)
+  * [Argo CD](https://argoproj.github.io/cd/)
+  * [Flux](https://fluxcd.io/)
+  * [prometheus-rancher-exporter](https://github.com/David-VTUK/prometheus-rancher-exporter)（请参阅 [issue 33](https://github.com/David-VTUK/prometheus-rancher-exporter/issues/33)）
+
+### 管理你的 Object 计数
+
+Etcd 是 Kubernetes 和 Rancher 的后端数据库，该数据库可能会遇到单个 Kubernetes 资源类型数量的限制，确切的限制因素各不相同，取决于诸多因素。经验表明，一旦单个资源类型的对象数量超过 60000，通常会出现性能问题，通常该资源类型是 RoleBinding 对象。
+
+这在 Rancher 中很常见，因为许多操作会在上游集群中创建新的 RoleBinding 对象。
+
+你可以通过以下方法减少上游集群的 `RoleBinding` 数量：
+* 减少使用 [Restricted Admin（受限管理员）](../../../how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions.md#受限管理员) 角色，改为使用其他角色。
+* 如果你使用了 [外部认证](../../../how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md)，配置其按组分配角色。
+* 仅在必要情况下将用户添加到集群和项目中。
+* 移除不需要的集群和项目。
+* 仅在必要情况下使用自定义角色。
+* 在自定义角色中，尽可能的减少规则数量。
+* 避免为用户添加多余的角色。
+* 考虑使用数量更少，但性能更强大的集群。
+* Kubernetes 权限始终是 “附加”（允许列表）而不是“减去”（拒绝列表）。尽量减少允许访问集群、项目或命名空间等方面的配置，因为这将导致创建大量的 RoleBinding 对象。
+* 实验一下，创建新项目或集群后，在你的特定用例场景是否表现出更少的 RoleBinding 的效果。
+
+### RoleBinding 计数估计
+
+预测给定的配置将创建多少个 RoleBinding 对象很复杂，但是以下注意事项可以提供粗略的估算：
+* 对于最小的数量估计，请使用公式 `32C + U + 2UaC + 8P + 5Pa`。
+   * `C` 是集群数量。
+   * `U` 是用户数量。
+   * `Ua` 是集群中具有成员资格的用户的平均数量。
+   * `P` 是项目总数。
+   * `Pa` 是项目中具有成员资格的平均用户数。
+* 受限管理员角色（Restricted Admin）遵循不同的公式，因为具有此角色的每个用户都会额外产生至少 `7C + 2P + 2` 个 `RoleBinding` 对象。
+* `RoleBinding` 的数量会随着集群、项目和用户的数量线性增加。
+
+### 使用新的应用代替旧版应用
+
+Rancher 使用两个 Kubernetes 应用程序资源：`apps.projects.cattle.io` 和 `apps.cattle.cattle.io`。以`apps.projects.cattle.io` 为代表的旧版应用程序在低版本的 Cluster Manager UI 中引入，现已弃用。新的应用程序（由 `apps.catalog.cattle.io` 表示）可以在 Cluster Explorer UI 中安装部署。新的 `apps.cattle.cattle.io` 应用程序数据保存在下游集群中，这可以减少上游集群中的资源数量。
+
+你应当删除 Cluster Manager UI 中遗留的所有旧版应用程序，并将其替换为 Cluster Explorer UI 中的应用程序。只在 Cluster Explorer UI 中创建任何新应用程序。
+
+### 使用授权集群端点 (ACE)
+
+[授权集群端点](../../../reference-guides/rancher-manager-architecture/communicating-with-downstream-user-clusters.md#4-授权集群端点) (ACE) 提供了 Rancher 部署的 RKE、RKE2 和 K3s 集群的 Kubernetes API 访问。启用后，ACE 会为生成的 `kubeconfig` 文件配置直接访问下游集群 Endpoint，从而绕过 Rancher 代理。在可以直接访问下游集群 Kubernetes API 的场景下，可以减少 Rancher 负载。有关更多信息，请参阅[授权集群端点](../../../reference-guides/rancher-manager-architecture/communicating-with-downstream-user-clusters.md#4-授权集群端点)配置说明。
+
+### 减少 Event Handler 执行
+
+Rancher 的大部分逻辑发生在 Event Handler 上。每当资源对象产生更新或 Rancher 启动时，这些资源对应的 Event Handler 都会执行。除此之外，它们会每隔 15 小时在 Rancher 计划的同步缓存时再运行一次，这可能会导致 Rancher 运行过程中出现大量性能消耗。可使用 `CATTLE_SYNC_ONLY_CHANGED_OBJECTS` 环境变量禁用计划的 Handler 处理程序执行。如果每 15 小时出现一次性能资源高峰，此设置会有所帮助。
+
+`CATTLE_SYNC_ONLY_CHANGED_OBJECTS` 的值可被设置为以下内容，以逗号分隔。这些值代表了处理程序的种类，将处理程序添加到该变量会禁止其在定期的缓存重新同步过程中运行。
+
+* `mgmt`：在 Rancher 节点上运行的 Management 管理控制器。
+* `user`：所有集群运行的用户控制器。其中一部分与 Management 管理控制器运行在同一节点上，而另一部分运行在下游集群中，该选项针对的是前者。
+* `scaled`：每个 Rancher 节点上运行的规模控制器。因规模控制器负责关键功能，应当避免设置此值。如果设置可能会破坏集群稳定。
+
+简而言之，如果你发现 CPU 使用率每 15 小时出现一次峰值，请将 `CATTLE_SYNC_ONLY_CHANGED_OBJECTS` 环境变量添加到 Rancher Deployment 中（添加至 `spec.containers.env` 列表），其值为 `mgmt,user`。
+
+## Rancher 之外的优化
+
+集群底层自身的配置也是影响性能的重要因素。如果上游集群存在错误配置，会带来 Rancher 软件所无法解决的性能瓶颈。
+
+### 使用 RKE2 直接管理上游集群节点
+
+由于 Rancher 对上游集群的要求非常高，尤其是在大规模部署场景，你需要拥有上游集群和节点的所有管理员权限，要找出资源消耗过高的根本原因，请使用标准的 Linux 故障排除工具，这有助于区分是 Rancher、Kubernetes 还是操作系统组件出现的问题。
+
+尽管托管 Kubernetes 服务使部署和运行 Kubernetes 集群变得更加容易，但在大规模场景中，不鼓励将其用于上游集群。 托管 Kubernetes 服务通常会限制对单个节点和服务配置的访问。
+
+建议在大规模用例场景中使用 RKE2 集群。
+
+### 及时更新 Kubernetes 版本
+
+你应当及时更新上游集群的 Kubernetes 版本，以确保你的集群具备最新的性能增强和问题修复。
+
+### 优化 Etcd
+
+Etcd 是 Kubernetes 和 Rancher 的后端数据库，在 Rancher 性能中扮演重要的角色。
+
+[Etcd 性能](https://etcd.io/docs/v3.4/op-guide/performance/)的两个主要瓶颈是磁盘和网络速度。Etcd 应当在具有高速网络和高读写速度 (IOPS) SSD 硬盘的专用节点上运行。有关 etcd 性能的更多信息，请参阅 [etcd 性能缓慢（性能测试和优化）](https://www.suse.com/support/kb/doc/?id=000020100)和[为大型安装进行 etcd 调优](../../../how-to-guides/advanced-user-guides/tune-etcd-for-large-installs.md)。有关磁盘的信息可以在[安装要求](../../../getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md#磁盘)中找到。
+
+根据 etcd 的[复制机制](https://etcd.io/docs/v3.5/faq/#what-is-maximum-cluster-size)，建议在三个节点上运行 etcd，运行在更多的节点上反而会降低速度。
+
+Etcd 性能也会受节点之间的网络延迟影响，因此 etcd 节点应与 Rancher 节点部署在一起。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cluster-configuration/cluster-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cluster-configuration/cluster-configuration.md
@@ -1,0 +1,32 @@
+---
+title: 集群配置
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/cluster-configuration"/>
+</head>
+
+使用 Rancher 配置 Kubernetes 集群后，你仍然可以编辑集群的选项和设置。
+
+有关编辑集群成员资格的信息，请转至[此页面](../../how-to-guides/new-user-guides/manage-clusters/access-clusters/add-users-to-clusters.md)。
+
+### 集群配置参考
+
+集群配置选项取决于 Kubernetes 集群的类型：
+
+- [RKE 集群配置](rancher-server-configuration/rke1-cluster-configuration.md)
+- [RKE2 集群配置](rancher-server-configuration/rke2-cluster-configuration.md)
+- [K3s 集群配置](rancher-server-configuration/k3s-cluster-configuration.md)
+- [EKS 集群配置](rancher-server-configuration/eks-cluster-configuration.md)
+- [GKE 集群配置](rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md)
+- [AKS 集群配置](rancher-server-configuration/aks-cluster-configuration.md)
+
+### 不同类型集群的管理功能
+
+对于已有集群而言，可提供的选项和设置取决于你配置集群的方法。
+
+下表总结了每一种类型的集群和对应的可编辑的选项和设置：
+
+import ClusterCapabilitiesTable from '../../shared-files/_cluster-capabilities-table.md';
+
+<ClusterCapabilitiesTable />

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cluster-configuration/downstream-cluster-configuration/downstream-cluster-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cluster-configuration/downstream-cluster-configuration/downstream-cluster-configuration.md
@@ -1,0 +1,9 @@
+---
+title: 下游集群配置
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/cluster-configuration/downstream-cluster-configuration"/>
+</head>
+
+以下文档将讨论[节点模板配置](node-template-configuration/node-template-configuration.md)和[主机配置](machine-configuration/machine-configuration.md)。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/machine-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/machine-configuration.md
@@ -1,0 +1,9 @@
+---
+title: 主机配置
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration"/>
+</head>
+
+主机配置指的是如何将资源分配给虚拟机。请参阅 [Amazon EC2](amazon-ec2.md)、[DigitalOcean](digitalocean.md) 和 [Azure](azure.md) 的文档以了解更多信息。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/node-template-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/node-template-configuration.md
@@ -1,0 +1,9 @@
+---
+title: 节点模板配置
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration"/>
+</head>
+
+要了解节点模板配置，请参阅[EC2 节点模板配置](amazon-ec2.md)、[DigitalOcean 节点模板配置](digitalocean.md)、[Azure 节点模板配置](azure.md)、[vSphere 节点模板配置](vsphere.md)和 [Nutanix 节点模板配置](nutanix.md)。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
@@ -1,0 +1,324 @@
+---
+title: GKE 集群配置参考
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration"/>
+</head>
+
+## Rancher 2.6 变更
+
+- 支持额外的配置选项：
+   - 项目网络隔离
+   - 网络标签
+
+## 集群位置
+
+| 值 | 描述 |
+|--------|--------------|
+| 位置类型 | 地区 (zone) 或区域 (region)。借助 GKE，你可以根据工作负载的可用性要求和预算创建一个量身定制的集群。默认情况下，集群的节点在单个计算区域中运行。选择多个区域时，集群的节点将跨越多个计算区域，而 controlplane 则只位于单个区域中。区域集群也增加了 controlplane 的可用性。有关选择集群可用性类型的帮助，请参阅[这些文档](https://cloud.google.com/kubernetes-engine/docs/best-practices/scalability#choosing_a_regional_or_zonal_control_plane)。 |
+| 地区 | 计算引擎中的每个区域都包含多地区。有关可用区域和可用区的更多信息，请参阅[这些文档](https://cloud.google.com/compute/docs/regions-zones#available)。 |
+| 其他地区 | 对于地区性集群，你可以选择其他地区来创建[多地区集群](https://cloud.google.com/kubernetes-engine/docs/concepts/types-of-clusters#multi-zonal_clusters)。 |
+| 区域 | 对于[区域性集群](https://cloud.google.com/kubernetes-engine/docs/concepts/types-of-clusters#regional_clusters)，你可以选择一个区域。有关可用区域和可用区的更多信息，请参阅[本节](https://cloud.google.com/compute/docs/regions-zones#available)。地区名称的前面部分是区域的名称。 |
+
+## 集群选项
+
+### Kubernetes 版本
+
+_可变：是_
+
+有关 GKE Kubernetes 版本的更多信息，请参阅[这些文档](https://cloud.google.com/kubernetes-engine/versioning)。
+
+### 容器地址范围
+
+_可变：否_
+
+集群中 Pod 的 IP 地址范围。必须是有效的 CIDR 范围，例如 10.42.0.0/16。如果未指定，则会自动从 10.0.0.0/8 中选择一个随机范围，并排除已分配给 VM、其他集群或路由的范围。自动选择的范围可能与预留的 IP 地址、动态路由或与集群对等的 VPC 中的路由发生冲突。
+
+### 网络
+
+_可变：否_
+
+集群连接的 Compute Engine 网络。将使用此网络创建路由和防火墙。如果使用[共享 VPC](https://cloud.google.com/vpc/docs/shared-vpc)，与你的项目共享的 VPC 网络将显示在此处。你将可以在此字段中进行选择。有关详细信息，请参阅[此页面](https://cloud.google.com/vpc/docs/vpc#vpc_networks_and_subnets)。
+
+### 节点子网/子网
+
+_可变：否_
+
+集群连接到的 Compute Engine 子网。该子网必须属于**网络**字段中指定的网络。选择一个现有的子网，或选择“自动创建子网”来自动创建一个子网。如果不使用现有网络，则需要使用**子网名称**来生成一个。如果使用[共享 VPC](https://cloud.google.com/vpc/docs/shared-vpc)，与你的项目共享的 VPC 子网将显示在此处。如果使用共享 VPC 网络，则无法选择“自动创建子网”。如需更多信息，请参阅[此页面](https://cloud.google.com/vpc/docs/vpc#vpc_networks_and_subnets)。
+
+### 子网名称
+
+_可变：否_
+
+使用提供的名称自动创建子网。如果为**节点子网**或**子网**选择了“自动创建子网”，则为必填。有关子网的更多信息，请参阅[此页面](https://cloud.google.com/vpc/docs/vpc#vpc_networks_and_subnets)。
+
+### IP 别名
+
+_可变：否_
+
+启用[别名 IP](https://cloud.google.com/vpc/docs/alias-ip)。这将启用 VPC 原生流量路由。如果使用[共享 VPC](https://cloud.google.com/vpc/docs/shared-vpc)，则为必填。
+
+### 网络策略
+
+_可变：是_
+
+在集群上启用的网络策略。网络策略定义了集群中 pod 和 service 之间可以发生的通信级别。有关详细信息，请参阅[此页面](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy)。
+
+### 项目网络隔离
+
+_可变：是_
+
+选择启用或禁用项目间通信。请注意，如果启用**项目网络隔离**，则将自动启用**网络策略**和**网络策略配置**，反之则不然。
+
+### 节点 IPv4 CIDR 块
+
+_可变：否_
+
+此集群中实例 IP 的 IP 地址范围。如果为**节点子网**或**子网**选择了“自动创建子网”，则可以进行设置。必须是有效的 CIDR 范围，例如 10.96.0.0/14。有关如何确定 IP 地址范围的详细信息，请参阅[此页面](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips#cluster_sizing)。
+
+### 集群次要范围名称
+
+_可变：否_
+
+Pod IP 地址的现有次要范围的名称。如果选中，将自动填充**集群 Pod 地址范围**。如果使用共享 VPC 网络，则为必填。
+
+### 集群 Pod 地址范围
+
+_可变：否_
+
+分配给集群中 pod 的 IP 地址范围。必须是有效的 CIDR 范围，例如 10.96.0.0/11。如果未提供，将自动创建。如果使用共享 VPC 网络，则必须提供。有关如何确定 pod 的 IP 地址范围的更多信息，请参阅[本节](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips#cluster_sizing_secondary_range_pods)。
+
+### Service 次要范围名称
+
+_可变：否_
+
+Service IP 地址的现有次要范围的名称。如果选中，将自动填充 **Service 地址范围**。如果使用共享 VPC 网络，则为必填。
+
+### Service 地址范围
+
+_可变：否_
+
+分配给集群中 Service 的地址范围。必须是有效的 CIDR 范围，例如 10.94.0.0/18。如果未提供，将自动创建。如果使用共享 VPC 网络，则必须提供。有关如何确定 Service 的 IP 地址范围的详细信息，请参阅[本节](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips#cluster_sizing_secondary_range_svcs)。
+
+### 私有集群
+
+_可变：否_
+
+:::caution
+
+私有集群需要在 Rancher 之外进行额外的规划和配置。请参阅[私有集群指南](gke-private-clusters.md)。
+
+:::
+
+仅分配节点内部 IP 地址。除非在 GCP 中执行了额外的联网步骤，否则私有集群节点无法访问公共互联网。
+
+### 启用私有端点
+
+:::caution
+
+私有集群需要在 Rancher 之外进行额外的规划和配置。请参阅[私有集群指南](gke-private-clusters.md)。
+
+:::
+
+_可变：否_
+
+锁定对 controlplane 端点的外部访问。仅当**私有集群**也被选中时可用。如果选中，并且 Rancher 无法直接访问集群所在的虚拟私有云网络，Rancher 将提供在集群上运行的注册命令，以使 Rancher 能够连接到集群。
+
+### 主 IPV4 CIDR 块
+
+_可变：否_
+
+controlplane VPC 的 IP 范围。
+
+### 主授权网络
+
+_可变：是_
+
+启用 controlplane 授权网络，以阻止不受信任的非 GCP 源 IP 通过 HTTPS 访问 Kubernetes master。如果选择，则可以添加额外的授权网络。如果集群是使用公共端点创建的，则此选项可用于将公共端点的访问锁定到特定网络（例如运行 Rancher 服务的网络）。如果集群只有一个私有端点，则需要此设置。
+
+## 其他选项
+
+### 集群插件
+
+其他 Kubernetes 集群组件。有关详细信息，请参阅[此页面](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters#Cluster.AddonsConfig)。
+
+#### 水平 Pod 自动缩放
+
+_可变：是_
+
+Horizo​​ntal Pod Autoscaler 通过自动增加或减少 Pod 的数量来调整 Kubernetes 工作负载，从而响应工作负载的 CPU 或内存消耗，以及 Kubernetes 内部报告的自定义指标或集群外部设置的指标。详情请参见[本页面](https://cloud.google.com/kubernetes-engine/docs/concepts/horizontalpodautoscaler)。
+
+#### HTTP (L7) 负载均衡
+
+_可变：是_
+
+HTTP (L7) 负载均衡将 HTTP 和 HTTPS 流量分配到托管在 GKE 上的后端。有关详细信息，请参阅[此页面](https://cloud.google.com/kubernetes-engine/docs/tutorials/http-balancer)。
+
+#### 网络策略配置（仅限 master）
+
+_可变：是_
+
+NetworkPolicy 的配置。仅跟踪 master 节点上是否启用了插件，不跟踪是否为节点启用了网络策略。
+
+### 集群特征（Alpha 功能）
+
+_可变：否_
+
+打开集群的所有 Kubernetes alpha API 组和功能。启用后，集群无法升级，并且会在 30 天后自动删除。由于 GKE SLA 未支持 alpha 集群，因此不建议将 Alpha 集群用于生产环境。有关详细信息，请参阅[此页面](https://cloud.google.com/kubernetes-engine/docs/concepts/alpha-clusters)。
+
+### Logging 服务
+
+_可变：是_
+
+集群用于写入日志的日志管理服务。要么使用 [Cloud Logging](https://cloud.google.com/logging)，要么不使用日志管理服务（不会从集群中导出日志）。
+
+### 监控服务
+
+_可变：是_
+
+集群用于写入指标的监控服务。要么使用 [Cloud Monitoring](https://cloud.google.com/monitoring)，要么不使用集群监控服务（不会从集群中导出指标）。
+
+
+### 维护窗口
+
+_可变：是_
+
+设置时长 4 小时的维护窗口的开始时间。使用 HH:MM 格式在 UTC 时区中指定时间。有关详细信息，请参阅[此页面](https://cloud.google.com/kubernetes-engine/docs/concepts/maintenance-windows-and-exclusions)。
+
+## 节点池
+
+在此部分中，输入描述节点池中每个节点的配置的详细信息。
+
+### Kubernetes 版本
+
+_可变：是_
+
+节点池中每个节点的 Kubernetes 版本。有关 GKE Kubernetes 版本的更多信息，请参阅[这些文档](https://cloud.google.com/kubernetes-engine/versioning)。
+
+### 镜像类型
+
+_可变：是_
+
+节点操作系统镜像。有关 GKE 为每个操作系统提供的节点镜像选项，请参阅[此页面](https://cloud.google.com/kubernetes-engine/docs/concepts/node-images#available_node_images)。
+
+:::note
+
+默认选项是 “Container-Optimized OS with Docker”。GCP Container-Optimized OS 上的只读文件系统与 Rancher 中的 [legacy logging](/versioned_docs/version-2.0-2.4/explanations/integrations-in-rancher/cluster-logging/cluster-logging.md) 实现不兼容。如果你需要使用旧版日志管理功能，请选择 “Ubuntu with Docker” 或 “Ubuntu with Containerd”。[current logging feature](../../../../integrations-in-rancher/logging/logging.md) 与 Container-Optimized OS 镜像兼容。
+
+:::
+
+:::note
+
+如果节点池镜像类型选择 “Windows Long Term Service Channel” 或 “Windows Semi-Annual Channel”，还必须至少添加一个 Container-Optimized OS 或 Ubuntu 节点池。
+
+:::
+
+### 主机类型
+
+_可变：否_
+
+节点实例可用的虚拟化硬件资源。有关 Google Cloud 主机类型的详细信息，请参阅[此页面](https://cloud.google.com/compute/docs/machine-types#machine_types)。
+
+### 根磁盘类型
+
+_可变：否_
+
+标准永久性磁盘由标准磁盘驱动器 (HDD) 支持，而 SSD 永久性磁盘由固态硬盘 (SSD) 支持。有关详细信息，请参阅[本节](https://cloud.google.com/compute/docs/disks)。
+
+### 本地 SSD 磁盘
+
+_可变：否_
+
+配置每个节点的本地 SSD 磁盘存储（以 GB 为单位）。本地 SSD 物理连接到托管你的 VM 实例的服务器。与标准永久性磁盘或 SSD 永久性磁盘相比，本地 SSD 具有更高的吞吐量和更低的延迟。存储在本地 SSD 上的数据只会保留到实例停止或删除。有关详细信息，请参阅[本节](https://cloud.google.com/compute/docs/disks#localssds)。
+
+### 抢占式节点（beta）
+
+_可变：否_
+
+抢占式节点也称为抢占式虚拟机。通常是最长持续 24 小时的 Compute Engine 虚拟机实例，不提供可用性保证。详情请参见[本页面](https://cloud.google.com/kubernetes-engine/docs/how-to/preemptible-vms)。
+
+### 污点
+
+_可变：否_
+
+将污点应用于节点时，仅允许容忍该污点的 Pod 在该节点上运行。在 GKE 集群中，你可以将污点应用到节点池，这会将污点应用到池中的所有节点。
+
+### 节点标签
+
+_可变：否_
+
+你可以将标签应用到节点池，这会将标签应用到池中的所有节点。
+
+无效标签会阻止升级，或阻止 Rancher 启动。有关标签语法的详细信息，请参阅 [Kubernetes 文档](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)。
+
+### 网络标签
+
+_可变：否_
+
+你可以将网络标签添加到节点池以制定防火墙规则和子网之间的路由。标签将应用于池中的所有节点。
+
+有关标签语法和要求的详细信息，请参阅 [Kubernetes 文档](https://cloud.google.com/vpc/docs/add-remove-network-tags)。
+
+## 组详细信息
+
+在此部分中，输入描述节点池的详细信息。
+
+### 名称
+
+_可变：否_
+
+输入节点池的名称。
+
+### 初始节点数
+
+_可变：是_
+
+节点池中初始节点数的整数。
+
+### 每个节点的最大 Pod 数量
+
+_可变：否_
+
+GKE 的硬性限制是每个节点 110 个 Pod。有关 Kubernetes 限制的更多信息，请参阅[本节](https://cloud.google.com/kubernetes-engine/docs/best-practices/scalability#dimension_limits)。
+
+### 自动缩放
+
+_可变：是_
+
+节点池自动缩放会根据工作负载的需求动态创建或删除节点。详情请参见[本页面](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler)。
+
+### 自动修复
+
+_可变：是_
+
+GKE 的节点自动修复功能可帮助你将集群中的节点保持在健康的运行状态。启用后，GKE 会定期检查集群中每个节点的运行状况。如果某个节点在较长时间段内连续未通过健康检查，GKE 会为该节点启动修复过程。有关详细信息，请参阅[自动修复节点](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-repair)。
+
+### 自动升级
+
+_可变：是_
+
+启用后，当你的 controlplane [按照你的需求更新](https://cloud.google.com/kubernetes-engine/upgrades#automatic_cp_upgrades)时，自动升级功能会使集群中的节点与集群 controlplane（master）版本保持同步。有关自动升级节点的更多信息，参见[此页面。](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-upgrades)
+
+### 访问范围
+
+_可变：否_
+
+设置访问范围是为你的节点指定权限的旧版方法。
+
+- **允许默认访问**：新集群的默认访问是 [Compute Engine 默认 ServiceAccount](https://cloud.google.com/compute/docs/access/service-accounts?hl=en_US#default_service_account)。
+- **允许完全访问所有 Cloud API**：通常，你只需设置云平台访问范围来允许完全访问所有 Cloud API，然后仅授予 ServiceAccount 相关的 IAM 角色。授予虚拟机实例的访问范围和授予 ServiceAccount 的 IAM 角色的组合决定了 ServiceAccount 对该实例的访问量。
+- **为每个 API 设置访问权限**：或者，你可以设置服务将调用的特定 API 方法的访问范围。
+
+有关详细信息，请参阅[为 VM 启用 ServiceAccount](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances)。
+
+
+### 配置刷新间隔
+
+刷新间隔可以通过 “gke-refresh” 来配置，它是一个代表秒的整数。
+
+默认值为 300 秒。
+
+你可以通过运行 `kubectl edit setting gke-refresh` 来更改同步间隔。
+
+刷新窗口越短，争用条件发生的可能性就越小。但这确实增加了遇到 GCP API 可能存在的请求限制的可能性。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cluster-configuration/rancher-server-configuration/rancher-server-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cluster-configuration/rancher-server-configuration/rancher-server-configuration.md
@@ -1,0 +1,16 @@
+---
+title: Rancher Server 配置
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/cluster-configuration/rancher-server-configuration"/>
+</head>
+
+- [RKE1 集群配置](rke1-cluster-configuration.md)
+- [RKE2 集群配置](rke2-cluster-configuration.md)
+- [K3s 集群配置](k3s-cluster-configuration.md)
+- [EKS 集群配置](eks-cluster-configuration.md)
+- [AKS 集群配置](aks-cluster-configuration.md)
+- [GKE 集群配置](gke-cluster-configuration/gke-cluster-configuration.md)
+- [使用现有节点](use-existing-nodes/use-existing-nodes.md)
+- [同步集群](sync-clusters.md)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md
@@ -1,0 +1,141 @@
+---
+title: 在现有自定义节点上启动 Kubernetes
+description: 要创建具有自定义节点的集群，你需要访问集群中的服务器，并根据 Rancher 的要求配置服务器。
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes"/>
+</head>
+
+创建自定义集群时，Rancher 使用 RKE（Rancher Kubernetes Engine）在本地裸机服务器、本地虚拟机或云服务器节点中创建 Kubernetes 集群。
+
+要使用此选项，你需要访问要在 Kubernetes 集群中使用的服务器。请根据[要求](../../../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/node-requirements-for-rancher-managed-clusters.md)配置每台服务器，其中包括硬件要求和 Docker 要求。在每台服务器上安装 Docker 后，你还需要在每台服务器上运行 Rancher UI 中提供的命令，从而将每台服务器转换为 Kubernetes 节点。
+
+本节介绍如何设置自定义集群。
+
+## 使用自定义节点创建集群
+
+:::note 使用 Windows 主机作为 Kubernetes Worker 节点？
+
+在开始之前，请参阅[配置 Windows 自定义集群](../../../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/use-windows-clusters.md)。
+
+:::
+
+### 1. 配置 Linux 主机
+
+你可以通过配置 Linux 主机，来创建自定义集群。你的主机可以是：
+
+- 云虚拟机
+- 本地虚拟机
+- 裸机服务器
+
+如果要重复使用之前的自定义集群中的节点，请在复用之前[清理节点](../../../../how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md)。如果你重复使用尚未清理的节点，则集群配置可能会失败。
+
+根据[安装要求](../../../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/node-requirements-for-rancher-managed-clusters.md)和[生产就绪集群的检查清单](../../../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/checklist-for-production-ready-clusters.md)配置主机。
+
+如果你使用 Amazon EC2 作为主机，并希望使用[双栈 (dual-stack)](https://kubernetes.io/docs/concepts/services-networking/dual-stack/) 功能，则需要满足配置主机的其他[要求](https://rancher.com/docs/rke//latest/en/config-options/dual-stack#requirements)。
+
+### 2. 创建自定义集群
+
+1. 点击 **☰ > 集群管理**。
+1. 在**集群**页面上，单击**创建**。
+1. 单击**自定义**。
+1. 输入**集群名称**。
+1. 在**集群配置**中，选择 Kubernetes 版本、要使用的网络提供商，以及是否启用项目网络隔离。要查看更多集群选项，请单击**显示高级选项**。
+
+   :::note 你使用 Windows 主机作为 Kubernetes Worker 节点？
+
+   - 请参阅[启用 Windows 支持选项](../../../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/use-windows-clusters.md)。
+   - 支持 Windows 集群的唯一网络插件是 Flannel。
+
+   :::
+
+   :::note Amazon EC2 上的双栈：
+
+   如果你使用 Amazon EC2 作为主机，并希望使用[双栈 (dual-stack)](https://kubernetes.io/docs/concepts/services-networking/dual-stack/) 功能，则需要满足配置 RKE 的其他[要求](https://rancher.com/docs/rke//latest/en/config-options/dual-stack#requirements)。
+
+   :::
+
+6. 点击**下一步**。
+
+4. 使用**成员角色**为集群配置用户授权。点击**添加成员**添加可以访问集群的用户。使用**角色**下拉菜单为每个用户设置权限。
+
+7. 从**节点角色**中，选择要由集群节点充当的角色。你必须为 `etcd`、`worker` 和 `controlplane` 角色配置至少一个节点。自定义集群需要所有三个角色才能完成配置。有关角色的详细信息，请参阅[本节](../../../kubernetes-concepts.md#kubernetes-集群中节点的角色)。
+
+:::note
+
+- 使用 Windows 主机作为 Kubernetes Worker 节点？请参阅[本节](../../../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/use-windows-clusters.md)。
+- 裸机服务器提醒：如果你想将裸机服务器专用于每个角色，则必须为每个角色配置一个裸机服务器（即配置多个裸机服务器）。
+
+:::
+
+8. **可选**：点击[显示高级选项](rancher-agent-options.md)来指定注册节点时使用的 IP 地址，覆盖节点的主机名，或将[标签](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)或[污点](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)添加到节点。
+
+9. 将屏幕上显示的命令复制到剪贴板。
+
+10. 使用你惯用的 shell（例如 PuTTy 或远程终端）登录到你的 Linux 主机。粘贴剪贴板的命令并运行。
+
+:::note
+
+如果要将特定主机专用于特定节点角色，请重复步骤 7-10。根据需要多次重复这些步骤。
+
+:::
+
+11. 在 Linux 主机上运行完命令后，单击**完成**。
+
+**结果**：
+
+你已创建集群，集群的状态是**配置中**。Rancher 已在你的集群中。
+
+当集群状态变为 **Active** 后，你可访问集群。
+
+**Active** 状态的集群会分配到两个项目：
+
+- `Default`：包含 `default` 命名空间
+- `System`：包含 `cattle-system`，`ingress-nginx`，`kube-public` 和 `kube-system` 命名空间。
+
+
+### 3. 仅限亚马逊：标签资源
+
+如果你已将集群配置为使用 Amazon 作为**云提供商**，请使用集群 ID 标记你的 AWS 资源。
+
+[Amazon 文档：标记你的 Amazon EC2 资源](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html)
+
+:::note
+
+你可以使用 Amazon EC2 实例，而无需在 Kubernetes 中配置云提供商。如果你想使用特定的 Kubernetes 云提供商功能，配置云提供商即可。如需更多信息，请参阅 [Kubernetes 云提供商](https://github.com/kubernetes/website/blob/release-1.18/content/en/docs/concepts/cluster-administration/cloud-providers.md)。
+
+:::
+
+以下资源需要使用 `ClusterID` 进行标记：
+
+- **Nodes**：Rancher 中添加的所有主机。
+- **Subnet**：集群使用的子网。
+- **Security Group**：用于你的集群的安全组。
+
+:::note
+
+不要标记多个安全组。创建 Elastic Load Balancer 时，标记多个组会导致错误。
+
+:::
+
+应该使用的标签是：
+
+```
+Key=kubernetes.io/cluster/<CLUSTERID>, Value=owned
+```
+
+`<CLUSTERID>` 可以是你选择的任何字符串。但是，必须在你标记的每个资源上使用相同的字符串。将值设置为 `owned` 会通知集群所有带有 `<CLUSTERID>` 标记的资源都由该集群拥有和管理。
+
+如果你在集群之间共享资源，你可以将标签更改为：
+
+```
+Key=kubernetes.io/cluster/CLUSTERID, Value=shared
+```
+
+## 可选的后续步骤
+
+创建集群后，你可以通过 Rancher UI 访问集群。最佳实践建议你设置以下访问集群的备用方式：
+
+- **通过 kubectl CLI 访问你的集群**：按照[这些步骤](../../../../how-to-guides/new-user-guides/manage-clusters/access-clusters/use-kubectl-and-kubeconfig.md#在工作站使用-kubectl-访问集群)在你的工作站上使用 kubectl 访问集群。在这种情况下，你将通过 Rancher Server 的身份验证代理进行身份验证，然后 Rancher 会让你连接到下游集群。此方法允许你在没有 Rancher UI 的情况下管理集群。
+- **通过 kubectl CLI 使用授权的集群端点访问你的集群**：按照[这些步骤](../../../../how-to-guides/new-user-guides/manage-clusters/access-clusters/use-kubectl-and-kubeconfig.md#直接使用下游集群进行身份验证)直接使用 kubectl 访问集群，而无需通过 Rancher 进行身份验证。我们建议设置此替代方法来访问集群，以便在无法连接到 Rancher 时访问集群。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/rancher-manager-architecture/rancher-manager-architecture.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/rancher-manager-architecture/rancher-manager-architecture.md
@@ -1,0 +1,21 @@
+---
+title: 架构
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/rancher-manager-architecture"/>
+</head>
+
+本章节重点介绍 [Rancher Server 及其组件](rancher-server-and-components.md) 以及 [Rancher 如何与下游 Kubernetes 集群通信](communicating-with-downstream-user-clusters.md)。
+
+有关安装 Rancher 的不同方式的信息，请参见[安装选项概述](../../getting-started/installation-and-upgrade/installation-and-upgrade.md#安装方式概述)。
+
+有关 Rancher API Server 的主要功能，请参见[概述](../../getting-started/overview.md#rancher-api-server-的功能)。
+
+有关如何为 Rancher Server 设置底层基础架构，请参见[架构推荐](architecture-recommendations.md)。
+
+:::note
+
+本节默认你已对 Docker 和 Kubernetes 有一定的了解。如果你需要了解 Kubernetes 组件如何协作，请参见 [Kubernetes 概念](../kubernetes-concepts.md)。
+
+:::

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/single-node-rancher-in-docker/single-node-rancher-in-docker.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/single-node-rancher-in-docker/single-node-rancher-in-docker.md
@@ -1,0 +1,9 @@
+---
+title: Docker 中的单节点 Rancher
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/zh/reference-guides/single-node-rancher-in-docker"/>
+</head>
+
+以下文档将讨论 Docker 安装的 [HTTP 代理配置](http-proxy-configuration.md)和[高级选项](advanced-options.md)。


### PR DESCRIPTION
Update missing Chinese translation for v2.6:
1. `reference-guides/best-practices/best-practices.md`
1. `reference-guides/best-practices/rancher-server/rancher-server.md`
1. `reference-guides/best-practices/rancher-server/tuning-and-best-practices-for-rancher-at-scale.md`
1. `reference-guides/best-practices/rancher-managed-clusters/rancher-managed-clusters.md`
1. `reference-guides/rancher-manager-architecture/rancher-manager-architecture.md`
1. `reference-guides/cluster-configuration/cluster-configuration.md`
1. `reference-guides/cluster-configuration/rancher-server-configuration/rancher-server-configuration.md`
1. `reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md`
1. `reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes.md`
1. `reference-guides/cluster-configuration/downstream-cluster-configuration/downstream-cluster-configuration.md`
1. `reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/node-template-configuration.md`
1. `reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/machine-configuration.md`
1. `reference-guides/single-node-rancher-in-docker/single-node-rancher-in-docker.md`
1. `reference-guides/backup-restore-configuration/backup-restore-configuration.md`

@JacieChao Please help to review the docs when you have free time. Thanks!
