### PR TITLE
Warn not to allow nonadmin on Rancher server cluster

### DIFF
--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
@@ -64,7 +64,7 @@ After you configure Rancher to allow sign on using an external authentication se
 
 :::warning 
 
-Only trusted admin-level users should have access to the local cluster. The local cluster manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow users on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to an Rancher instance's architecture, inappropriate access carries security risks.
+Only trusted admin-level users should have access to the local cluster, which manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow admins on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to a Rancher instance's architecture, inappropriate access carries security risks.
 
 :::
 

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
@@ -62,6 +62,12 @@ After you configure Rancher to allow sign on using an external authentication se
 | Allow members of Clusters, Projects, plus Authorized Users and Organizations | Any user in the authorization service and any group added as a **Cluster Member** or **Project Member** can log in to Rancher. Additionally, any user in the authentication service or group you add to the **Authorized Users and Organizations** list may log in to Rancher. |
 | Restrict access to only Authorized Users and Organizations | Only users in the authentication service or groups added to the Authorized Users and Organizations can log in to Rancher. |
 
+:::warning 
+
+Only trusted admin-level users should have access to the local cluster. The local cluster manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow users on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to an Rancher instance's architecture, inappropriate access carries security risks.
+
+:::
+
 To set the Rancher access level for users in the authorization service, follow these steps:
 
 1. In the upper left corner, click **☰ > Users & Authentication**.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/manage-users-and-groups.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/manage-users-and-groups.md
@@ -10,6 +10,12 @@ Rancher relies on users and groups to determine who is allowed to log in to Ranc
 
 Access to clusters, projects, multi-cluster apps, and global DNS providers and entries can be controlled by adding either individual users or groups to these resources. When you add a group to a resource, all users who are members of that group in the authentication provider, will be able to access the resource with the permissions that you've specified for the group. For more information on roles and permissions, see [Role Based Access Control](../../manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.md).
 
+:::warning 
+
+Only trusted admin-level users should have access to the local cluster. The local cluster manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow users on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to an Rancher instance's architecture, inappropriate access carries security risks.
+
+:::
+
 ## Managing Members
 
 When adding a user or group to a resource, you can search for users or groups by beginning to type their name. The Rancher server will query the authentication provider to find users and groups that match what you've entered. Searching is limited to the authentication provider that you are currently logged in with. For example, if you've enabled GitHub authentication but are logged in using a [local](create-local-users.md) user account, you will not be able to search for GitHub users or groups.

--- a/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/manage-users-and-groups.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/manage-users-and-groups.md
@@ -12,7 +12,7 @@ Access to clusters, projects, multi-cluster apps, and global DNS providers and e
 
 :::warning 
 
-Only trusted admin-level users should have access to the local cluster. The local cluster manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow users on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to an Rancher instance's architecture, inappropriate access carries security risks.
+Only trusted admin-level users should have access to the local cluster, which manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow admins on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to a Rancher instance's architecture, inappropriate access carries security risks.
 
 :::
 

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/manage-users-and-groups.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/manage-users-and-groups.md
@@ -10,6 +10,12 @@ Rancher relies on users and groups to determine who is allowed to log in to Ranc
 
 Access to clusters, projects, multi-cluster apps, and global DNS providers and entries can be controlled by adding either individual users or groups to these resources. When you add a group to a resource, all users who are members of that group in the authentication provider, will be able to access the resource with the permissions that you've specified for the group. For more information on roles and permissions, see [Role Based Access Control](../../manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.md).
 
+:::warning 
+
+Only trusted admin-level users should have access to the local cluster. The local cluster manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow users on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to an Rancher instance's architecture, inappropriate access carries security risks.
+
+:::
+
 ## Managing Members
 
 When adding a user or group to a resource, you can search for users or groups by beginning to type their name. The Rancher server will query the authentication provider to find users and groups that match what you've entered. Searching is limited to the authentication provider that you are currently logged in with. For example, if you've enabled GitHub authentication but are logged in using a [local](create-local-users.md) user account, you will not be able to search for GitHub users or groups.

--- a/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/manage-users-and-groups.md
+++ b/versioned_docs/version-2.5/how-to-guides/advanced-user-guides/authentication-permissions-and-global-configuration/about-authentication/authentication-config/manage-users-and-groups.md
@@ -12,7 +12,7 @@ Access to clusters, projects, multi-cluster apps, and global DNS providers and e
 
 :::warning 
 
