### PR TITLE
Remove references to when old features became available

### DIFF
--- a/docs/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
+++ b/docs/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
@@ -102,8 +102,6 @@ There is a [known issue](https://github.com/rancher/rancher/issues/25478) in whi
 
 ### Maintaining Availability for Applications During Upgrades
 
-_Available as of RKE v1.1.0_
-
 In [this section of the RKE documentation,](https://rancher.com/docs/rke/latest/en/upgrades/maintaining-availability/) you'll learn the requirements to prevent downtime for your applications when upgrading the cluster.
 
 ### Configuring the Upgrade Strategy in the cluster.yml

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -62,21 +62,6 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
 
 ### 2. Restore from backup using a Restore custom resource
 
-:::note Important:
-
-Kubernetes v1.22, available as an experimental feature of v2.6.3, does not support restoring from backup files containing CRDs with the apiVersion `apiextensions.k8s.io/v1beta1`. In v1.22, the default `resourceSet` in the rancher-backup app is updated to collect only CRDs that use `apiextensions.k8s.io/v1`. There are currently two ways to work around this issue:
-
-1. Update the default `resourceSet` to collect the CRDs with the apiVersion v1.
-1. Update the default `resourceSet` and the client to use the new APIs internally, with `apiextensions.k8s.io/v1` as the replacement.
-
-    :::note
-
-    When making or restoring backups for v1.22, the Rancher version and the local cluster's Kubernetes version should be the same. The Kubernetes version should be considered when restoring a backup since the supported apiVersion in the cluster and in the backup file could be different.
-
-    :::
-
-:::
-
 1. When using S3 object storage as the backup source for a restore that requires credentials, create a `Secret` object in this cluster to add the S3 credentials. The secret data must have two keys - `accessKey`, and `secretKey`, that contain the S3 credentials.
 
    The secret can be created in any namespace, this example uses the default namespace.

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -184,8 +184,6 @@ To prevent issues when upgrading, the [Kubernetes upgrade best practices](https:
 
 ## Authorized Cluster Endpoint Support for RKE2 and K3s Clusters
 
-_Available as of v2.6.3_
-
 Authorized Cluster Endpoint (ACE) support has been added for registered RKE2 and K3s clusters. This support includes manual steps you will perform on the downstream cluster to enable the ACE. For additional information on the authorized cluster endpoint, click [here](../manage-clusters/access-clusters/authorized-cluster-endpoint.md).
 
 :::note Notes:

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -184,7 +184,7 @@ To prevent issues when upgrading, the [Kubernetes upgrade best practices](https:
 
 ## Authorized Cluster Endpoint Support for RKE2 and K3s Clusters
 
-Authorized Cluster Endpoint (ACE) support has been added for registered RKE2 and K3s clusters. This support includes manual steps you will perform on the downstream cluster to enable the ACE. For additional information on the authorized cluster endpoint, click [here](../manage-clusters/access-clusters/authorized-cluster-endpoint.md).
+Rancher supports Authorized Cluster Endpoints (ACE) for registered RKE2 and K3s clusters. This support includes manual steps you will perform on the downstream cluster to enable the ACE. For additional information on the authorized cluster endpoint, click [here](../manage-clusters/access-clusters/authorized-cluster-endpoint.md).
 
 :::note Notes:
 

--- a/docs/integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.md
+++ b/docs/integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.md
@@ -112,7 +112,7 @@ Monitoring also creates additional `ClusterRoles` that aren't assigned to users 
 
 | Role | Purpose  |
 | ------------------------------| ---------------------------|
-| monitoring-ui-view | _Available as of Monitoring v2 14.5.100+_ This ClusterRole allows users with write access to the project to view metrics graphs for the specified cluster in the Rancher UI. This is done by granting Read-only access to external Monitoring UIs. Users with this role have permission to list the Prometheus, Alertmanager, and Grafana endpoints and make GET requests to Prometheus, Alertmanager, and Grafana UIs through the Rancher proxy. <br/> <br/> This role doesn't grant access to monitoring endpoints. As a result, users with this role won't be able to view cluster monitoring graphs and dashboards in the Rancher UI; however, they are able to access the monitoring Grafana, Prometheus, and Alertmanager UIs if provided those links. |
+| monitoring-ui-view | This ClusterRole allows users with write access to the project to view metrics graphs for the specified cluster in the Rancher UI. This is done by granting Read-only access to external Monitoring UIs. Users with this role have permission to list the Prometheus, Alertmanager, and Grafana endpoints and make GET requests to Prometheus, Alertmanager, and Grafana UIs through the Rancher proxy. <br/> <br/> This role doesn't grant access to monitoring endpoints. As a result, users with this role won't be able to view cluster monitoring graphs and dashboards in the Rancher UI; however, they are able to access the monitoring Grafana, Prometheus, and Alertmanager UIs if provided those links. |
 
 :::note
 

--- a/docs/integrations-in-rancher/monitoring-and-alerting/windows-support.md
+++ b/docs/integrations-in-rancher/monitoring-and-alerting/windows-support.md
@@ -6,7 +6,7 @@ title: Windows Cluster Support for Monitoring V2
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/monitoring-and-alerting/windows-support"/>
 </head>
 
-Starting at Monitoring V2 14.5.100 (used by default in Rancher 2.5.8), Monitoring V2 can now be deployed on a Windows cluster and will scrape metrics from Windows nodes using [prometheus-community/windows_exporter](https://github.com/prometheus-community/windows_exporter) (previously named `wmi_exporter`).
+Monitoring V2 can be deployed on a Windows cluster to scrape metrics from Windows nodes using [prometheus-community/windows_exporter](https://github.com/prometheus-community/windows_exporter) (previously named `wmi_exporter`).
 
 ## Cluster Requirements
 

--- a/docs/integrations-in-rancher/monitoring-and-alerting/windows-support.md
+++ b/docs/integrations-in-rancher/monitoring-and-alerting/windows-support.md
@@ -6,8 +6,6 @@ title: Windows Cluster Support for Monitoring V2
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/monitoring-and-alerting/windows-support"/>
 </head>
 
-_Available as of v2.5.8_
-
 Starting at Monitoring V2 14.5.100 (used by default in Rancher 2.5.8), Monitoring V2 can now be deployed on a Windows cluster and will scrape metrics from Windows nodes using [prometheus-community/windows_exporter](https://github.com/prometheus-community/windows_exporter) (previously named `wmi_exporter`).
 
 ## Cluster Requirements

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration.md
@@ -6,13 +6,6 @@ title: AKS Cluster Configuration Reference
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration"/>
 </head>
 
-## Changes in Rancher v2.6
-
-- Support for adding more than one node pool
-- Support for private clusters
-- Enabled autoscaling node pools
-- The AKS permissions are now configured in cloud credentials
-
 ## Role-based Access Control
 
 When provisioning an AKS cluster in the Rancher UI, RBAC cannot be disabled. If role-based access control is disabled for the cluster in AKS, the cluster cannot be registered or imported into Rancher.

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
@@ -6,12 +6,6 @@ title: GKE Cluster Configuration Reference
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration"/>
 </head>
 
-## Changes in Rancher v2.6
-
-- Support for additional configuration options:
-  - Project network isolation
-  - Network tags
-
 ## Cluster Location
 
 | Value | Description |

--- a/docs/reference-guides/user-settings/user-preferences.md
+++ b/docs/reference-guides/user-settings/user-preferences.md
@@ -41,8 +41,6 @@ Choose how certain information is displayed:
 
 ## Confirmation Setting
 
-_Available as of v2.7.2_
-
 Choose whether to ask for confirmation when scaling down node pools.
 
 ## Advanced Features

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
@@ -102,8 +102,6 @@ There is a [known issue](https://github.com/rancher/rancher/issues/25478) in whi
 
 ### Maintaining Availability for Applications During Upgrades
 
-_Available as of RKE v1.1.0_
-
 In [this section of the RKE documentation,](https://rancher.com/docs/rke/latest/en/upgrades/maintaining-availability/) you'll learn the requirements to prevent downtime for your applications when upgrading the cluster.
 
 ### Configuring the Upgrade Strategy in the cluster.yml

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -62,21 +62,6 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
 
 ### 2. Restore from backup using a Restore custom resource
 
-:::note Important:
-
-Kubernetes v1.22, available as an experimental feature of v2.6.3, does not support restoring from backup files containing CRDs with the apiVersion `apiextensions.k8s.io/v1beta1`. In v1.22, the default `resourceSet` in the rancher-backup app is updated to collect only CRDs that use `apiextensions.k8s.io/v1`. There are currently two ways to work around this issue:
-
-1. Update the default `resourceSet` to collect the CRDs with the apiVersion v1.
-1. Update the default `resourceSet` and the client to use the new APIs internally, with `apiextensions.k8s.io/v1` as the replacement.
-
-    :::note
-
-    When making or restoring backups for v1.22, the Rancher version and the local cluster's Kubernetes version should be the same. The Kubernetes version should be considered when restoring a backup since the supported apiVersion in the cluster and in the backup file could be different.
-
-    :::
-
-:::
-
 1. When using S3 object storage as the backup source for a restore that requires credentials, create a `Secret` object in this cluster to add the S3 credentials. The secret data must have two keys - `accessKey`, and `secretKey`, that contain the S3 credentials.
 
    The secret can be created in any namespace, this example uses the default namespace.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -184,8 +184,6 @@ To prevent issues when upgrading, the [Kubernetes upgrade best practices](https:
 
 ## Authorized Cluster Endpoint Support for RKE2 and K3s Clusters
 
-_Available as of v2.6.3_
-
 Authorized Cluster Endpoint (ACE) support has been added for registered RKE2 and K3s clusters. This support includes manual steps you will perform on the downstream cluster to enable the ACE. For additional information on the authorized cluster endpoint, click [here](../manage-clusters/access-clusters/authorized-cluster-endpoint.md).
 
 :::note Notes:

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -184,7 +184,7 @@ To prevent issues when upgrading, the [Kubernetes upgrade best practices](https:
 
 ## Authorized Cluster Endpoint Support for RKE2 and K3s Clusters
 
-Authorized Cluster Endpoint (ACE) support has been added for registered RKE2 and K3s clusters. This support includes manual steps you will perform on the downstream cluster to enable the ACE. For additional information on the authorized cluster endpoint, click [here](../manage-clusters/access-clusters/authorized-cluster-endpoint.md).
+Rancher supports Authorized Cluster Endpoints (ACE) for registered RKE2 and K3s clusters. This support includes manual steps you will perform on the downstream cluster to enable the ACE. For additional information on the authorized cluster endpoint, click [here](../manage-clusters/access-clusters/authorized-cluster-endpoint.md).
 
 :::note Notes:
 

--- a/versioned_docs/version-2.7/integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.md
@@ -112,7 +112,7 @@ Monitoring also creates additional `ClusterRoles` that aren't assigned to users 
 
 | Role | Purpose  |
 | ------------------------------| ---------------------------|
-| monitoring-ui-view | _Available as of Monitoring v2 14.5.100+_ This ClusterRole allows users with write access to the project to view metrics graphs for the specified cluster in the Rancher UI. This is done by granting Read-only access to external Monitoring UIs. Users with this role have permission to list the Prometheus, Alertmanager, and Grafana endpoints and make GET requests to Prometheus, Alertmanager, and Grafana UIs through the Rancher proxy. <br/> <br/> This role doesn't grant access to monitoring endpoints. As a result, users with this role won't be able to view cluster monitoring graphs and dashboards in the Rancher UI; however, they are able to access the monitoring Grafana, Prometheus, and Alertmanager UIs if provided those links. |
+| monitoring-ui-view | This ClusterRole allows users with write access to the project to view metrics graphs for the specified cluster in the Rancher UI. This is done by granting Read-only access to external Monitoring UIs. Users with this role have permission to list the Prometheus, Alertmanager, and Grafana endpoints and make GET requests to Prometheus, Alertmanager, and Grafana UIs through the Rancher proxy. <br/> <br/> This role doesn't grant access to monitoring endpoints. As a result, users with this role won't be able to view cluster monitoring graphs and dashboards in the Rancher UI; however, they are able to access the monitoring Grafana, Prometheus, and Alertmanager UIs if provided those links. |
 
 :::note
 

--- a/versioned_docs/version-2.7/integrations-in-rancher/monitoring-and-alerting/windows-support.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/monitoring-and-alerting/windows-support.md
@@ -6,7 +6,7 @@ title: Windows Cluster Support for Monitoring V2
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/monitoring-and-alerting/windows-support"/>
 </head>
 
-Starting at Monitoring V2 14.5.100 (used by default in Rancher 2.5.8), Monitoring V2 can now be deployed on a Windows cluster and will scrape metrics from Windows nodes using [prometheus-community/windows_exporter](https://github.com/prometheus-community/windows_exporter) (previously named `wmi_exporter`).
+Monitoring V2 can be deployed on a Windows cluster to scrape metrics from Windows nodes using [prometheus-community/windows_exporter](https://github.com/prometheus-community/windows_exporter) (previously named `wmi_exporter`).
 
 ## Cluster Requirements
 

--- a/versioned_docs/version-2.7/integrations-in-rancher/monitoring-and-alerting/windows-support.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/monitoring-and-alerting/windows-support.md
@@ -6,8 +6,6 @@ title: Windows Cluster Support for Monitoring V2
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/monitoring-and-alerting/windows-support"/>
 </head>
 
-_Available as of v2.5.8_
-
 Starting at Monitoring V2 14.5.100 (used by default in Rancher 2.5.8), Monitoring V2 can now be deployed on a Windows cluster and will scrape metrics from Windows nodes using [prometheus-community/windows_exporter](https://github.com/prometheus-community/windows_exporter) (previously named `wmi_exporter`).
 
 ## Cluster Requirements

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration.md
@@ -6,13 +6,6 @@ title: AKS Cluster Configuration Reference
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration"/>
 </head>
 
-## Changes in Rancher v2.6
-
-- Support for adding more than one node pool
-- Support for private clusters
-- Enabled autoscaling node pools
-- The AKS permissions are now configured in cloud credentials
-
 ## Role-based Access Control
 
 When provisioning an AKS cluster in the Rancher UI, RBAC cannot be disabled. If role-based access control is disabled for the cluster in AKS, the cluster cannot be registered or imported into Rancher.

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
@@ -6,12 +6,6 @@ title: GKE Cluster Configuration Reference
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration"/>
 </head>
 
-## Changes in Rancher v2.6
-
-- Support for additional configuration options:
-  - Project network isolation
-  - Network tags
-
 ## Cluster Location
 
 | Value | Description |

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
@@ -102,8 +102,6 @@ There is a [known issue](https://github.com/rancher/rancher/issues/25478) in whi
 
 ### Maintaining Availability for Applications During Upgrades
 
-_Available as of RKE v1.1.0_
-
 In [this section of the RKE documentation,](https://rancher.com/docs/rke/latest/en/upgrades/maintaining-availability/) you'll learn the requirements to prevent downtime for your applications when upgrading the cluster.
 
 ### Configuring the Upgrade Strategy in the cluster.yml

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -62,21 +62,6 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
 
 ### 2. Restore from backup using a Restore custom resource
 
-:::note Important:
-
-Kubernetes v1.22, available as an experimental feature of v2.6.3, does not support restoring from backup files containing CRDs with the apiVersion `apiextensions.k8s.io/v1beta1`. In v1.22, the default `resourceSet` in the rancher-backup app is updated to collect only CRDs that use `apiextensions.k8s.io/v1`. There are currently two ways to work around this issue:
-
-1. Update the default `resourceSet` to collect the CRDs with the apiVersion v1.
-1. Update the default `resourceSet` and the client to use the new APIs internally, with `apiextensions.k8s.io/v1` as the replacement.
-
-    :::note
-
-    When making or restoring backups for v1.22, the Rancher version and the local cluster's Kubernetes version should be the same. The Kubernetes version should be considered when restoring a backup since the supported apiVersion in the cluster and in the backup file could be different.
-
-    :::
-
-:::
-
 1. When using S3 object storage as the backup source for a restore that requires credentials, create a `Secret` object in this cluster to add the S3 credentials. The secret data must have two keys - `accessKey`, and `secretKey`, that contain the S3 credentials.
 
    The secret can be created in any namespace, this example uses the default namespace.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -184,8 +184,6 @@ To prevent issues when upgrading, the [Kubernetes upgrade best practices](https:
 
 ## Authorized Cluster Endpoint Support for RKE2 and K3s Clusters
 
-_Available as of v2.6.3_
-
 Authorized Cluster Endpoint (ACE) support has been added for registered RKE2 and K3s clusters. This support includes manual steps you will perform on the downstream cluster to enable the ACE. For additional information on the authorized cluster endpoint, click [here](../manage-clusters/access-clusters/authorized-cluster-endpoint.md).
 
 :::note Notes:

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -184,7 +184,7 @@ To prevent issues when upgrading, the [Kubernetes upgrade best practices](https:
 
 ## Authorized Cluster Endpoint Support for RKE2 and K3s Clusters
 
-Authorized Cluster Endpoint (ACE) support has been added for registered RKE2 and K3s clusters. This support includes manual steps you will perform on the downstream cluster to enable the ACE. For additional information on the authorized cluster endpoint, click [here](../manage-clusters/access-clusters/authorized-cluster-endpoint.md).
+Rancher supports Authorized Cluster Endpoints (ACE) for registered RKE2 and K3s clusters. This support includes manual steps you will perform on the downstream cluster to enable the ACE. For additional information on the authorized cluster endpoint, click [here](../manage-clusters/access-clusters/authorized-cluster-endpoint.md).
 
 :::note Notes:
 

--- a/versioned_docs/version-2.8/integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.md
@@ -112,7 +112,7 @@ Monitoring also creates additional `ClusterRoles` that aren't assigned to users 
 
 | Role | Purpose  |
 | ------------------------------| ---------------------------|
-| monitoring-ui-view | _Available as of Monitoring v2 14.5.100+_ This ClusterRole allows users with write access to the project to view metrics graphs for the specified cluster in the Rancher UI. This is done by granting Read-only access to external Monitoring UIs. Users with this role have permission to list the Prometheus, Alertmanager, and Grafana endpoints and make GET requests to Prometheus, Alertmanager, and Grafana UIs through the Rancher proxy. <br/> <br/> This role doesn't grant access to monitoring endpoints. As a result, users with this role won't be able to view cluster monitoring graphs and dashboards in the Rancher UI; however, they are able to access the monitoring Grafana, Prometheus, and Alertmanager UIs if provided those links. |
+| monitoring-ui-view | This ClusterRole allows users with write access to the project to view metrics graphs for the specified cluster in the Rancher UI. This is done by granting Read-only access to external Monitoring UIs. Users with this role have permission to list the Prometheus, Alertmanager, and Grafana endpoints and make GET requests to Prometheus, Alertmanager, and Grafana UIs through the Rancher proxy. <br/> <br/> This role doesn't grant access to monitoring endpoints. As a result, users with this role won't be able to view cluster monitoring graphs and dashboards in the Rancher UI; however, they are able to access the monitoring Grafana, Prometheus, and Alertmanager UIs if provided those links. |
 
 :::note
 

--- a/versioned_docs/version-2.8/integrations-in-rancher/monitoring-and-alerting/windows-support.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/monitoring-and-alerting/windows-support.md
@@ -6,7 +6,7 @@ title: Windows Cluster Support for Monitoring V2
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/monitoring-and-alerting/windows-support"/>
 </head>
 
-Starting at Monitoring V2 14.5.100 (used by default in Rancher 2.5.8), Monitoring V2 can now be deployed on a Windows cluster and will scrape metrics from Windows nodes using [prometheus-community/windows_exporter](https://github.com/prometheus-community/windows_exporter) (previously named `wmi_exporter`).
+Monitoring V2 can be deployed on a Windows cluster to scrape metrics from Windows nodes using [prometheus-community/windows_exporter](https://github.com/prometheus-community/windows_exporter) (previously named `wmi_exporter`).
 
 ## Cluster Requirements
 

--- a/versioned_docs/version-2.8/integrations-in-rancher/monitoring-and-alerting/windows-support.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/monitoring-and-alerting/windows-support.md
@@ -6,8 +6,6 @@ title: Windows Cluster Support for Monitoring V2
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/monitoring-and-alerting/windows-support"/>
 </head>
 
-_Available as of v2.5.8_
-
 Starting at Monitoring V2 14.5.100 (used by default in Rancher 2.5.8), Monitoring V2 can now be deployed on a Windows cluster and will scrape metrics from Windows nodes using [prometheus-community/windows_exporter](https://github.com/prometheus-community/windows_exporter) (previously named `wmi_exporter`).
 
 ## Cluster Requirements

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration.md
@@ -6,13 +6,6 @@ title: AKS Cluster Configuration Reference
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration"/>
 </head>
 
-## Changes in Rancher v2.6
-
-- Support for adding more than one node pool
-- Support for private clusters
-- Enabled autoscaling node pools
-- The AKS permissions are now configured in cloud credentials
-
 ## Role-based Access Control
 
 When provisioning an AKS cluster in the Rancher UI, RBAC cannot be disabled. If role-based access control is disabled for the cluster in AKS, the cluster cannot be registered or imported into Rancher.

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
@@ -6,12 +6,6 @@ title: GKE Cluster Configuration Reference
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration"/>
 </head>
 
-## Changes in Rancher v2.6
-
-- Support for additional configuration options:
-  - Project network isolation
-  - Network tags
-
 ## Cluster Location
 
 | Value | Description |

--- a/versioned_docs/version-2.8/reference-guides/user-settings/user-preferences.md
+++ b/versioned_docs/version-2.8/reference-guides/user-settings/user-preferences.md
@@ -41,8 +41,6 @@ Choose how certain information is displayed:
 
 ## Confirmation Setting
 
-_Available as of v2.7.2_
-
 Choose whether to ask for confirmation when scaling down node pools.
 
 ## Advanced Features

--- a/versioned_docs/version-2.9/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
+++ b/versioned_docs/version-2.9/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
@@ -102,8 +102,6 @@ There is a [known issue](https://github.com/rancher/rancher/issues/25478) in whi
 
 ### Maintaining Availability for Applications During Upgrades
 
-_Available as of RKE v1.1.0_
-
 In [this section of the RKE documentation,](https://rancher.com/docs/rke/latest/en/upgrades/maintaining-availability/) you'll learn the requirements to prevent downtime for your applications when upgrading the cluster.
 
 ### Configuring the Upgrade Strategy in the cluster.yml

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -62,21 +62,6 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
 
 ### 2. Restore from backup using a Restore custom resource
 
-:::note Important:
-
-Kubernetes v1.22, available as an experimental feature of v2.6.3, does not support restoring from backup files containing CRDs with the apiVersion `apiextensions.k8s.io/v1beta1`. In v1.22, the default `resourceSet` in the rancher-backup app is updated to collect only CRDs that use `apiextensions.k8s.io/v1`. There are currently two ways to work around this issue:
-
-1. Update the default `resourceSet` to collect the CRDs with the apiVersion v1.
-1. Update the default `resourceSet` and the client to use the new APIs internally, with `apiextensions.k8s.io/v1` as the replacement.
-
-    :::note
-
-    When making or restoring backups for v1.22, the Rancher version and the local cluster's Kubernetes version should be the same. The Kubernetes version should be considered when restoring a backup since the supported apiVersion in the cluster and in the backup file could be different.
-
-    :::
-
-:::
-
 1. When using S3 object storage as the backup source for a restore that requires credentials, create a `Secret` object in this cluster to add the S3 credentials. The secret data must have two keys - `accessKey`, and `secretKey`, that contain the S3 credentials.
 
    The secret can be created in any namespace, this example uses the default namespace.

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -184,8 +184,6 @@ To prevent issues when upgrading, the [Kubernetes upgrade best practices](https:
 
 ## Authorized Cluster Endpoint Support for RKE2 and K3s Clusters
 
-_Available as of v2.6.3_
-
 Authorized Cluster Endpoint (ACE) support has been added for registered RKE2 and K3s clusters. This support includes manual steps you will perform on the downstream cluster to enable the ACE. For additional information on the authorized cluster endpoint, click [here](../manage-clusters/access-clusters/authorized-cluster-endpoint.md).
 
 :::note Notes:

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -184,7 +184,7 @@ To prevent issues when upgrading, the [Kubernetes upgrade best practices](https:
 
 ## Authorized Cluster Endpoint Support for RKE2 and K3s Clusters
 
-Authorized Cluster Endpoint (ACE) support has been added for registered RKE2 and K3s clusters. This support includes manual steps you will perform on the downstream cluster to enable the ACE. For additional information on the authorized cluster endpoint, click [here](../manage-clusters/access-clusters/authorized-cluster-endpoint.md).
+Rancher supports Authorized Cluster Endpoints (ACE) for registered RKE2 and K3s clusters. This support includes manual steps you will perform on the downstream cluster to enable the ACE. For additional information on the authorized cluster endpoint, click [here](../manage-clusters/access-clusters/authorized-cluster-endpoint.md).
 
 :::note Notes:
 

--- a/versioned_docs/version-2.9/integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.md
+++ b/versioned_docs/version-2.9/integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.md
@@ -112,7 +112,7 @@ Monitoring also creates additional `ClusterRoles` that aren't assigned to users 
 
 | Role | Purpose  |
 | ------------------------------| ---------------------------|
-| monitoring-ui-view | _Available as of Monitoring v2 14.5.100+_ This ClusterRole allows users with write access to the project to view metrics graphs for the specified cluster in the Rancher UI. This is done by granting Read-only access to external Monitoring UIs. Users with this role have permission to list the Prometheus, Alertmanager, and Grafana endpoints and make GET requests to Prometheus, Alertmanager, and Grafana UIs through the Rancher proxy. <br/> <br/> This role doesn't grant access to monitoring endpoints. As a result, users with this role won't be able to view cluster monitoring graphs and dashboards in the Rancher UI; however, they are able to access the monitoring Grafana, Prometheus, and Alertmanager UIs if provided those links. |
+| monitoring-ui-view | This ClusterRole allows users with write access to the project to view metrics graphs for the specified cluster in the Rancher UI. This is done by granting Read-only access to external Monitoring UIs. Users with this role have permission to list the Prometheus, Alertmanager, and Grafana endpoints and make GET requests to Prometheus, Alertmanager, and Grafana UIs through the Rancher proxy. <br/> <br/> This role doesn't grant access to monitoring endpoints. As a result, users with this role won't be able to view cluster monitoring graphs and dashboards in the Rancher UI; however, they are able to access the monitoring Grafana, Prometheus, and Alertmanager UIs if provided those links. |
 
 :::note
 

--- a/versioned_docs/version-2.9/integrations-in-rancher/monitoring-and-alerting/windows-support.md
+++ b/versioned_docs/version-2.9/integrations-in-rancher/monitoring-and-alerting/windows-support.md
@@ -6,7 +6,7 @@ title: Windows Cluster Support for Monitoring V2
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/monitoring-and-alerting/windows-support"/>
 </head>
 
-Starting at Monitoring V2 14.5.100 (used by default in Rancher 2.5.8), Monitoring V2 can now be deployed on a Windows cluster and will scrape metrics from Windows nodes using [prometheus-community/windows_exporter](https://github.com/prometheus-community/windows_exporter) (previously named `wmi_exporter`).
+Monitoring V2 can be deployed on a Windows cluster to scrape metrics from Windows nodes using [prometheus-community/windows_exporter](https://github.com/prometheus-community/windows_exporter) (previously named `wmi_exporter`).
 
 ## Cluster Requirements
 

--- a/versioned_docs/version-2.9/integrations-in-rancher/monitoring-and-alerting/windows-support.md
+++ b/versioned_docs/version-2.9/integrations-in-rancher/monitoring-and-alerting/windows-support.md
@@ -6,8 +6,6 @@ title: Windows Cluster Support for Monitoring V2
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/monitoring-and-alerting/windows-support"/>
 </head>
 
-_Available as of v2.5.8_
-
 Starting at Monitoring V2 14.5.100 (used by default in Rancher 2.5.8), Monitoring V2 can now be deployed on a Windows cluster and will scrape metrics from Windows nodes using [prometheus-community/windows_exporter](https://github.com/prometheus-community/windows_exporter) (previously named `wmi_exporter`).
 
 ## Cluster Requirements

--- a/versioned_docs/version-2.9/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration.md
+++ b/versioned_docs/version-2.9/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration.md
@@ -6,13 +6,6 @@ title: AKS Cluster Configuration Reference
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration"/>
 </head>
 
-## Changes in Rancher v2.6
-
-- Support for adding more than one node pool
-- Support for private clusters
-- Enabled autoscaling node pools
-- The AKS permissions are now configured in cloud credentials
-
 ## Role-based Access Control
 
 When provisioning an AKS cluster in the Rancher UI, RBAC cannot be disabled. If role-based access control is disabled for the cluster in AKS, the cluster cannot be registered or imported into Rancher.

--- a/versioned_docs/version-2.9/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
+++ b/versioned_docs/version-2.9/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
@@ -6,12 +6,6 @@ title: GKE Cluster Configuration Reference
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration"/>
 </head>
 
-## Changes in Rancher v2.6
-
-- Support for additional configuration options:
-  - Project network isolation
-  - Network tags
-
 ## Cluster Location
 
 | Value | Description |

--- a/versioned_docs/version-2.9/reference-guides/user-settings/user-preferences.md
+++ b/versioned_docs/version-2.9/reference-guides/user-settings/user-preferences.md
@@ -41,8 +41,6 @@ Choose how certain information is displayed:
 
 ## Confirmation Setting
 
-_Available as of v2.7.2_
-
 Choose whether to ask for confirmation when scaling down node pools.
 
 ## Advanced Features


### PR DESCRIPTION
## Description

We often highlight when a new feature became available in a patch version X for minor version A, but this information is no longer relevant for subsequent minor versions (e.g. A+1, A+2,...). This PR removes such references.


