### PR TITLE
#1293 Create an AKS cluster page may need a refresh. Part 1: Commands and section headings

### DIFF
--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/aks.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/aks.md
@@ -28,22 +28,16 @@ The below sections describe how to set up these prerequisites using either the A
 
 ### Setting Up the Service Principal with the Azure Command Line Tool
 
-Create the service principal and give it Contributor privileges. You must provide `scopes` a full path to at least one Azure resource:
+You must assign roles to the service principal so that it has communication privileges with the AKS API. It also needs access to create and list virtual networks. 
+
+The following command creates the service principal and gives it the Contributor role. The Contributor role can manage anything on AKS but cannot give access to others. Note that you must provide `scopes` a full path to at least one Azure resource: 
 
 ```
-az ad sp create-for-rbac \
-  --role Contributor 
-  --scopes /subscriptions/<subscription-id>/resourceGroups/<group> \
-  ```
-
-
-```
-az ad sp create-for-rbac \
-  --scope /subscriptions/<subscription-id>/resourceGroups/<group> \
-  --role Contributor
+az ad sp create-for-rbac --role Contributor --scopes /subscriptions/<subscription-id>/resourceGroups/<group>
 ```
 
 The result should show information about the new service principal:
+
 ```
 {
   "appId": "xxxx--xxx",
@@ -54,21 +48,10 @@ The result should show information about the new service principal:
 }
 ```
 
-Create the Resource Group by running this command:
+The following creates a [Resource Group](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-cli) to contain your Azure resources:
 
 ```
 az group create --location <azure-location-name> --resource-group <azure-resource-group-name>
-```
-
-You must add roles to the service principal so that it has privileges for communication with the AKS API. It also needs access to create and list virtual networks.
-
-Below is an example command for assigning the Contributor role to a service principal. Contributors can manage anything on AKS but cannot give access to others:
-
-```
-az role assignment create \
-  --assignee <client-id> \
-  --scope /subscriptions/<subscription-id>/resourceGroups/<group> \
-  --role Contributor
 ```
 
 ### Setting Up the Service Principal from the Azure Portal

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/aks.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/aks.md
@@ -101,7 +101,7 @@ To give role-based access to your service principal,
 
 **Result:** Your service principal now has access to AKS.
 
-## 1. Create the AKS Cloud Credentials
+## Create the AKS Cloud Credentials
 
 1. In the Rancher UI, click **☰ > Cluster Management**.
 1. Click **Cloud Credentials**.
