### PR TITLE
[2.9.0] #1364 New installation requirement: http/2

### DIFF
--- a/docs/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
+++ b/docs/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
@@ -216,6 +216,12 @@ Each node used should have a static IP configured, regardless of whether you are
 
 To operate properly, Rancher requires a number of ports to be open on Rancher nodes and on downstream Kubernetes cluster nodes. [Port Requirements](port-requirements.md) lists all the necessary ports for Rancher and Downstream Clusters for the different cluster types.
 
+### Load Balancer Requirements
+
+If you choose to use a load balancer, we recommend that the load balancer be HTTP/2 compatible. Rancher falls back to HTTP/1.1 when HTTP/2 is not available. However, since HTTP/2 offers improved web application performance, using HTTP/1.1 can create performance issues. 
+
+Customers using Rancher Prime must use an HTTP/2 compatible load balancer to receive help from SUSE Support.
+
 ## Dockershim Support
 
 For more information on Dockershim support, refer to [this page](dockershim.md).

--- a/docs/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
+++ b/docs/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
@@ -218,9 +218,11 @@ To operate properly, Rancher requires a number of ports to be open on Rancher no
 
 ### Load Balancer Requirements
 
-If you choose to use a load balancer, we recommend that the load balancer be HTTP/2 compatible. Rancher falls back to HTTP/1.1 when HTTP/2 is not available. However, since HTTP/2 offers improved web application performance, using HTTP/1.1 can create performance issues. 
+If you use a load balancer, it should be be HTTP/2 compatible. 
 
-Customers using Rancher Prime must use an HTTP/2 compatible load balancer to receive help from SUSE Support.
+Rancher Prime customers must use an HTTP/2 compatible load balancer to receive help from SUSE Support.
+
+When HTTP/2 is not available, Rancher falls back to HTTP/1.1. However, since HTTP/2 offers improved web application performance, using HTTP/1.1 can create performance issues. 
 
 ## Dockershim Support
 

--- a/docs/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
+++ b/docs/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
@@ -220,7 +220,7 @@ To operate properly, Rancher requires a number of ports to be open on Rancher no
 
 If you use a load balancer, it should be be HTTP/2 compatible. 
 
-Rancher Prime customers must use an HTTP/2 compatible load balancer to receive help from SUSE Support.
+To receive help from SUSE Support, Rancher Prime customers who use load balancers (or any other middleboxes such as firewalls), must use one that is HTTP/2 compatible.
 
 When HTTP/2 is not available, Rancher falls back to HTTP/1.1. However, since HTTP/2 offers improved web application performance, using HTTP/1.1 can create performance issues. 
 

--- a/versioned_docs/version-2.9/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
+++ b/versioned_docs/version-2.9/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
@@ -216,6 +216,12 @@ Each node used should have a static IP configured, regardless of whether you are
 
 To operate properly, Rancher requires a number of ports to be open on Rancher nodes and on downstream Kubernetes cluster nodes. [Port Requirements](port-requirements.md) lists all the necessary ports for Rancher and Downstream Clusters for the different cluster types.
 
+### Load Balancer Requirements
+
+If you choose to use a load balancer, we recommend that the load balancer be HTTP/2 compatible. Rancher falls back to HTTP/1.1 when HTTP/2 is not available. However, since HTTP/2 offers improved web application performance, using HTTP/1.1 can create performance issues. 
+
+Customers using Rancher Prime must use an HTTP/2 compatible load balancer to receive help from SUSE Support.
+
 ## Dockershim Support
 
 For more information on Dockershim support, refer to [this page](dockershim.md).

--- a/versioned_docs/version-2.9/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
+++ b/versioned_docs/version-2.9/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
@@ -218,9 +218,11 @@ To operate properly, Rancher requires a number of ports to be open on Rancher no
 
 ### Load Balancer Requirements
 
-If you choose to use a load balancer, we recommend that the load balancer be HTTP/2 compatible. Rancher falls back to HTTP/1.1 when HTTP/2 is not available. However, since HTTP/2 offers improved web application performance, using HTTP/1.1 can create performance issues. 
+If you use a load balancer, it should be be HTTP/2 compatible. 
 
-Customers using Rancher Prime must use an HTTP/2 compatible load balancer to receive help from SUSE Support.
+Rancher Prime customers must use an HTTP/2 compatible load balancer to receive help from SUSE Support.
+
+When HTTP/2 is not available, Rancher falls back to HTTP/1.1. However, since HTTP/2 offers improved web application performance, using HTTP/1.1 can create performance issues.
 
 ## Dockershim Support
 

--- a/versioned_docs/version-2.9/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
+++ b/versioned_docs/version-2.9/getting-started/installation-and-upgrade/installation-requirements/installation-requirements.md
@@ -220,7 +220,7 @@ To operate properly, Rancher requires a number of ports to be open on Rancher no
 
 If you use a load balancer, it should be be HTTP/2 compatible. 
 
-Rancher Prime customers must use an HTTP/2 compatible load balancer to receive help from SUSE Support.
+To receive help from SUSE Support, Rancher Prime customers who use load balancers (or any other middleboxes such as firewalls), must use one that is HTTP/2 compatible.
 
 When HTTP/2 is not available, Rancher falls back to HTTP/1.1. However, since HTTP/2 offers improved web application performance, using HTTP/1.1 can create performance issues.
 


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #1364 

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, remember to add a "MERGE ON RELEASE" label and set the proper milestone.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

From the issue:

> HTTP/2 is a network protocol introduced and widely supported by most browsers in 2015 (https://caniuse.com/http2). The protocol is substantially different from the earlier HTTP/1.1 protocol, and several changes were introduced to improve web application performance.
>
> The Rancher UI requires support of this protocol to operate efficiently:
>
> - in browsers, and this is already documented
> - in any potential third party load balancer or similar network infrastructure sitting between the browser and the Rancher cluster, **this is not yet documented**
>
> Note that the Rancher UI will fall back to HTTP/1.1 if HTTP/2 is not available, although this will create performance issues.
>
> ### Policy notes
>
> This is a general, non-hardware requirement which is especially critical in high performance/high scalability cases, but in some pages (such as the App Catalog) is important regardless of the Rancher installation size.
>
> The use of HTTP/2 compatible load balancers should be _recommended_ in general and for community users, note however that it should be worded as _requirement_ to get SUSE Support help for paying customers (this was already discussed and approved with PM, specifically asettle and CamrynCarter).

## Comments

From @gaktive in the issue thread:

> Bullseye leans towards having http/2 listed as a recommendation for 2.9.0+ and maybe throughout our version history. mattfarina is checking if a requirement should be considered down the road.

<!--
Any additional notes a reviewer should know before we review.
-->
