### PR TITLE
Add support matrix links for 2.8.4 and 2.7.13

### DIFF
--- a/docs/reference-guides/rancher-webhook.md
+++ b/docs/reference-guides/rancher-webhook.md
@@ -19,7 +19,7 @@ Each Rancher version is designed to be compatible with a single version of the w
 
 | Rancher Version | Webhook Version | Availability in Prime | Availability in Community |
 |-----------------|-----------------|-----------------------|---------------------------|
-| v2.8.4          |     v0.4.5      | &cross;               | &check;                   |
+| v2.8.4          |     v0.4.5      | &check;               | &check;                   |
 | v2.8.3          |     v0.4.3      | &check;               | &check;                   |
 | v2.8.2          |     v0.4.2      | &check;               | &check;                   |
 | v2.8.1          |     v0.4.2      | &check;               | &check;                   |

--- a/src/pages/versions.md
+++ b/src/pages/versions.md
@@ -21,8 +21,8 @@ Here you can find links to supporting documentation for the current released ver
     <td><b>v2.8.4</b></td>
     <td><a href="https://ranchermanager.docs.rancher.com/v2.8">Documentation</a></td>
     <td><a href="https://github.com/rancher/rancher/releases/tag/v2.8.4">Release Notes</a></td>
-    <td><center>N/A</center></td>
-    <td><center>N/A</center></td>
+    <td><a href="https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-8-4/">Support Matrix</a></td>
+    <td><center>&#10003;</center></td>
     <td><center>&#10003;</center></td>
   </tr>
 </table>
@@ -42,7 +42,7 @@ Here you can find links to supporting documentation for the current released ver
     <td><b>v2.7.13</b></td>
     <td><a href="https://ranchermanager.docs.rancher.com/v2.7">Documentation</a></td>
     <td><a href="https://github.com/rancher/rancher/releases/tag/v2.7.13">Release Notes</a></td>
-    <td><center>N/A</center></td>
+    <td><a href="https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-7-13/">Support Matrix</a></td>
     <td><center>&#10003;</center></td>
     <td><center>N/A</center></td>
   </tr>

--- a/versioned_docs/version-2.8/reference-guides/rancher-webhook.md
+++ b/versioned_docs/version-2.8/reference-guides/rancher-webhook.md
@@ -20,7 +20,7 @@ Each Rancher version is designed to be compatible with a single version of the w
 
 | Rancher Version | Webhook Version | Availability in Prime | Availability in Community |
 |-----------------|-----------------|-----------------------|---------------------------|
-| v2.8.4          |     v0.4.5      | &cross;               | &check;                   |
+| v2.8.4          |     v0.4.5      | &check;               | &check;                   |
 | v2.8.3          |     v0.4.3      | &check;               | &check;                   |
 | v2.8.2          |     v0.4.2      | &check;               | &check;                   |
 | v2.8.1          |     v0.4.2      | &check;               | &check;                   |


### PR DESCRIPTION
## Description

Support matrix links are now live and v2.8.4 has been promoted to Prime.