### PR TITLE
#999 Clarify support and stipulations for use of firewall in documentation

### DIFF
--- a/docs/how-to-guides/advanced-user-guides/open-ports-with-firewalld.md
+++ b/docs/how-to-guides/advanced-user-guides/open-ports-with-firewalld.md
@@ -6,7 +6,15 @@ title: Opening Ports with firewalld
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/open-ports-with-firewalld"/>
 </head>
 
-> We recommend disabling firewalld. For Kubernetes 1.19.x and higher, firewalld must be turned off.
+:::danger
+Enabling firewalld can cause serious network communication problems. 
+
+For proper network functioning, firewalld must be disabled on systems runninmg RKE2. [Firewalld conflicts with Canal](https://docs.rke2.io/known_issues?_highlight=firewalld#firewalld-conflicts-with-default-networking), RKE2's default networking stack.
+
+Firewalld must also be disabled on systems running Kubernetes 1.19 and later.
+
+If you enable firewalld on systems running Kubernetes 1.18 or earlier, understand that this may cause network communication problems. CNIs in Kubernetes dynamically update iptables and networking rules independently of any external firewalls, such as firewalld or Ubuntu's UFW. This can cause unexpected behavior when the CNI and the firewall conflict.
+:::
 
 Some distributions of Linux [derived from RHEL,](https://en.wikipedia.org/wiki/Red_Hat_Enterprise_Linux#Rebuilds) including Oracle Linux, may have default firewall rules that block communication with Helm.
 

--- a/docs/how-to-guides/advanced-user-guides/open-ports-with-firewalld.md
+++ b/docs/how-to-guides/advanced-user-guides/open-ports-with-firewalld.md
@@ -10,7 +10,7 @@ title: Opening Ports with firewalld
 
 Enabling firewalld can cause serious network communication problems. 
 
-For proper network functioning, firewalld must be disabled on systems runninmg RKE2. [Firewalld conflicts with Canal](https://docs.rke2.io/known_issues?_highlight=firewalld#firewalld-conflicts-with-default-networking), RKE2's default networking stack.
+For proper network functioning, firewalld must be disabled on systems runninmg RKE2. [Firewalld conflicts with Canal](https://docs.rke2.io/known_issues#firewalld-conflicts-with-default-networking), RKE2's default networking stack.
 
 Firewalld must also be disabled on systems running Kubernetes 1.19 and later.
 

--- a/docs/how-to-guides/advanced-user-guides/open-ports-with-firewalld.md
+++ b/docs/how-to-guides/advanced-user-guides/open-ports-with-firewalld.md
@@ -7,13 +7,15 @@ title: Opening Ports with firewalld
 </head>
 
 :::danger
+
 Enabling firewalld can cause serious network communication problems. 
 
 For proper network functioning, firewalld must be disabled on systems runninmg RKE2. [Firewalld conflicts with Canal](https://docs.rke2.io/known_issues?_highlight=firewalld#firewalld-conflicts-with-default-networking), RKE2's default networking stack.
 
 Firewalld must also be disabled on systems running Kubernetes 1.19 and later.
 
-If you enable firewalld on systems running Kubernetes 1.18 or earlier, understand that this may cause network communication problems. CNIs in Kubernetes dynamically update iptables and networking rules independently of any external firewalls, such as firewalld or Ubuntu's UFW. This can cause unexpected behavior when the CNI and the firewall conflict.
+If you enable firewalld on systems running Kubernetes 1.18 or earlier, understand that this may cause networking issues. CNIs in Kubernetes dynamically update iptables and networking rules independently of any external firewalls, such as firewalld. This can cause unexpected behavior when the CNI and the external firewall conflict.
+
 :::
 
 Some distributions of Linux [derived from RHEL,](https://en.wikipedia.org/wiki/Red_Hat_Enterprise_Linux#Rebuilds) including Oracle Linux, may have default firewall rules that block communication with Helm.

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/advanced-options/advanced-use-cases/open-ports-with-firewalld.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/advanced-options/advanced-use-cases/open-ports-with-firewalld.md
@@ -2,7 +2,13 @@
 title: Opening Ports with firewalld
 ---
 
-> We recommend disabling firewalld. For Kubernetes 1.19.x and higher, firewalld must be turned off.
+:::danger
+
+Enabling firewalld can cause serious network communication problems. 
+
+CNIs in Kubernetes dynamically update iptables and networking rules independently of any external firewalls, such as firewalld. This can cause unexpected behavior when the CNI and the external firewall conflict.
+
+:::
 
 Some distributions of Linux [derived from RHEL,](https://en.wikipedia.org/wiki/Red_Hat_Enterprise_Linux#Rebuilds) including Oracle Linux, may have default firewall rules that block communication with Helm.
 

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/advanced-options/advanced-use-cases/open-ports-with-firewalld.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/advanced-options/advanced-use-cases/open-ports-with-firewalld.md
@@ -2,7 +2,17 @@
 title: Opening Ports with firewalld
 ---
 
-> We recommend disabling firewalld. For Kubernetes 1.19.x and higher, firewalld must be turned off.
+:::danger
+
+Enabling firewalld can cause serious network communication problems. 
+
+For proper network functioning, firewalld must be disabled on systems runninmg RKE2. [Firewalld conflicts with Canal](https://docs.rke2.io/known_issues#firewalld-conflicts-with-default-networking), RKE2's default networking stack.
+
+Firewalld must also be disabled on systems running Kubernetes 1.19 and later.
+
+If you enable firewalld on systems running Kubernetes 1.18 or earlier, understand that this may cause networking issues. CNIs in Kubernetes dynamically update iptables and networking rules independently of any external firewalls, such as firewalld. This can cause unexpected behavior when the CNI and the external firewall conflict.
+
+:::
 
 Some distributions of Linux [derived from RHEL,](https://en.wikipedia.org/wiki/Red_Hat_Enterprise_Linux#Rebuilds) including Oracle Linux, may have default firewall rules that block communication with Helm.
 

--- a/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/open-ports-with-firewalld.md
+++ b/versioned_docs/version-2.6/how-to-guides/advanced-user-guides/open-ports-with-firewalld.md
@@ -6,7 +6,17 @@ title: Opening Ports with firewalld
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/open-ports-with-firewalld"/>
 </head>
 
-> We recommend disabling firewalld. For Kubernetes 1.19.x and higher, firewalld must be turned off.
+:::danger
+
+Enabling firewalld can cause serious network communication problems. 
+
+For proper network functioning, firewalld must be disabled on systems runninmg RKE2. [Firewalld conflicts with Canal](https://docs.rke2.io/known_issues#firewalld-conflicts-with-default-networking), RKE2's default networking stack.
+
+Firewalld must also be disabled on systems running Kubernetes 1.19 and later.
+
+If you enable firewalld on systems running Kubernetes 1.18 or earlier, understand that this may cause networking issues. CNIs in Kubernetes dynamically update iptables and networking rules independently of any external firewalls, such as firewalld. This can cause unexpected behavior when the CNI and the external firewall conflict.
+
+:::
 
 Some distributions of Linux [derived from RHEL,](https://en.wikipedia.org/wiki/Red_Hat_Enterprise_Linux#Rebuilds) including Oracle Linux, may have default firewall rules that block communication with Helm.
 

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/open-ports-with-firewalld.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/open-ports-with-firewalld.md
@@ -6,7 +6,17 @@ title: Opening Ports with firewalld
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/open-ports-with-firewalld"/>
 </head>
 
-> We recommend disabling firewalld. For Kubernetes 1.19.x and higher, firewalld must be turned off.
+:::danger
+
+Enabling firewalld can cause serious network communication problems. 
+
+For proper network function, firewalld must be disabled on systems running RKE2. [Firewalld conflicts with Canal](https://docs.rke2.io/known_issues#firewalld-conflicts-with-default-networking), RKE2's default networking stack.
+
+Firewalld must also be disabled on systems running Kubernetes 1.19 and later.
+
+If you enable firewalld on systems running Kubernetes 1.18 or earlier, understand that this may cause networking issues. CNIs in Kubernetes dynamically update iptables and networking rules independently of any external firewalls, such as firewalld. This can cause unexpected behavior when the CNI and the external firewall conflict.
+
+:::
 
 Some distributions of Linux [derived from RHEL,](https://en.wikipedia.org/wiki/Red_Hat_Enterprise_Linux#Rebuilds) including Oracle Linux, may have default firewall rules that block communication with Helm.
 

--- a/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/open-ports-with-firewalld.md
+++ b/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/open-ports-with-firewalld.md
@@ -6,7 +6,17 @@ title: Opening Ports with firewalld
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/open-ports-with-firewalld"/>
 </head>
 
-> We recommend disabling firewalld. For Kubernetes 1.19.x and higher, firewalld must be turned off.
+:::danger
+
+Enabling firewalld can cause serious network communication problems. 
+
+For proper network function, firewalld must be disabled on systems running RKE2. [Firewalld conflicts with Canal](https://docs.rke2.io/known_issues#firewalld-conflicts-with-default-networking), RKE2's default networking stack.
+
+Firewalld must also be disabled on systems running Kubernetes 1.19 and later.
+
+If you enable firewalld on systems running Kubernetes 1.18 or earlier, understand that this may cause networking issues. CNIs in Kubernetes dynamically update iptables and networking rules independently of any external firewalls, such as firewalld. This can cause unexpected behavior when the CNI and the external firewall conflict.
+
+:::
 
 Some distributions of Linux [derived from RHEL,](https://en.wikipedia.org/wiki/Red_Hat_Enterprise_Linux#Rebuilds) including Oracle Linux, may have default firewall rules that block communication with Helm.
 


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #999 

Fixes SURE-7077

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

This adds a stronger warning against turning on firewalld. Although we provide the user the information to work with firewalld, it is known to conflict with RKE2, and may block or break network communication on non-RKE2 systems. There is an archived Slack thread related to this issue. The information I added is based on the discussion there.

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->