### PR TITLE
Remove Rancher v2.3 Reference

### DIFF
--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
@@ -15,9 +15,9 @@ Rancher can provision nodes in vSphere and install Kubernetes on them. When crea
 
 A vSphere cluster may consist of multiple groups of VMs with distinct properties, such as the amount of memory or the number of vCPUs. This grouping allows for fine-grained control over the sizing of nodes for each Kubernetes role.
 
-## VMware vSphere Enhancements in Rancher v2.3
+## VMware vSphere Enhancements
 
-The vSphere node templates have been updated, allowing you to bring cloud operations on-premises with the following enhancements:
+The vSphere node templates allow you to bring cloud operations on-premises with the following enhancements:
 
 ### Self-healing Node Pools
 
@@ -38,12 +38,6 @@ For the fields to be populated, your setup needs to fulfill the [prerequisites.]
 ### More Supported Operating Systems
 
 You can provision VMs with any operating system that supports `cloud-init`. Only YAML format is supported for the [cloud config.](https://cloudinit.readthedocs.io/en/latest/topics/examples.html)
-
-### Video Walkthrough of v2.3.3 Node Template Features
-
-In this YouTube video, we demonstrate how to set up a node template with the new features designed to help you bring cloud operations to on-premises clusters.
-
-<YouTube id="dPIwg6x1AlU"/>
 
 ## Creating a VMware vSphere Cluster
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
@@ -15,9 +15,9 @@ Rancher can provision nodes in vSphere and install Kubernetes on them. When crea
 
 A vSphere cluster may consist of multiple groups of VMs with distinct properties, such as the amount of memory or the number of vCPUs. This grouping allows for fine-grained control over the sizing of nodes for each Kubernetes role.
 
-## VMware vSphere Enhancements in Rancher v2.3
+## VMware vSphere Enhancements
 
-The vSphere node templates have been updated, allowing you to bring cloud operations on-premises with the following enhancements:
+The vSphere node templates allow you to bring cloud operations on-premises with the following enhancements:
 
 ### Self-healing Node Pools
 
@@ -38,12 +38,6 @@ For the fields to be populated, your setup needs to fulfill the [prerequisites.]
 ### More Supported Operating Systems
 
 You can provision VMs with any operating system that supports `cloud-init`. Only YAML format is supported for the [cloud config.](https://cloudinit.readthedocs.io/en/latest/topics/examples.html)
-
-### Video Walkthrough of v2.3.3 Node Template Features
-
-In this YouTube video, we demonstrate how to set up a node template with the new features designed to help you bring cloud operations to on-premises clusters.
-
-<YouTube id="dPIwg6x1AlU"/>
 
 ## Creating a VMware vSphere Cluster
 

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
@@ -15,9 +15,9 @@ Rancher can provision nodes in vSphere and install Kubernetes on them. When crea
 
 A vSphere cluster may consist of multiple groups of VMs with distinct properties, such as the amount of memory or the number of vCPUs. This grouping allows for fine-grained control over the sizing of nodes for each Kubernetes role.
 
-## VMware vSphere Enhancements in Rancher v2.3
+## VMware vSphere Enhancements
 
-The vSphere node templates have been updated, allowing you to bring cloud operations on-premises with the following enhancements:
+The vSphere node templates allow you to bring cloud operations on-premises with the following enhancements:
 
 ### Self-healing Node Pools
 
@@ -38,12 +38,6 @@ For the fields to be populated, your setup needs to fulfill the [prerequisites.]
 ### More Supported Operating Systems
 
 You can provision VMs with any operating system that supports `cloud-init`. Only YAML format is supported for the [cloud config.](https://cloudinit.readthedocs.io/en/latest/topics/examples.html)
-
-### Video Walkthrough of v2.3.3 Node Template Features
-
-In this YouTube video, we demonstrate how to set up a node template with the new features designed to help you bring cloud operations to on-premises clusters.
-
-<YouTube id="dPIwg6x1AlU"/>
 
 ## Creating a VMware vSphere Cluster
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
@@ -15,9 +15,9 @@ Rancher can provision nodes in vSphere and install Kubernetes on them. When crea
 
 A vSphere cluster may consist of multiple groups of VMs with distinct properties, such as the amount of memory or the number of vCPUs. This grouping allows for fine-grained control over the sizing of nodes for each Kubernetes role.
 
-## VMware vSphere Enhancements in Rancher v2.3
+## VMware vSphere Enhancements
 
-The vSphere node templates have been updated, allowing you to bring cloud operations on-premises with the following enhancements:
+The vSphere node templates allow you to bring cloud operations on-premises with the following enhancements:
 
 ### Self-healing Node Pools
 
@@ -38,12 +38,6 @@ For the fields to be populated, your setup needs to fulfill the [prerequisites.]
 ### More Supported Operating Systems
 
 You can provision VMs with any operating system that supports `cloud-init`. Only YAML format is supported for the [cloud config.](https://cloudinit.readthedocs.io/en/latest/topics/examples.html)
-
-### Video Walkthrough of v2.3.3 Node Template Features
-
-In this YouTube video, we demonstrate how to set up a node template with the new features designed to help you bring cloud operations to on-premises clusters.
-
-<YouTube id="dPIwg6x1AlU"/>
 
 ## Creating a VMware vSphere Cluster
 

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
@@ -15,9 +15,9 @@ Rancher can provision nodes in vSphere and install Kubernetes on them. When crea
 
 A vSphere cluster may consist of multiple groups of VMs with distinct properties, such as the amount of memory or the number of vCPUs. This grouping allows for fine-grained control over the sizing of nodes for each Kubernetes role.
 
-## VMware vSphere Enhancements in Rancher v2.3
+## VMware vSphere Enhancements
 
-The vSphere node templates have been updated, allowing you to bring cloud operations on-premises with the following enhancements:
+The vSphere node templates allow you to bring cloud operations on-premises with the following enhancements:
 
 ### Self-healing Node Pools
 
@@ -38,12 +38,6 @@ For the fields to be populated, your setup needs to fulfill the [prerequisites.]
 ### More Supported Operating Systems
 
 You can provision VMs with any operating system that supports `cloud-init`. Only YAML format is supported for the [cloud config.](https://cloudinit.readthedocs.io/en/latest/topics/examples.html)
-
-### Video Walkthrough of v2.3.3 Node Template Features
-
-In this YouTube video, we demonstrate how to set up a node template with the new features designed to help you bring cloud operations to on-premises clusters.
-
-<YouTube id="dPIwg6x1AlU"/>
 
 ## Creating a VMware vSphere Cluster
 


### PR DESCRIPTION
Removing reference to outdated Rancher v2.3 version in the relevant documentation versions. The video demo uses an older Rancher version so I removed the section as well.

Fixes #1351 