### PR TITLE
Use release date instead of placeholder

### DIFF
--- a/docs/faq/deprecated-features.md
+++ b/docs/faq/deprecated-features.md
@@ -16,7 +16,7 @@ Rancher will publish deprecated features as part of the [release notes](https://
 
 | Patch Version |  Release Date |
 |---------------|---------------|
-| [2.8.4](https://github.com/rancher/rancher/releases/tag/v2.8.4) | TBD |
+| [2.8.4](https://github.com/rancher/rancher/releases/tag/v2.8.4) | May 16, 2024 |
 | [2.8.3](https://github.com/rancher/rancher/releases/tag/v2.8.3) | Mar 28, 2024 |
 | [2.8.2](https://github.com/rancher/rancher/releases/tag/v2.8.2) | Feb 8, 2024 |
 | [2.8.1](https://github.com/rancher/rancher/releases/tag/v2.8.1) | Jan 22, 2024 |

--- a/versioned_docs/version-2.7/faq/deprecated-features.md
+++ b/versioned_docs/version-2.7/faq/deprecated-features.md
@@ -16,7 +16,7 @@ Rancher will publish deprecated features as part of the [release notes](https://
 
 | Patch Version |  Release Date |
 |---------------|---------------|
-| [2.7.13](https://github.com/rancher/rancher/releases/tag/v2.7.13) |  TBD  |
+| [2.7.13](https://github.com/rancher/rancher/releases/tag/v2.7.13) |  May 16, 2024  |
 | [2.7.12](https://github.com/rancher/rancher/releases/tag/v2.7.12) |  Mar 28, 2024  |
 | [2.7.11](https://github.com/rancher/rancher/releases/tag/v2.7.11) |  Mar 1, 2024  |
 | [2.7.10](https://github.com/rancher/rancher/releases/tag/v2.7.10) |  Feb 8, 2024  |

--- a/versioned_docs/version-2.8/faq/deprecated-features.md
+++ b/versioned_docs/version-2.8/faq/deprecated-features.md
@@ -16,7 +16,7 @@ Rancher will publish deprecated features as part of the [release notes](https://
 
 | Patch Version |  Release Date |
 |---------------|---------------|
-| [2.8.4](https://github.com/rancher/rancher/releases/tag/v2.8.4) | TBD |
+| [2.8.4](https://github.com/rancher/rancher/releases/tag/v2.8.4) | May 16, 2024 |
 | [2.8.3](https://github.com/rancher/rancher/releases/tag/v2.8.3) | Mar 28, 2024 |
 | [2.8.2](https://github.com/rancher/rancher/releases/tag/v2.8.2) | Feb 8, 2024 |
 | [2.8.1](https://github.com/rancher/rancher/releases/tag/v2.8.1) | Jan 22, 2024 |


### PR DESCRIPTION
## Description

Missed updating the `TBD` placeholders in #1271 and #1272 before merging.

