### PR TITLE
Update clean-cluster-nodes.md to point to RKE2 specific docs

### DIFF
--- a/docs/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
@@ -183,7 +183,8 @@ for mount in $(mount | grep tmpfs | grep '/var/lib/kubelet' | awk '{ print $3 }'
 
 </TabItem>
 <TabItem value="RKE2">
-
+Note: for instructions for cleaning a _Non-Rancher deployed RKE2 cluster_ see: https://docs.rke2.io/install/uninstall
+  
 You need to remove the following components from Rancher-provisioned RKE2 nodes:
 
 * The rancher-system-agent, which connects to Rancher and installs and manages RKE2.

--- a/docs/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
@@ -183,8 +183,11 @@ for mount in $(mount | grep tmpfs | grep '/var/lib/kubelet' | awk '{ print $3 }'
 
 </TabItem>
 <TabItem value="RKE2">
-:::note 
+
+:::note
+
 For instructions on cleaning nodes in RKE2 clusters that weren't deployed by Rancher, see the [official RKE2 documentation](https://docs.rke2.io/install/uninstall) on uninstalling clusters.
+
 :::
   
 You need to remove the following components from Rancher-provisioned RKE2 nodes:

--- a/docs/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
+++ b/docs/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
@@ -183,7 +183,9 @@ for mount in $(mount | grep tmpfs | grep '/var/lib/kubelet' | awk '{ print $3 }'
 
 </TabItem>
 <TabItem value="RKE2">
-Note: for instructions for cleaning a _Non-Rancher deployed RKE2 cluster_ see: https://docs.rke2.io/install/uninstall
+:::note 
+For instructions on cleaning nodes in RKE2 clusters that weren't deployed by Rancher, see the [official RKE2 documentation](https://docs.rke2.io/install/uninstall) on uninstalling clusters.
+:::
   
 You need to remove the following components from Rancher-provisioned RKE2 nodes:
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
@@ -180,6 +180,12 @@ for mount in $(mount | grep tmpfs | grep '/var/lib/kubelet' | awk '{ print $3 }'
 </TabItem>
 <TabItem value="RKE2">
 
+:::note
+
+For instructions on cleaning nodes in RKE2 clusters that weren't deployed by Rancher, see the [official RKE2 documentation](https://docs.rke2.io/install/uninstall) on uninstalling clusters.
+
+:::
+
 你需要从 Rancher 提供的 RKE2 节点中删除以下组件：
 
 * rancher-system-agent，用于连接 Rancher 并安装和管理 RKE2。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.10/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.10/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
@@ -180,6 +180,12 @@ for mount in $(mount | grep tmpfs | grep '/var/lib/kubelet' | awk '{ print $3 }'
 </TabItem>
 <TabItem value="RKE2">
 
+:::note
+
+For instructions on cleaning nodes in RKE2 clusters that weren't deployed by Rancher, see the [official RKE2 documentation](https://docs.rke2.io/install/uninstall) on uninstalling clusters.
+
+:::
+
 你需要从 Rancher 提供的 RKE2 节点中删除以下组件：
 
 * rancher-system-agent，用于连接 Rancher 并安装和管理 RKE2。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.11/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.11/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
@@ -180,6 +180,12 @@ for mount in $(mount | grep tmpfs | grep '/var/lib/kubelet' | awk '{ print $3 }'
 </TabItem>
 <TabItem value="RKE2">
 
+:::note
+
+For instructions on cleaning nodes in RKE2 clusters that weren't deployed by Rancher, see the [official RKE2 documentation](https://docs.rke2.io/install/uninstall) on uninstalling clusters.
+
+:::
+
 你需要从 Rancher 提供的 RKE2 节点中删除以下组件：
 
 * rancher-system-agent，用于连接 Rancher 并安装和管理 RKE2。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
@@ -180,6 +180,12 @@ for mount in $(mount | grep tmpfs | grep '/var/lib/kubelet' | awk '{ print $3 }'
 </TabItem>
 <TabItem value="RKE2">
 
+:::note
+
+For instructions on cleaning nodes in RKE2 clusters that weren't deployed by Rancher, see the [official RKE2 documentation](https://docs.rke2.io/install/uninstall) on uninstalling clusters.
+
+:::
+
 你需要从 Rancher 提供的 RKE2 节点中删除以下组件：
 
 * rancher-system-agent，用于连接 Rancher 并安装和管理 RKE2。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.8/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.8/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
@@ -180,6 +180,12 @@ for mount in $(mount | grep tmpfs | grep '/var/lib/kubelet' | awk '{ print $3 }'
 </TabItem>
 <TabItem value="RKE2">
 
+:::note
+
+For instructions on cleaning nodes in RKE2 clusters that weren't deployed by Rancher, see the [official RKE2 documentation](https://docs.rke2.io/install/uninstall) on uninstalling clusters.
+
+:::
+
 你需要从 Rancher 提供的 RKE2 节点中删除以下组件：
 
 * rancher-system-agent，用于连接 Rancher 并安装和管理 RKE2。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.9/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.9/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
@@ -180,6 +180,12 @@ for mount in $(mount | grep tmpfs | grep '/var/lib/kubelet' | awk '{ print $3 }'
 </TabItem>
 <TabItem value="RKE2">
 
+:::note
+
+For instructions on cleaning nodes in RKE2 clusters that weren't deployed by Rancher, see the [official RKE2 documentation](https://docs.rke2.io/install/uninstall) on uninstalling clusters.
+
+:::
+
 你需要从 Rancher 提供的 RKE2 节点中删除以下组件：
 
 * rancher-system-agent，用于连接 Rancher 并安装和管理 RKE2。

--- a/versioned_docs/version-2.10/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
+++ b/versioned_docs/version-2.10/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
@@ -184,6 +184,12 @@ for mount in $(mount | grep tmpfs | grep '/var/lib/kubelet' | awk '{ print $3 }'
 </TabItem>
 <TabItem value="RKE2">
 
+:::note
+
+For instructions on cleaning nodes in RKE2 clusters that weren't deployed by Rancher, see the [official RKE2 documentation](https://docs.rke2.io/install/uninstall) on uninstalling clusters.
+
+:::
+  
 You need to remove the following components from Rancher-provisioned RKE2 nodes:
 
 * The rancher-system-agent, which connects to Rancher and installs and manages RKE2.

--- a/versioned_docs/version-2.11/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
+++ b/versioned_docs/version-2.11/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
@@ -184,6 +184,12 @@ for mount in $(mount | grep tmpfs | grep '/var/lib/kubelet' | awk '{ print $3 }'
 </TabItem>
 <TabItem value="RKE2">
 
+:::note
+
+For instructions on cleaning nodes in RKE2 clusters that weren't deployed by Rancher, see the [official RKE2 documentation](https://docs.rke2.io/install/uninstall) on uninstalling clusters.
+
+:::
+  
 You need to remove the following components from Rancher-provisioned RKE2 nodes:
 
 * The rancher-system-agent, which connects to Rancher and installs and manages RKE2.

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
@@ -184,6 +184,12 @@ for mount in $(mount | grep tmpfs | grep '/var/lib/kubelet' | awk '{ print $3 }'
 </TabItem>
 <TabItem value="RKE2">
 
+:::note
+
+For instructions on cleaning nodes in RKE2 clusters that weren't deployed by Rancher, see the [official RKE2 documentation](https://docs.rke2.io/install/uninstall) on uninstalling clusters.
+
+:::
+  
 You need to remove the following components from Rancher-provisioned RKE2 nodes:
 
 * The rancher-system-agent, which connects to Rancher and installs and manages RKE2.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
@@ -184,6 +184,12 @@ for mount in $(mount | grep tmpfs | grep '/var/lib/kubelet' | awk '{ print $3 }'
 </TabItem>
 <TabItem value="RKE2">
 
+:::note
+
+For instructions on cleaning nodes in RKE2 clusters that weren't deployed by Rancher, see the [official RKE2 documentation](https://docs.rke2.io/install/uninstall) on uninstalling clusters.
+
+:::
+  
 You need to remove the following components from Rancher-provisioned RKE2 nodes:
 
 * The rancher-system-agent, which connects to Rancher and installs and manages RKE2.

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes.md
@@ -184,6 +184,12 @@ for mount in $(mount | grep tmpfs | grep '/var/lib/kubelet' | awk '{ print $3 }'
 </TabItem>
 <TabItem value="RKE2">
 
+:::note
+
+For instructions on cleaning nodes in RKE2 clusters that weren't deployed by Rancher, see the [official RKE2 documentation](https://docs.rke2.io/install/uninstall) on uninstalling clusters.
+
+:::
+  
 You need to remove the following components from Rancher-provisioned RKE2 nodes:
 
 * The rancher-system-agent, which connects to Rancher and installs and manages RKE2.


### PR DESCRIPTION
When cleaning nodes for re-use which were deployed manually with RKE2, the process differs slightly.  This is more important in reverse so I'm editing that doc as well.  I think there's like a note callout or something that might be better?

<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #[issue_number]

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, remember to add a "MERGE ON RELEASE" label and set the proper milestone.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->
