### PR TITLE
#1281 docker machine link redirects to docker desktop documentation

### DIFF
--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
@@ -56,4 +56,6 @@ If you want to use a node driver that Rancher doesn't support out-of-the-box, yo
 
 ### Developing Your Own Node Drivers
 
-Node drivers are implemented with [Docker Machine](https://gcbw.github.io/docker.github.io/machine/).
+Node drivers are implemented with [Rancher Machine](https://github.com/rancher/machine), a fork of [Docker Machine](https://github.com/docker/machine). Docker Machine is no longer under active development.
+
+Refer to the original [Docker Machine documentation](https://gcbw.github.io/docker.github.io/machine/) for details on how to develop your own node drivers.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
@@ -56,4 +56,4 @@ If you want to use a node driver that Rancher doesn't support out-of-the-box, yo
 
 ### Developing Your Own Node Drivers
 
-Node drivers are implemented with [Docker Desktop](https://docs.docker.com/desktop/).
+Node drivers are implemented with [Docker Machine](https://gcbw.github.io/docker.github.io/machine/).

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
@@ -56,4 +56,4 @@ If you want to use a node driver that Rancher doesn't support out-of-the-box, yo
 
 ### Developing Your Own Node Drivers
 
-Node drivers are implemented with [Docker Machine](https://docs.docker.com/machine/).
+Node drivers are implemented with [Docker Desktop](https://docs.docker.com/desktop/).

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
@@ -58,4 +58,4 @@ If you want to use a node driver that Rancher doesn't support out-of-the-box, yo
 
 Node drivers are implemented with [Rancher Machine](https://github.com/rancher/machine), a fork of [Docker Machine](https://github.com/docker/machine). Docker Machine is no longer under active development.
 
-Refer to the original [Docker Machine documentation](https://gcbw.github.io/docker.github.io/machine/) for details on how to develop your own node drivers.
+Refer to the original [Docker Machine documentation](https://github.com/docker/docs/blob/vnext-engine/machine/overview.md) for details on how to develop your own node drivers.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
@@ -39,4 +39,4 @@ If you want to use a node driver that Rancher doesn't support out-of-the-box, yo
 
 Node drivers are implemented with [Rancher Machine](https://github.com/rancher/machine), a fork of [Docker Machine](https://github.com/docker/machine). Docker Machine is no longer under active development.
 
-Refer to the original [Docker Machine documentation](https://gcbw.github.io/docker.github.io/machine/) for details on how to develop your own node drivers.
+Refer to the original [Docker Machine documentation](https://github.com/docker/docs/blob/vnext-engine/machine/overview.md) for details on how to develop your own node drivers.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
@@ -37,4 +37,6 @@ If you want to use a node driver that Rancher doesn't support out-of-the-box, yo
 
 ### Developing your own node driver
 
-Node drivers are implemented with [Docker Machine](https://docs.docker.com/machine/).
+Node drivers are implemented with [Rancher Machine](https://github.com/rancher/machine), a fork of [Docker Machine](https://github.com/docker/machine). Docker Machine is no longer under active development.
+
+Refer to the original [Docker Machine documentation](https://gcbw.github.io/docker.github.io/machine/) for details on how to develop your own node drivers.

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
@@ -39,4 +39,4 @@ If you want to use a node driver that Rancher doesn't support out-of-the-box, yo
 
 Node drivers are implemented with [Rancher Machine](https://github.com/rancher/machine), a fork of [Docker Machine](https://github.com/docker/machine). Docker Machine is no longer under active development.
 
-Refer to the original [Docker Machine documentation](https://gcbw.github.io/docker.github.io/machine/) for details on how to develop your own node drivers.
+Refer to the original [Docker Machine documentation](https://github.com/docker/docs/blob/vnext-engine/machine/overview.md) for details on how to develop your own node drivers.

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
@@ -37,4 +37,6 @@ If you want to use a node driver that Rancher doesn't support out-of-the-box, yo
 
 ### Developing your own node driver
 
-Node drivers are implemented with [Docker Machine](https://docs.docker.com/machine/).
+Node drivers are implemented with [Rancher Machine](https://github.com/rancher/machine), a fork of [Docker Machine](https://github.com/docker/machine). Docker Machine is no longer under active development.
+
+Refer to the original [Docker Machine documentation](https://gcbw.github.io/docker.github.io/machine/) for details on how to develop your own node drivers.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
@@ -42,4 +42,6 @@ If you want to use a node driver that Rancher doesn't support out-of-the-box, yo
 
 ### Developing your own node driver
 
-Node drivers are implemented with [Docker Machine](https://docs.docker.com/machine/).
+Node drivers are implemented with [Rancher Machine](https://github.com/rancher/machine), a fork of [Docker Machine](https://github.com/docker/machine). Docker Machine is no longer under active development.
+
+Refer to the original [Docker Machine documentation](https://gcbw.github.io/docker.github.io/machine/) for details on how to develop your own node drivers.

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
@@ -44,4 +44,4 @@ If you want to use a node driver that Rancher doesn't support out-of-the-box, yo
 
 Node drivers are implemented with [Rancher Machine](https://github.com/rancher/machine), a fork of [Docker Machine](https://github.com/docker/machine). Docker Machine is no longer under active development.
 
-Refer to the original [Docker Machine documentation](https://gcbw.github.io/docker.github.io/machine/) for details on how to develop your own node drivers.
+Refer to the original [Docker Machine documentation](https://github.com/docker/docs/blob/vnext-engine/machine/overview.md) for details on how to develop your own node drivers.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
@@ -56,4 +56,6 @@ If you want to use a node driver that Rancher doesn't support out-of-the-box, yo
 
 ### Developing Your Own Node Drivers
 
-Node drivers are implemented with [Docker Machine](https://docs.docker.com/machine/).
+Node drivers are implemented with [Rancher Machine](https://github.com/rancher/machine), a fork of [Docker Machine](https://github.com/docker/machine). Docker Machine is no longer under active development.
+
+Refer to the original [Docker Machine documentation](https://gcbw.github.io/docker.github.io/machine/) for details on how to develop your own node drivers.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
@@ -58,4 +58,4 @@ If you want to use a node driver that Rancher doesn't support out-of-the-box, yo
 
 Node drivers are implemented with [Rancher Machine](https://github.com/rancher/machine), a fork of [Docker Machine](https://github.com/docker/machine). Docker Machine is no longer under active development.
 
-Refer to the original [Docker Machine documentation](https://gcbw.github.io/docker.github.io/machine/) for details on how to develop your own node drivers.
+Refer to the original [Docker Machine documentation](https://github.com/docker/docs/blob/vnext-engine/machine/overview.md) for details on how to develop your own node drivers.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
@@ -56,4 +56,6 @@ If you want to use a node driver that Rancher doesn't support out-of-the-box, yo
 
 ### Developing Your Own Node Drivers
 
-Node drivers are implemented with [Docker Machine](https://docs.docker.com/machine/).
+Node drivers are implemented with [Rancher Machine](https://github.com/rancher/machine), a fork of [Docker Machine](https://github.com/docker/machine). Docker Machine is no longer under active development.
+
+Refer to the original [Docker Machine documentation](https://gcbw.github.io/docker.github.io/machine/) for details on how to develop your own node drivers.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers.md
@@ -58,4 +58,4 @@ If you want to use a node driver that Rancher doesn't support out-of-the-box, yo
 
 Node drivers are implemented with [Rancher Machine](https://github.com/rancher/machine), a fork of [Docker Machine](https://github.com/docker/machine). Docker Machine is no longer under active development.
 
-Refer to the original [Docker Machine documentation](https://gcbw.github.io/docker.github.io/machine/) for details on how to develop your own node drivers.
+Refer to the original [Docker Machine documentation](https://github.com/docker/docs/blob/vnext-engine/machine/overview.md) for details on how to develop your own node drivers.


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #1281 

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

Upon investigating the original problem, learned that:

1. Docker deprecated Docker Machine in 2021
2. Docker now redirects visitors seeking docs about Docker Machine to docs about Docker Desktop
3. Rancher (the org) maintains its own fork of Docker Machine and it is used within Rancher (the software)
4. The Rancher Machine fork links to the original Docker Machine documentation the link intended to point to

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->

Original comment from #1281:

> I did a little research. The Docker Machine repo is now archived and the project is deprecated.
> 
> From [docker/machine#4894 (comment)](https://github.com/docker/machine/issues/4894#issuecomment-897601827):
> 
> > We are not actively maintaining this project and see [Docker Desktop](https://www.docker.com/products/docker-desktop) as its successor for container development on macOS and Windows. I've added an item on our [docker/roadmap#245](https://github.com/docker/roadmap/issues/245) where you can leave us feedback.
> 
> From [docker/roadmap#245](https://github.com/docker/roadmap/issues/245):
> 
> > The Docker Machine project started in 2014 to make it easier to setup and run Docker in a virtual machine. One of the major use cases for this was to make it easier to use Docker on macOS and Windows. Since its release in 2016, [Docker Desktop](https://www.docker.com/products/docker-desktop) has been seen as the replacement for Docker Machine to develop with containers on macOS and Windows. Not only does Docker Desktop provide a Docker API endpoint but it also provides transparent handling of file sharing and networking between the host and VM which make container development easier.
> 
> [Rancher: Node Drivers](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/manage-node-drivers#developing-your-own-node-drivers) contains a link to https://docs.docker.com/machine/ but that page has been removed and the Docker site redirects visitors to https://docs.docker.com/desktop/ instead.
> 
> Curiously enough, Rancher maintains its own fork of Docker Machine at https://github.com/rancher/machine. The README on that repo points to https://gcbw.github.io/docker.github.io/machine/, a mirror of the original Docker Machine docs.
> 
> The Rancher fork notes:
> 
> > This project is intended to be embedded and executed by the full [Rancher](https://github.com/rancher/rancher) product and the stand alone cli functionality will remain but the human use of it will not be the primary focus as we will expect inputs provided by other things like Terraform or UIs.