-Only trusted admin-level users should have access to the local cluster. The local cluster manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow users on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to an Rancher instance's architecture, inappropriate access carries security risks.
+Only trusted admin-level users should have access to the local cluster, which manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow admins on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to a Rancher instance's architecture, inappropriate access carries security risks.
 
 :::
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
@@ -64,7 +64,7 @@ After you configure Rancher to allow sign on using an external authentication se
 
 :::warning 
 
-Only trusted admin-level users should have access to the local cluster. The local cluster manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow users on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to an Rancher instance's architecture, inappropriate access carries security risks.
+Only trusted admin-level users should have access to the local cluster, which manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow admins on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to a Rancher instance's architecture, inappropriate access carries security risks.
 
 :::
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
@@ -62,6 +62,12 @@ After you configure Rancher to allow sign on using an external authentication se
 | Allow members of Clusters, Projects, plus Authorized Users and Organizations | Any user in the authorization service and any group added as a **Cluster Member** or **Project Member** can log in to Rancher. Additionally, any user in the authentication service or group you add to the **Authorized Users and Organizations** list may log in to Rancher. |
 | Restrict access to only Authorized Users and Organizations | Only users in the authentication service or groups added to the Authorized Users and Organizations can log in to Rancher. |
 
+:::warning 
+
+Only trusted admin-level users should have access to the local cluster. The local cluster manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow users on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to an Rancher instance's architecture, inappropriate access carries security risks.
+
+:::
+
 To set the Rancher access level for users in the authorization service, follow these steps:
 
 1. In the upper left corner, click **☰ > Users & Authentication**.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
@@ -64,7 +64,7 @@ After you configure Rancher to allow sign on using an external authentication se
 
 :::warning 
 
-Only trusted admin-level users should have access to the local cluster. The local cluster manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow users on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to an Rancher instance's architecture, inappropriate access carries security risks.
+Only trusted admin-level users should have access to the local cluster, which manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow admins on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to a Rancher instance's architecture, inappropriate access carries security risks.
 
 :::
 

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
@@ -62,6 +62,12 @@ After you configure Rancher to allow sign on using an external authentication se
 | Allow members of Clusters, Projects, plus Authorized Users and Organizations | Any user in the authorization service and any group added as a **Cluster Member** or **Project Member** can log in to Rancher. Additionally, any user in the authentication service or group you add to the **Authorized Users and Organizations** list may log in to Rancher. |
 | Restrict access to only Authorized Users and Organizations | Only users in the authentication service or groups added to the Authorized Users and Organizations can log in to Rancher. |
 
+:::warning 
+
+Only trusted admin-level users should have access to the local cluster. The local cluster manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow users on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to an Rancher instance's architecture, inappropriate access carries security risks.
+
+:::
+
 To set the Rancher access level for users in the authorization service, follow these steps:
 
 1. In the upper left corner, click **☰ > Users & Authentication**.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
@@ -64,7 +64,7 @@ After you configure Rancher to allow sign on using an external authentication se
 
 :::warning 
 
-Only trusted admin-level users should have access to the local cluster. The local cluster manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow users on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to an Rancher instance's architecture, inappropriate access carries security risks.
+Only trusted admin-level users should have access to the local cluster, which manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow admins on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to a Rancher instance's architecture, inappropriate access carries security risks.
 
 :::
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config.md
@@ -62,6 +62,12 @@ After you configure Rancher to allow sign on using an external authentication se
 | Allow members of Clusters, Projects, plus Authorized Users and Organizations | Any user in the authorization service and any group added as a **Cluster Member** or **Project Member** can log in to Rancher. Additionally, any user in the authentication service or group you add to the **Authorized Users and Organizations** list may log in to Rancher. |
 | Restrict access to only Authorized Users and Organizations | Only users in the authentication service or groups added to the Authorized Users and Organizations can log in to Rancher. |
 
+:::warning 
+
+Only trusted admin-level users should have access to the local cluster. The local cluster manages all of the other clusters in a Rancher instance. Rancher is directly installed on the local cluster, and Rancher's management features allow users on the local cluster to provision, modify, connect to, and view details about downstream clusters. Since the local cluster is key to an Rancher instance's architecture, inappropriate access carries security risks.
+
+:::
+
 To set the Rancher access level for users in the authorization service, follow these steps:
 
 1. In the upper left corner, click **☰ > Users & Authentication**.


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #[issue_number]

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, remember to add a "MERGE ON RELEASE" label and set the proper milestone.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

This is an internal request to explain possible security concerns with allowing untrusted users access to the local cluster. This is a general warning.

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->


