### PR TITLE
Update CSP Adapter Table - v2.8.5

### DIFF
--- a/docs/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/install-adapter.md
+++ b/docs/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/install-adapter.md
@@ -19,6 +19,7 @@ In order to deploy and run the adapter successfully, you need to ensure its vers
 
 | Rancher Version | Adapter Version  |
 |-----------------|:----------------:|
+| v2.8.5          | TBD              |
 | v2.8.4          | v103.0.1+up3.0.1 |
 | v2.8.3          | v103.0.1+up3.0.1 |
 | v2.8.2          | v103.0.0+up3.0.0 |

--- a/docs/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/install-adapter.md
+++ b/docs/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/install-adapter.md
@@ -19,7 +19,7 @@ In order to deploy and run the adapter successfully, you need to ensure its vers
 
 | Rancher Version | Adapter Version  |
 |-----------------|:----------------:|
-| v2.8.5          | TBD              |
+| v2.8.5          | v103.0.1+up3.0.1 |
 | v2.8.4          | v103.0.1+up3.0.1 |
 | v2.8.3          | v103.0.1+up3.0.1 |
 | v2.8.2          | v103.0.0+up3.0.0 |

--- a/versioned_docs/version-2.8/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/install-adapter.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/install-adapter.md
@@ -19,6 +19,7 @@ In order to deploy and run the adapter successfully, you need to ensure its vers
 
 | Rancher Version | Adapter Version  |
 |-----------------|:----------------:|
+| v2.8.5          | TBD              |
 | v2.8.4          | v103.0.1+up3.0.1 |
 | v2.8.3          | v103.0.1+up3.0.1 |
 | v2.8.2          | v103.0.0+up3.0.0 |

--- a/versioned_docs/version-2.8/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/install-adapter.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/install-adapter.md
@@ -19,7 +19,7 @@ In order to deploy and run the adapter successfully, you need to ensure its vers
 
 | Rancher Version | Adapter Version  |
 |-----------------|:----------------:|
-| v2.8.5          | TBD              |
+| v2.8.5          | v103.0.1+up3.0.1 |
 | v2.8.4          | v103.0.1+up3.0.1 |
 | v2.8.3          | v103.0.1+up3.0.1 |
 | v2.8.2          | v103.0.0+up3.0.0 |


### PR DESCRIPTION
Updating the CSP adapter table with v2.8.5 section.

[Source](https://github.com/rancher/rancher/blob/release/v2.8.5/build.yaml)
