### PR TITLE
Fix Tabs groupId typo + other typos

### DIFF
--- a/docs/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
+++ b/docs/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
@@ -109,7 +109,7 @@ Rancher Server is distributed as a Docker image, which have tags attached to the
 | -------------------------- | ------ |
 | `rancher/rancher:latest`   | Our latest development release. These builds are validated through our CI automation framework. These releases are not recommended for production environments. |
 | `rancher/rancher:stable`   | Our newest stable release. This tag is recommended for production.                                                                                              |
-| `rancher/rancher:<v2.X.X>` | You can install specific versions of Rancher by using the tag from a previous release. See what's available at DockerHub.                                       |
+| `rancher/rancher:<v2.X.X>` | You can install specific versions of Rancher by using the tag from a previous release. See what's available at Docker Hub.                                       |
 
 :::note
 

--- a/docs/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.md
+++ b/docs/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.md
@@ -111,7 +111,7 @@ Profiling data (such as advanced memory or CPU analysis) is not present as it is
 
 To enable the Rancher Performance Dashboard:
 
-<Tabs groupid="UIorCLI">
+<Tabs groupId="UIorCLI">
 <TabItem value="Helm">
 
 Use the following options with the Helm CLI:

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/custom-branding.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/custom-branding.md
@@ -23,7 +23,7 @@ This option replaces "Rancher" with the value you provide in most places. Files 
 
 ### Support Links
 
