### PR TITLE
#1279 - [BUG] RKE1 vSphere external (out-of-tree) cloud provider description, has a docs link which leads to 404 Not Found

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2736,7 +2736,7 @@ module.exports = {
           }, // Redirects for #1279 - 404 in Rancher Dashboard
           {
             to: '/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/launch-kubernetes-with-rancher/set-up-cloud-providers/vsphere/configure-out-of-tree-vsphere',
-            from: 'v2.8/cluster-provisioning/rke-clusters/cloud-providers/vsphere/out-of-tree'
+            from: '/v2.8/cluster-provisioning/rke-clusters/cloud-providers/vsphere/out-of-tree'
           }, // # 1279 redirect (end)
           {
             to: '/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/migrate-to-an-out-of-tree-cloud-provider/migrate-to-out-of-tree-vsphere',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2736,8 +2736,8 @@ module.exports = {
           },
           // Redirects for #1279 - 404 in Rancher Dashboard
           {
-            to: 'v2.8/cluster-provisioning/rke-clusters/cloud-providers/vsphere/out-of-tree',
-            from: '/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/launch-kubernetes-with-rancher/set-up-cloud-providers/vsphere/configure-out-of-tree-vsphere'
+            to: '/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/launch-kubernetes-with-rancher/set-up-cloud-providers/vsphere/configure-out-of-tree-vsphere',
+            from: 'v2.8/cluster-provisioning/rke-clusters/cloud-providers/vsphere/out-of-tree'
           },
           // # 1279 redirect (end)
           {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2734,6 +2734,12 @@ module.exports = {
             to: '/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-out-of-tree-vsphere',
             from: '/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/launch-kubernetes-with-rancher/set-up-cloud-providers/vsphere/configure-out-of-tree-vsphere'
           },
+          // Redirects for #1279 - 404 in Rancher Dashboard
+          {
+            to: 'v2.8/cluster-provisioning/rke-clusters/cloud-providers/vsphere/out-of-tree',
+            from: '/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/launch-kubernetes-with-rancher/set-up-cloud-providers/vsphere/configure-out-of-tree-vsphere'
+          },
+          // # 1279 redirect (end)
           {
             to: '/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/migrate-to-an-out-of-tree-cloud-provider/migrate-to-out-of-tree-vsphere',
             from: '/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/launch-kubernetes-with-rancher/set-up-cloud-providers/vsphere/migrate-from-in-tree-to-out-of-tree'

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2733,13 +2733,11 @@ module.exports = {
           {
             to: '/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-out-of-tree-vsphere',
             from: '/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/launch-kubernetes-with-rancher/set-up-cloud-providers/vsphere/configure-out-of-tree-vsphere'
-          },
-          // Redirects for #1279 - 404 in Rancher Dashboard
+          }, // Redirects for #1279 - 404 in Rancher Dashboard
           {
             to: '/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/launch-kubernetes-with-rancher/set-up-cloud-providers/vsphere/configure-out-of-tree-vsphere',
             from: 'v2.8/cluster-provisioning/rke-clusters/cloud-providers/vsphere/out-of-tree'
-          },
-          // # 1279 redirect (end)
+          }, // # 1279 redirect (end)
           {
             to: '/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/migrate-to-an-out-of-tree-cloud-provider/migrate-to-out-of-tree-vsphere',
             from: '/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/launch-kubernetes-with-rancher/set-up-cloud-providers/vsphere/migrate-from-in-tree-to-out-of-tree'

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2735,7 +2735,7 @@ module.exports = {
             from: '/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/launch-kubernetes-with-rancher/set-up-cloud-providers/vsphere/configure-out-of-tree-vsphere'
           }, // Redirects for #1279 - 404 in Rancher Dashboard
           {
-            to: '/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/launch-kubernetes-with-rancher/set-up-cloud-providers/vsphere/configure-out-of-tree-vsphere',
+            to: '/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-out-of-tree-vsphere',
             from: '/v2.8/cluster-provisioning/rke-clusters/cloud-providers/vsphere/out-of-tree'
           }, // # 1279 redirect (end)
           {


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #1279 

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, remember to add a "MERGE ON RELEASE" label and set the proper milestone.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

A link in the Rancher UI points to https://rancher.com/docs/rancher/v2.8/en/cluster-provisioning/rke-clusters/cloud-providers/vsphere/out-of-tree, which returns a `404`. The correct path is https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-out-of-tree-vsphere. Only v2.8 is reported as affected.

I added a redirect, patterned after the redirects on lines 2398 to 2406 in the Docusuarus config file. Since all those redirects also point to files in the now-removed path `/v2.8/cluster-provisioning/rke-clusters`, I wonder if this broken redirect is related to the same issue (dashboard#9970)?

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->