@@ -110,7 +110,7 @@ To give role-based access to your service principal,
 1. Fill out the form. For help with filling out the form, see the [configuration reference.](../../../../reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration.md#cloud-credentials)
 1. Click **Create**.
 
-## 2. Create the AKS Cluster
+## Create the AKS Cluster
 
 Use Rancher to set up and configure your Kubernetes cluster.
 
@@ -124,7 +124,8 @@ Use Rancher to set up and configure your Kubernetes cluster.
 
 You can access your cluster after its state is updated to **Active**.
 
-## Role-based Access Control
+## Configure Role-based Access Control
+
 When provisioning an AKS cluster in the Rancher UI, RBAC is not configurable because it is required to be enabled.
 
 RBAC is required for AKS clusters that are registered or imported into Rancher.

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/aks.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/aks.md
@@ -21,7 +21,7 @@ To interact with Azure APIs, an AKS cluster requires an Azure Active Directory (
 Before creating the service principal, you need to obtain the following information from the [Microsoft Azure Portal](https://portal.azure.com):
 
 - Subscription ID
-- App ID (also known as the client ID) 
+- Client ID (also known as app ID) 
 - Client secret
 
 The below sections describe how to set up these prerequisites using either the Azure command line tool or the Azure portal.

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/aks.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/aks.md
@@ -21,7 +21,7 @@ To interact with Azure APIs, an AKS cluster requires an Azure Active Directory (
 Before creating the service principal, you need to obtain the following information from the [Microsoft Azure Portal](https://portal.azure.com):
 
 - Subscription ID
-- Client ID
+- App ID (also known as the client ID) 
 - Client secret
 
 The below sections describe how to set up these prerequisites using either the Azure command line tool or the Azure portal.
@@ -38,10 +38,10 @@ The result should show information about the new service principal:
 ```
 {
   "appId": "xxxx--xxx",
-  "displayName": "<SERVICE-PRINCIPAL-NAME>",
-  "name": "http://<SERVICE-PRINCIPAL-NAME>",
-  "password": "<SECRET>",
-  "tenant": "<TENANT NAME>"
+  "displayName": "<service-principal-name>",
+  "name": "http://<service-principal-name>",
+  "password": "<secret>",
+  "tenant": "<tenant-name>"
 }
 ```
 
@@ -51,8 +51,8 @@ Below is an example command for assigning the Contributor role to a service prin
 
 ```
 az role assignment create \
-  --assignee $appId \
-  --scope /subscriptions/$<SUBSCRIPTION-ID>/resourceGroups/$<GROUP> \
+  --assignee <client-id> \
+  --scope /subscriptions/<subscription-id>/resourceGroups/<group> \
   --role Contributor
 ```
 
@@ -60,14 +60,14 @@ You can also create the service principal and give it Contributor privileges by 
 
 ```
 az ad sp create-for-rbac \
-  --scope /subscriptions/$<SUBSCRIPTION-ID>/resourceGroups/$<GROUP> \
+  --scope /subscriptions/<subscription-id>/resourceGroups/<group> \
   --role Contributor
 ```
 
 Create the Resource Group by running this command:
 
 ```
-az group create --location AZURE_LOCATION_NAME --resource-group AZURE_RESOURCE_GROUP_NAME
+az group create --location <azure-location-name> --resource-group <azure-resource-group-name>
 ```
 
 ### Setting Up the Service Principal from the Azure Portal
@@ -136,8 +136,8 @@ Assign the Rancher AKSv2 role to the service principal with the Azure Command Li
 
 ```
 az role assignment create \
---assignee CLIENT_ID \
---scope "/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_NAME" \
+--assignee <client-id> \
+--scope "/subscriptions/<subscription-id>/resourceGroups/<resource-group-name>" \
 --role "Rancher AKSv2"
 ```
 

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/aks.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/aks.md
@@ -28,10 +28,19 @@ The below sections describe how to set up these prerequisites using either the A
 
 ### Setting Up the Service Principal with the Azure Command Line Tool
 
-You can create the service principal by running this command:
+Create the service principal and give it Contributor privileges. You must provide `scopes` a full path to at least one Azure resource:
 
 ```
-az ad sp create-for-rbac
+az ad sp create-for-rbac \
+  --role Contributor 
+  --scopes /subscriptions/<subscription-id>/resourceGroups/<group> \
+  ```
+
+
+```
+az ad sp create-for-rbac \
+  --scope /subscriptions/<subscription-id>/resourceGroups/<group> \
+  --role Contributor
 ```
 
 The result should show information about the new service principal:
@@ -45,7 +54,13 @@ The result should show information about the new service principal:
 }
 ```
 
-You also need to add roles to the service principal so that it has privileges for communication with the AKS API. It also needs access to create and list virtual networks.
+Create the Resource Group by running this command:
+
+```
+az group create --location <azure-location-name> --resource-group <azure-resource-group-name>
+```
+
+You must add roles to the service principal so that it has privileges for communication with the AKS API. It also needs access to create and list virtual networks.
 
 Below is an example command for assigning the Contributor role to a service principal. Contributors can manage anything on AKS but cannot give access to others:
 
@@ -56,31 +71,16 @@ az role assignment create \
   --role Contributor
 ```
 
-You can also create the service principal and give it Contributor privileges by combining the two commands into one. In this command, the scope needs to provide a full path to an Azure resource:
-
-```
-az ad sp create-for-rbac \
-  --scope /subscriptions/<subscription-id>/resourceGroups/<group> \
-  --role Contributor
-```
-
-Create the Resource Group by running this command:
-
-```
-az group create --location <azure-location-name> --resource-group <azure-resource-group-name>
-```
-
 ### Setting Up the Service Principal from the Azure Portal
 
-You can also follow these instructions to set up a service principal and give it role-based access from the Azure Portal.
+Follow these instructions to set up a service principal and give it role-based access from the Azure Portal.
 
 1. Go to the Microsoft Azure Portal [home page](https://portal.azure.com).
-
 1. Click **Azure Active Directory**.
 1. Click **App registrations**.
 1. Click **New registration**.
-1. Enter a name. This will be the name of your service principal.
-1. Optional: Choose which accounts can use the service principal.
+1. Enter a name for your service principal.
+  1. Optional: Choose which accounts can use the service principal.
 1. Click **Register**.
 1. You should now see the name of your service principal under **Azure Active Directory > App registrations**.
 1. Click the name of your service principal. Take note of the application ID (also called app ID or client ID) so that you can use it when provisioning your AKS cluster. Then click **Certificates & secrets**.

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/aks.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/aks.md
@@ -31,7 +31,7 @@ The below sections describe how to set up these prerequisites using either the A
 You can create the service principal by running this command:
 
 ```
-az ad sp create-for-rbac --skip-assignment
+az ad sp create-for-rbac
 ```
 
 The result should show information about the new service principal:

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/aks.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/aks.md
@@ -30,10 +30,10 @@ The below sections describe how to set up these prerequisites using either the A
 
 You must assign roles to the service principal so that it has communication privileges with the AKS API. It also needs access to create and list virtual networks. 
 
-The following command creates the service principal and gives it the Contributor role. The Contributor role can manage anything on AKS but cannot give access to others. Note that you must provide `scopes` a full path to at least one Azure resource: 
+In the following example, the command creates the service principal and gives it the Contributor role. The Contributor role can manage anything on AKS but cannot give access to others. Note that you must provide `scopes` a full path to at least one Azure resource: 
 
 ```
-az ad sp create-for-rbac --role Contributor --scopes /subscriptions/<subscription-id>/resourceGroups/<group>
+az ad sp create-for-rbac --role Contributor --scopes /subscriptions/<subscription-id>/resourceGroups/<resource-group-name>
 ```
 
 The result should show information about the new service principal:
@@ -51,7 +51,7 @@ The result should show information about the new service principal:
 The following creates a [Resource Group](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-cli) to contain your Azure resources:
 
 ```
-az group create --location <azure-location-name> --resource-group <azure-resource-group-name>
+az group create --location <azure-location-name> --resource-group <resource-group-name>
 ```
 
 ### Setting Up the Service Principal from the Azure Portal
@@ -63,7 +63,7 @@ Follow these instructions to set up a service principal and give it role-based a
 1. Click **App registrations**.
 1. Click **New registration**.
 1. Enter a name for your service principal.
-  1. Optional: Choose which accounts can use the service principal.
+1. Optional: Choose which accounts can use the service principal.
 1. Click **Register**.
 1. You should now see the name of your service principal under **Azure Active Directory > App registrations**.
 1. Click the name of your service principal. Take note of the application ID (also called app ID or client ID) so that you can use it when provisioning your AKS cluster. Then click **Certificates & secrets**.


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Addresses parts of #1293 

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, make sure to target the release branch instead of `main`.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

This PR addresses the following parts of #1293:

>  the structure of the page is inconsistent, with some titles being numbered and others not

Removed numbering, revised some headings to be more consistent

>  the --skip-assignment commandline flag is now deprecated in az 

See first example in https://learn.microsoft.com/en-us/cli/azure/ad/sp?view=azure-cli-latest#az-ad-sp-create-for-rbac-examples -- not only is the flag deprecated, the default behavior is to skip assignment.

>  in the commands, some variables referring to the same value are written differently (as $appId first and CLIENT_ID later). It would help to uniform variable names and "style of declaration"

Opted for `<name-with-dashes>` style and "client-ID"

>  in "Setting Up the Service Principal with the Azure Command Line Tool" instructions cover a two-command way to achieve the goal followed by a simpler one-command way. As a user following along I felt tricked into going via the more difficult path needlessly

I opted to remove the two command way as I didn't see the utility when there is a simpler way and we link to the MS docs if the user needs to do more complicated setups anyway.

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->

I'll do a separate PR for the outdated terminology as that involves touching other pages besides "Creating an AKS Cluster". I'll also look into syncing with https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-azure-cluster instructions later.