-Use a url address to send new "File an Issue" reports instead of sending users to the Github issues page. Optionally show Rancher community support links.
+Use a url address to send new "File an Issue" reports instead of sending users to the GitHub issues page. Optionally show Rancher community support links.
 
 ### Logo
 

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
@@ -332,7 +332,7 @@ Refer to the offical AWS upstream documentation for the [cloud controller manage
 <Tabs groupId="k8s-distro">
 <TabItem value="RKE2">
 
-Official upstream docs for [Helm chart installation](https://github.com/kubernetes/cloud-provider-aws/tree/master/charts/aws-cloud-controller-manager) can be found on Github.
+Official upstream docs for [Helm chart installation](https://github.com/kubernetes/cloud-provider-aws/tree/master/charts/aws-cloud-controller-manager) can be found on GitHub.
 
 1. Add the Helm repository:
 
@@ -465,7 +465,7 @@ kubectl rollout status daemonset -n kube-system aws-cloud-controller-manager
 
 <TabItem value="RKE">
 
-Official upstream docs for [Helm chart installation](https://github.com/kubernetes/cloud-provider-aws/tree/master/charts/aws-cloud-controller-manager) can be found on Github.
+Official upstream docs for [Helm chart installation](https://github.com/kubernetes/cloud-provider-aws/tree/master/charts/aws-cloud-controller-manager) can be found on GitHub.
 
 1. Add the Helm repository:
 

--- a/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
@@ -46,7 +46,7 @@ If you need to create a private registry, refer to the documentation pages for y
     :::
 
 1. Select a namespace for the registry.
-1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use DockerHub, provide your DockerHub username and password.
+1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use Docker Hub, provide your Docker Hub username and password.
 1. Click **Save**.
 
 **Result:**
@@ -89,7 +89,7 @@ Before v2.6, secrets were required to be in a project scope. Projects are no lon
     :::
 
 1. Select a namespace for the registry.
-1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use DockerHub, provide your DockerHub username and password.
+1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use Docker Hub, provide your Docker Hub username and password.
 1. Click **Save**.
 
 **Result:**

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-private-clusters.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-private-clusters.md
@@ -20,7 +20,7 @@ Cloud NAT will [incur charges](https://cloud.google.com/nat/pricing).
 
 :::
 
-If restricting outgoing internet access is not a concern for your organization, use Google's [Cloud NAT](https://cloud.google.com/nat/docs/using-nat) service to allow nodes in the private network to access the internet, enabling them to download the required images from Dockerhub and contact the Rancher management server. This is the simplest solution.
+If restricting outgoing internet access is not a concern for your organization, use Google's [Cloud NAT](https://cloud.google.com/nat/docs/using-nat) service to allow nodes in the private network to access the internet, enabling them to download the required images from Docker Hub and contact the Rancher management server. This is the simplest solution.
 
 #### Private registry
 

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/advanced-options/advanced-use-cases/air-gap-helm2/install-rancher.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/advanced-options/advanced-use-cases/air-gap-helm2/install-rancher.md
@@ -214,7 +214,7 @@ kubectl -n cattle-system apply -R -f ./rancher
 
 ### E. For Rancher versions before v2.3.0, Configure System Charts
 
-If you are installing Rancher versions before v2.3.0, you will not be able to use the packaged system charts. Since the Rancher system charts are hosted in Github, an air gapped installation will not be able to access these charts. Therefore, you must [configure the Rancher system charts](../../../resources/local-system-charts.md).
+If you are installing Rancher versions before v2.3.0, you will not be able to use the packaged system charts. Since the Rancher system charts are hosted in GitHub, an air gapped installation will not be able to access these charts. Therefore, you must [configure the Rancher system charts](../../../resources/local-system-charts.md).
 
 ### Additional Resources
 
@@ -334,7 +334,7 @@ docker run -d --restart=unless-stopped \
 
 If you are installing Rancher v2.3.0+, the installation is complete.
 
-If you are installing Rancher versions before v2.3.0, you will not be able to use the packaged system charts. Since the Rancher system charts are hosted in Github, an air gapped installation will not be able to access these charts. Therefore, you must [configure the Rancher system charts](../../../resources/local-system-charts.md).
+If you are installing Rancher versions before v2.3.0, you will not be able to use the packaged system charts. Since the Rancher system charts are hosted in GitHub, an air gapped installation will not be able to access these charts. Therefore, you must [configure the Rancher system charts](../../../resources/local-system-charts.md).
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.md
@@ -221,7 +221,7 @@ kubectl -n cattle-system apply -R -f ./rancher
 
 ## 5. For Rancher versions before v2.3.0, Configure System Charts
 
-If you are installing Rancher versions before v2.3.0, you will not be able to use the packaged system charts. Since the Rancher system charts are hosted in Github, an air gapped installation will not be able to access these charts. Therefore, you must [configure the Rancher system charts](../../resources/local-system-charts.md).
+If you are installing Rancher versions before v2.3.0, you will not be able to use the packaged system charts. Since the Rancher system charts are hosted in GitHub, an air gapped installation will not be able to access these charts. Therefore, you must [configure the Rancher system charts](../../resources/local-system-charts.md).
 
 ## Additional Resources
 
@@ -357,7 +357,7 @@ If you are installing Rancher v2.3.0+, the installation is complete.
 
 > **Note:** If you don't intend to send telemetry data, opt out [telemetry](../../../../faq/telemetry.md) during the initial login.
 
-If you are installing Rancher versions before v2.3.0, you will not be able to use the packaged system charts. Since the Rancher system charts are hosted in Github, an air gapped installation will not be able to access these charts. Therefore, you must [configure the Rancher system charts](../../resources/local-system-charts.md).
+If you are installing Rancher versions before v2.3.0, you will not be able to use the packaged system charts. Since the Rancher system charts are hosted in GitHub, an air gapped installation will not be able to access these charts. Therefore, you must [configure the Rancher system charts](../../resources/local-system-charts.md).
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
+++ b/versioned_docs/version-2.0-2.4/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
@@ -103,7 +103,7 @@ Rancher Server is distributed as a Docker image, which have tags attached to the
 | -------------------------- | ------ |
 | `rancher/rancher:latest`   | Our latest development release. These builds are validated through our CI automation framework. These releases are not recommended for production environments. |
 | `rancher/rancher:stable`   | Our newest stable release. This tag is recommended for production.                                                                                              |
-| `rancher/rancher:<v2.X.X>` | You can install specific versions of Rancher by using the tag from a previous release. See what's available at DockerHub.                                       |
+| `rancher/rancher:<v2.X.X>` | You can install specific versions of Rancher by using the tag from a previous release. See what's available at Docker Hub.                                       |
 
 > **Notes:**
 >

--- a/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
+++ b/versioned_docs/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
@@ -34,7 +34,7 @@ Currently, deployments pull the private registry credentials automatically only 
 
 1. Select a **Scope** for the registry. You can either make the registry available for the entire project or a single namespace.
 
-1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use DockerHub, provide your DockerHub username and password.
+1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use Docker Hub, provide your Docker Hub username and password.
 
 1. Click **Save**.
 

--- a/versioned_docs/version-2.0-2.4/reference-guides/pipelines/pipeline-configuration.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/pipelines/pipeline-configuration.md
@@ -542,7 +542,7 @@ For your convenience, the following variables are available for your pipeline co
 
 Variable Name           | Description
 ------------------------|------------------------------------------------------------
-`CICD_GIT_REPO_NAME`      | Repository name (Github organization omitted).
+`CICD_GIT_REPO_NAME`      | Repository name (GitHub organization omitted).
 `CICD_GIT_URL`            | URL of the Git repository.
 `CICD_GIT_COMMIT`         | Git commit ID being executed.
 `CICD_GIT_BRANCH`         | Git branch of this event.

--- a/versioned_docs/version-2.0-2.4/reference-guides/pipelines/pipelines.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/pipelines/pipelines.md
@@ -86,7 +86,7 @@ Select your provider's tab below and follow the directions.
 
 1. Select **Tools > Pipelines** in the navigation bar. In versions before v2.2.0, you can select **Resources > Pipelines**.
 
-1. Follow the directions displayed to **Setup a Github application**. Rancher redirects you to Github to setup an OAuth App in Github.
+1. Follow the directions displayed to **Setup a GitHub application**. Rancher redirects you to GitHub to setup an OAuth App in GitHub.
 
 1. From GitHub, copy the **Client ID** and **Client Secret**. Paste them into Rancher.
 

--- a/versioned_docs/version-2.0-2.4/reference-guides/pipelines/v2.0.x.md
+++ b/versioned_docs/version-2.0-2.4/reference-guides/pipelines/v2.0.x.md
@@ -111,7 +111,7 @@ For your convenience the following environment variables are available in your b
 
 Variable Name           | Description
 ------------------------|------------------------------------------------------------
-CICD_GIT_REPO_NAME      | Repository Name (Stripped of Github Organization)
+CICD_GIT_REPO_NAME      | Repository Name (Stripped of GitHub Organization)
 CICD_PIPELINE_NAME      | Name of the pipeline
 CICD_GIT_BRANCH         | Git branch of this event
 CICD_TRIGGER_TYPE       | Event that triggered the build

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
@@ -105,7 +105,7 @@ Rancher Server is distributed as a Docker image, which have tags attached to the
 | -------------------------- | ------ |
 | `rancher/rancher:latest`   | Our latest development release. These builds are validated through our CI automation framework. These releases are not recommended for production environments. |
 | `rancher/rancher:stable`   | Our newest stable release. This tag is recommended for production.                                                                                              |
-| `rancher/rancher:<v2.X.X>` | You can install specific versions of Rancher by using the tag from a previous release. See what's available at DockerHub.                                       |
+| `rancher/rancher:<v2.X.X>` | You can install specific versions of Rancher by using the tag from a previous release. See what's available at Docker Hub.                                       |
 
 > **Notes:**
 >

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -21,7 +21,7 @@ Rancher can be installed on any Kubernetes cluster, including hosted Kubernetes 
 Since Rancher can be installed on any Kubernetes cluster, you can use this backup and restore method to migrate Rancher from one Kubernetes cluster to any other Kubernetes cluster. This method *only* migrates Rancher-related resources and won't affect other applications on the cluster. Refer to the [support matrix](https://www.suse.com/lifecycle/) to identify which Kubernetes cluster types and versions are supported for your Rancher version.
 
 ### 1. Install the rancher-backup Helm chart
-Install version 1.x.x of the rancher-backup chart. The following assumes a connected environment with access to DockerHub:
+Install version 1.x.x of the rancher-backup chart. The following assumes a connected environment with access to Docker Hub:
 
 ```
 helm repo add rancher-charts https://charts.rancher.io

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
@@ -34,7 +34,7 @@ Currently, deployments pull the private registry credentials automatically only 
 
 1. Select a **Scope** for the registry. You can either make the registry available for the entire project or a single namespace.
 
-1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use DockerHub, provide your DockerHub username and password.
+1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use Docker Hub, provide your Docker Hub username and password.
 
 1. Click **Save**.
 

--- a/versioned_docs/version-2.5/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-private-clusters.md
+++ b/versioned_docs/version-2.5/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-private-clusters.md
@@ -19,7 +19,7 @@ Because the nodes in a private cluster only have internal IP addresses, they wil
 >**Note**
 >Cloud NAT will [incur charges](https://cloud.google.com/nat/pricing).
 
-If restricting outgoing internet access is not a concern for your organization, use Google's [Cloud NAT](https://cloud.google.com/nat/docs/using-nat) service to allow nodes in the private network to access the internet, enabling them to download the required images from Dockerhub and contact the Rancher management server. This is the simplest solution.
+If restricting outgoing internet access is not a concern for your organization, use Google's [Cloud NAT](https://cloud.google.com/nat/docs/using-nat) service to allow nodes in the private network to access the internet, enabling them to download the required images from Docker Hub and contact the Rancher management server. This is the simplest solution.
 
 #### Private registry
 

--- a/versioned_docs/version-2.6/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
+++ b/versioned_docs/version-2.6/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
@@ -109,7 +109,7 @@ Rancher Server is distributed as a Docker image, which have tags attached to the
 | -------------------------- | ------ |
 | `rancher/rancher:latest`   | Our latest development release. These builds are validated through our CI automation framework. These releases are not recommended for production environments. |
 | `rancher/rancher:stable`   | Our newest stable release. This tag is recommended for production.                                                                                              |
-| `rancher/rancher:<v2.X.X>` | You can install specific versions of Rancher by using the tag from a previous release. See what's available at DockerHub.                                       |
+| `rancher/rancher:<v2.X.X>` | You can install specific versions of Rancher by using the tag from a previous release. See what's available at Docker Hub.                                       |
 
 :::note
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/custom-branding.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/custom-branding.md
@@ -25,7 +25,7 @@ This option replaces "Rancher" with the value you provide in most places. Files 
 
 ### Support Links
 
-Use a url address to send new "File an Issue" reports instead of sending users to the Github issues page. Optionally show Rancher community support links.
+Use a url address to send new "File an Issue" reports instead of sending users to the GitHub issues page. Optionally show Rancher community support links.
 
 ### Logo
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
@@ -40,7 +40,7 @@ You must have a [private registry](https://docs.docker.com/registry/deploying/) 
     :::
 
 1. Select a namespace for the registry.
-1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use DockerHub, provide your DockerHub username and password.
+1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use Docker Hub, provide your Docker Hub username and password.
 1. Click **Save**.
 
 **Result:**
@@ -77,7 +77,7 @@ Before v2.6, secrets were required to be in a project scope. Projects are no lon
     :::
 
 1. Select a namespace for the registry.
-1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use DockerHub, provide your DockerHub username and password.
+1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use Docker Hub, provide your Docker Hub username and password.
 1. Click **Save**.
 
 **Result:**

--- a/versioned_docs/version-2.6/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-private-clusters.md
+++ b/versioned_docs/version-2.6/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-private-clusters.md
@@ -20,7 +20,7 @@ Cloud NAT will [incur charges](https://cloud.google.com/nat/pricing).
 
 :::
 
-If restricting outgoing internet access is not a concern for your organization, use Google's [Cloud NAT](https://cloud.google.com/nat/docs/using-nat) service to allow nodes in the private network to access the internet, enabling them to download the required images from Dockerhub and contact the Rancher management server. This is the simplest solution.
+If restricting outgoing internet access is not a concern for your organization, use Google's [Cloud NAT](https://cloud.google.com/nat/docs/using-nat) service to allow nodes in the private network to access the internet, enabling them to download the required images from Docker Hub and contact the Rancher management server. This is the simplest solution.
 
 #### Private registry
 

--- a/versioned_docs/version-2.6/reference-guides/pipelines/pipeline-configuration.md
+++ b/versioned_docs/version-2.6/reference-guides/pipelines/pipeline-configuration.md
@@ -524,7 +524,7 @@ For your convenience, the following variables are available for your pipeline co
 
 Variable Name           | Description
 ------------------------|------------------------------------------------------------
-`CICD_GIT_REPO_NAME`      | Repository name (Github organization omitted).
+`CICD_GIT_REPO_NAME`      | Repository name (GitHub organization omitted).
 `CICD_GIT_URL`            | URL of the Git repository.
 `CICD_GIT_COMMIT`         | Git commit ID being executed.
 `CICD_GIT_BRANCH`         | Git branch of this event.

--- a/versioned_docs/version-2.6/reference-guides/pipelines/pipelines.md
+++ b/versioned_docs/version-2.6/reference-guides/pipelines/pipelines.md
@@ -113,7 +113,7 @@ Select your provider's tab below and follow the directions.
 1. In the dropdown menu in the top navigation bar, select the project where you want to configure pipelines.
 1. In the left navigation bar, click **Legacy > Project > Pipelines**.
 1. Click the **Configuration** tab.
-1. Follow the directions displayed to **Setup a Github application**. Rancher redirects you to Github to set up an OAuth App in Github.
+1. Follow the directions displayed to **Setup a GitHub application**. Rancher redirects you to GitHub to set up an OAuth App in GitHub.
 1. From GitHub, copy the **Client ID** and **Client Secret**. Paste them into Rancher.
 1. If you're using GitHub for enterprise, select **Use a private github enterprise installation**. Enter the host address of your GitHub installation.
 1. Click **Authenticate**.

--- a/versioned_docs/version-2.7/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
+++ b/versioned_docs/version-2.7/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
@@ -109,7 +109,7 @@ Rancher Server is distributed as a Docker image, which have tags attached to the
 | -------------------------- | ------ |
 | `rancher/rancher:latest`   | Our latest development release. These builds are validated through our CI automation framework. These releases are not recommended for production environments. |
 | `rancher/rancher:stable`   | Our newest stable release. This tag is recommended for production.                                                                                              |
-| `rancher/rancher:<v2.X.X>` | You can install specific versions of Rancher by using the tag from a previous release. See what's available at DockerHub.                                       |
+| `rancher/rancher:<v2.X.X>` | You can install specific versions of Rancher by using the tag from a previous release. See what's available at Docker Hub.                                       |
 
 :::note
 

--- a/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.md
+++ b/versioned_docs/version-2.7/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.md
@@ -112,7 +112,7 @@ Profiling data (such as advanced memory or CPU analysis) is not present as it is
 
 To enable the Rancher Performance Dashboard:
 
-<Tabs groupid="UIorCLI">
+<Tabs groupId="UIorCLI">
 <TabItem value="Helm">
 
 Use the following options with the Helm CLI:

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/custom-branding.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/custom-branding.md
@@ -23,7 +23,7 @@ This option replaces "Rancher" with the value you provide in most places. Files 
 
 ### Support Links
 
-Use a url address to send new "File an Issue" reports instead of sending users to the Github issues page. Optionally show Rancher community support links.
+Use a url address to send new "File an Issue" reports instead of sending users to the GitHub issues page. Optionally show Rancher community support links.
 
 ### Logo
 

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
@@ -332,7 +332,7 @@ Refer to the offical AWS upstream documentation for the [cloud controller manage
 <Tabs>
 <TabItem value="RKE2">
 
-Official upstream docs for [Helm chart installation](https://github.com/kubernetes/cloud-provider-aws/tree/master/charts/aws-cloud-controller-manager) can be found on Github.
+Official upstream docs for [Helm chart installation](https://github.com/kubernetes/cloud-provider-aws/tree/master/charts/aws-cloud-controller-manager) can be found on GitHub.
 
 1. Add the Helm repository:
 
@@ -465,7 +465,7 @@ kubectl rollout status daemonset -n kube-system aws-cloud-controller-manager
 
 <TabItem value="RKE">
 
-Official upstream docs for [Helm chart installation](https://github.com/kubernetes/cloud-provider-aws/tree/master/charts/aws-cloud-controller-manager) can be found on Github.
+Official upstream docs for [Helm chart installation](https://github.com/kubernetes/cloud-provider-aws/tree/master/charts/aws-cloud-controller-manager) can be found on GitHub.
 
 1. Add the Helm repository:
 

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
@@ -46,7 +46,7 @@ If you need to create a private registry, refer to the documentation pages for y
     :::
 
 1. Select a namespace for the registry.
-1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use DockerHub, provide your DockerHub username and password.
+1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use Docker Hub, provide your Docker Hub username and password.
 1. Click **Save**.
 
 **Result:**
@@ -89,7 +89,7 @@ Before v2.6, secrets were required to be in a project scope. Projects are no lon
     :::
 
 1. Select a namespace for the registry.
-1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use DockerHub, provide your DockerHub username and password.
+1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use Docker Hub, provide your Docker Hub username and password.
 1. Click **Save**.
 
 **Result:**

--- a/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-private-clusters.md
+++ b/versioned_docs/version-2.7/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-private-clusters.md
@@ -20,7 +20,7 @@ Cloud NAT will [incur charges](https://cloud.google.com/nat/pricing).
 
 :::
 
-If restricting outgoing internet access is not a concern for your organization, use Google's [Cloud NAT](https://cloud.google.com/nat/docs/using-nat) service to allow nodes in the private network to access the internet, enabling them to download the required images from Dockerhub and contact the Rancher management server. This is the simplest solution.
+If restricting outgoing internet access is not a concern for your organization, use Google's [Cloud NAT](https://cloud.google.com/nat/docs/using-nat) service to allow nodes in the private network to access the internet, enabling them to download the required images from Docker Hub and contact the Rancher management server. This is the simplest solution.
 
 #### Private registry
 

--- a/versioned_docs/version-2.8/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
+++ b/versioned_docs/version-2.8/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
@@ -109,7 +109,7 @@ Rancher Server is distributed as a Docker image, which have tags attached to the
 | -------------------------- | ------ |
 | `rancher/rancher:latest`   | Our latest development release. These builds are validated through our CI automation framework. These releases are not recommended for production environments. |
 | `rancher/rancher:stable`   | Our newest stable release. This tag is recommended for production.                                                                                              |
-| `rancher/rancher:<v2.X.X>` | You can install specific versions of Rancher by using the tag from a previous release. See what's available at DockerHub.                                       |
+| `rancher/rancher:<v2.X.X>` | You can install specific versions of Rancher by using the tag from a previous release. See what's available at Docker Hub.                                       |
 
 :::note
 

--- a/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.md
+++ b/versioned_docs/version-2.8/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.md
@@ -111,7 +111,7 @@ Profiling data (such as advanced memory or CPU analysis) is not present as it is
 
 To enable the Rancher Performance Dashboard:
 
-<Tabs groupid="UIorCLI">
+<Tabs groupId="UIorCLI">
 <TabItem value="Helm">
 
 Use the following options with the Helm CLI:

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/custom-branding.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/custom-branding.md
@@ -23,7 +23,7 @@ This option replaces "Rancher" with the value you provide in most places. Files 
 
 ### Support Links
 
-Use a url address to send new "File an Issue" reports instead of sending users to the Github issues page. Optionally show Rancher community support links.
+Use a url address to send new "File an Issue" reports instead of sending users to the GitHub issues page. Optionally show Rancher community support links.
 
 ### Logo
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
@@ -332,7 +332,7 @@ Refer to the offical AWS upstream documentation for the [cloud controller manage
 <Tabs groupId="k8s-distro">
 <TabItem value="RKE2">
 
-Official upstream docs for [Helm chart installation](https://github.com/kubernetes/cloud-provider-aws/tree/master/charts/aws-cloud-controller-manager) can be found on Github.
+Official upstream docs for [Helm chart installation](https://github.com/kubernetes/cloud-provider-aws/tree/master/charts/aws-cloud-controller-manager) can be found on GitHub.
 
 1. Add the Helm repository:
 
@@ -465,7 +465,7 @@ kubectl rollout status daemonset -n kube-system aws-cloud-controller-manager
 
 <TabItem value="RKE">
 
-Official upstream docs for [Helm chart installation](https://github.com/kubernetes/cloud-provider-aws/tree/master/charts/aws-cloud-controller-manager) can be found on Github.
+Official upstream docs for [Helm chart installation](https://github.com/kubernetes/cloud-provider-aws/tree/master/charts/aws-cloud-controller-manager) can be found on GitHub.
 
 1. Add the Helm repository:
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
@@ -46,7 +46,7 @@ If you need to create a private registry, refer to the documentation pages for y
     :::
 
 1. Select a namespace for the registry.
-1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use DockerHub, provide your DockerHub username and password.
+1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use Docker Hub, provide your Docker Hub username and password.
 1. Click **Save**.
 
 **Result:**
@@ -89,7 +89,7 @@ Before v2.6, secrets were required to be in a project scope. Projects are no lon
     :::
 
 1. Select a namespace for the registry.
-1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use DockerHub, provide your DockerHub username and password.
+1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use Docker Hub, provide your Docker Hub username and password.
 1. Click **Save**.
 
 **Result:**

--- a/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-private-clusters.md
+++ b/versioned_docs/version-2.8/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-private-clusters.md
@@ -20,7 +20,7 @@ Cloud NAT will [incur charges](https://cloud.google.com/nat/pricing).
 
 :::
 
-If restricting outgoing internet access is not a concern for your organization, use Google's [Cloud NAT](https://cloud.google.com/nat/docs/using-nat) service to allow nodes in the private network to access the internet, enabling them to download the required images from Dockerhub and contact the Rancher management server. This is the simplest solution.
+If restricting outgoing internet access is not a concern for your organization, use Google's [Cloud NAT](https://cloud.google.com/nat/docs/using-nat) service to allow nodes in the private network to access the internet, enabling them to download the required images from Docker Hub and contact the Rancher management server. This is the simplest solution.
 
 #### Private registry
 

--- a/versioned_docs/version-2.9/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
+++ b/versioned_docs/version-2.9/getting-started/installation-and-upgrade/resources/choose-a-rancher-version.md
@@ -109,7 +109,7 @@ Rancher Server is distributed as a Docker image, which have tags attached to the
 | -------------------------- | ------ |
 | `rancher/rancher:latest`   | Our latest development release. These builds are validated through our CI automation framework. These releases are not recommended for production environments. |
 | `rancher/rancher:stable`   | Our newest stable release. This tag is recommended for production.                                                                                              |
-| `rancher/rancher:<v2.X.X>` | You can install specific versions of Rancher by using the tag from a previous release. See what's available at DockerHub.                                       |
+| `rancher/rancher:<v2.X.X>` | You can install specific versions of Rancher by using the tag from a previous release. See what's available at Docker Hub.                                       |
 
 :::note
 

--- a/versioned_docs/version-2.9/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.md
+++ b/versioned_docs/version-2.9/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.md
@@ -111,7 +111,7 @@ Profiling data (such as advanced memory or CPU analysis) is not present as it is
 
 To enable the Rancher Performance Dashboard:
 
-<Tabs groupid="UIorCLI">
+<Tabs groupId="UIorCLI">
 <TabItem value="Helm">
 
 Use the following options with the Helm CLI:

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/custom-branding.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/custom-branding.md
@@ -23,7 +23,7 @@ This option replaces "Rancher" with the value you provide in most places. Files 
 
 ### Support Links
 
-Use a url address to send new "File an Issue" reports instead of sending users to the Github issues page. Optionally show Rancher community support links.
+Use a url address to send new "File an Issue" reports instead of sending users to the GitHub issues page. Optionally show Rancher community support links.
 
 ### Logo
 

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon.md
@@ -332,7 +332,7 @@ Refer to the offical AWS upstream documentation for the [cloud controller manage
 <Tabs groupId="k8s-distro">
 <TabItem value="RKE2">
 
-Official upstream docs for [Helm chart installation](https://github.com/kubernetes/cloud-provider-aws/tree/master/charts/aws-cloud-controller-manager) can be found on Github.
+Official upstream docs for [Helm chart installation](https://github.com/kubernetes/cloud-provider-aws/tree/master/charts/aws-cloud-controller-manager) can be found on GitHub.
 
 1. Add the Helm repository:
 
@@ -465,7 +465,7 @@ kubectl rollout status daemonset -n kube-system aws-cloud-controller-manager
 
 <TabItem value="RKE">
 
-Official upstream docs for [Helm chart installation](https://github.com/kubernetes/cloud-provider-aws/tree/master/charts/aws-cloud-controller-manager) can be found on Github.
+Official upstream docs for [Helm chart installation](https://github.com/kubernetes/cloud-provider-aws/tree/master/charts/aws-cloud-controller-manager) can be found on GitHub.
 
 1. Add the Helm repository:
 

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-and-docker-registries.md
@@ -46,7 +46,7 @@ If you need to create a private registry, refer to the documentation pages for y
     :::
 
 1. Select a namespace for the registry.
-1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use DockerHub, provide your DockerHub username and password.
+1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use Docker Hub, provide your Docker Hub username and password.
 1. Click **Save**.
 
 **Result:**
@@ -89,7 +89,7 @@ Before v2.6, secrets were required to be in a project scope. Projects are no lon
     :::
 
 1. Select a namespace for the registry.
-1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use DockerHub, provide your DockerHub username and password.
+1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use Docker Hub, provide your Docker Hub username and password.
 1. Click **Save**.
 
 **Result:**

--- a/versioned_docs/version-2.9/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-private-clusters.md
+++ b/versioned_docs/version-2.9/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-private-clusters.md
@@ -20,7 +20,7 @@ Cloud NAT will [incur charges](https://cloud.google.com/nat/pricing).
 
 :::
 
-If restricting outgoing internet access is not a concern for your organization, use Google's [Cloud NAT](https://cloud.google.com/nat/docs/using-nat) service to allow nodes in the private network to access the internet, enabling them to download the required images from Dockerhub and contact the Rancher management server. This is the simplest solution.
+If restricting outgoing internet access is not a concern for your organization, use Google's [Cloud NAT](https://cloud.google.com/nat/docs/using-nat) service to allow nodes in the private network to access the internet, enabling them to download the required images from Docker Hub and contact the Rancher management server. This is the simplest solution.
 
 #### Private registry
 


### PR DESCRIPTION
## Description

Mainly to a fix typo in the Tabs `groupId` (was incorrectly `groupid`) attribute of `/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.md`.

Also fixed a couple other typos:
`Github` -> `GitHub`
`Dockerhub` and `DockerHub` -> `Docker Hub`