### PR TITLE
[2.9.1][2.8-Next1] Add info about Private Registry Credentials covering backup labels

### DIFF
--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
@@ -54,8 +54,20 @@ Since the private registry cannot be configured after the cluster is created, yo
 1. Select **☰ > Cluster Management**.
 1. On the **Clusters** page, click **Create**.
 1. Choose a cluster type.
-1. In the **Cluster Configuration** go to the **Registries** tab and select **Pull images for Rancher from a private registry**.
-1. Enter the registry hostname and credentials.
+1. In the **Cluster Configuration** go to the **Registries** tab.
+1. Check the box next to **Enable cluster scoped container registry for Rancher system container images**.
+1. Enter the registry hostname.
+1. Under **Authentication** select **Create a HTTP Basic Auth Secret** and fill in the credential fields.
 1. Click **Create**.
 
 **Result:** The new cluster pulls images from the private registry.
+
+### Working with Private Registry Credentials
+
+When working with private registries, it is important to ensure that any secrets created for these registries are properly backed up. By default, when you add a private registry credential secret through the process outlined above, it is included in backup operations.
+
+However, if you create credential secrets outside of the Rancher GUI (using kubectl, or Terraform), you must take an extra step to ensure they are backed up effectively. When creating these secrets, make sure to add the `fleet.cattle.io/managed=true` label to indicate that this secret should be included in backups created by Rancher Backups.
+
+For example, if you have a custom private registry named "my-private-registry" and create a secret called "my-reg-creds" for it, apply the `fleet.cattle.io/managed=true` label to this secret. This ensures that your backup process captures this secret providing easy restoration if needed.
+
+By following this guidance, you can ensure that all your private registry credentials are backed up and easily accessible in the event of a restore or migration.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
@@ -64,7 +64,7 @@ Since the private registry cannot be configured after the cluster is created, yo
 
 ### Working with Private Registry Credentials
 
-When working with private registries, it is important to ensure that any secrets created for these registries are properly backed up. By default, when you add a private registry credential secret through the process outlined above, it is included in backup operations.
+When working with private registries, it is important to ensure that any secrets created for these registries are properly backed up. By default, when you add a private registry credential secret through the process outlined above, it is included in backup operations using Rancher Backups.
 
 However, if you create credential secrets outside of the Rancher GUI (using kubectl, or Terraform), you must take an extra step to ensure they are backed up effectively. When creating these secrets, make sure to add the `fleet.cattle.io/managed=true` label to indicate that this secret should be included in backups created by Rancher Backups.
 

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
@@ -66,7 +66,7 @@ Since the private registry cannot be configured after the cluster is created, yo
 
 When working with private registries, it is important to ensure that any secrets created for these registries are properly backed up. By default, when you add a private registry credential secret through the process outlined above, it is included in backup operations using Rancher Backups.
 
-However, if you create credential secrets outside of the Rancher GUI (using kubectl, or Terraform), you must take an extra step to ensure they are backed up effectively. When creating these secrets, make sure to add the `fleet.cattle.io/managed=true` label to indicate that this secret should be included in backups created by Rancher Backups.
+However, if you create a credential secret outside of the Rancher GUI, such as by using kubectl or Terraform, you must add the `fleet.cattle.io/managed=true` label to indicate that the secret should be included in backups created by Rancher Backups.
 
 For example, if you have a custom private registry named "my-private-registry" and create a secret called "my-reg-creds" for it, apply the `fleet.cattle.io/managed=true` label to this secret. This ensures that your backup process captures the secret, providing easy restoration if needed.
 

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
@@ -70,4 +70,4 @@ However, if you create credential secrets outside of the Rancher GUI (using kube
 
 For example, if you have a custom private registry named "my-private-registry" and create a secret called "my-reg-creds" for it, apply the `fleet.cattle.io/managed=true` label to this secret. This ensures that your backup process captures this secret providing easy restoration if needed.
 
-By following this guidance, you can ensure that all your private registry credentials are backed up and easily accessible in the event of a restore or migration.
+By following this guidance, you can ensure that all of your private registry credentials are backed up and easily accessible in the event of a restore or migration.

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
@@ -64,7 +64,7 @@ Since the private registry cannot be configured after the cluster is created, yo
 
 ### Working with Private Registry Credentials
 
-When working with private registries, it is important to ensure that any secrets created for these registries are properly backed up. By default, when you add a private registry credential secret through the process outlined above, it is included in backup operations using Rancher Backups.
+When working with private registries, it is important to ensure that any secrets created for these registries are properly backed up. When you add a private registry credential secret through the Rancher GUI and select **Create a HTTP Basic Auth Secret**, the secret is included in backup operations using Rancher Backups.
 
 However, if you create a credential secret outside of the Rancher GUI, such as by using kubectl or Terraform, you must add the `fleet.cattle.io/managed=true` label to indicate that the secret should be included in backups created by Rancher Backups.
 

--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
@@ -68,6 +68,6 @@ When working with private registries, it is important to ensure that any secrets
 
 However, if you create credential secrets outside of the Rancher GUI (using kubectl, or Terraform), you must take an extra step to ensure they are backed up effectively. When creating these secrets, make sure to add the `fleet.cattle.io/managed=true` label to indicate that this secret should be included in backups created by Rancher Backups.
 
-For example, if you have a custom private registry named "my-private-registry" and create a secret called "my-reg-creds" for it, apply the `fleet.cattle.io/managed=true` label to this secret. This ensures that your backup process captures this secret providing easy restoration if needed.
+For example, if you have a custom private registry named "my-private-registry" and create a secret called "my-reg-creds" for it, apply the `fleet.cattle.io/managed=true` label to this secret. This ensures that your backup process captures the secret, providing easy restoration if needed.
 
 By following this guidance, you can ensure that all of your private registry credentials are backed up and easily accessible in the event of a restore or migration.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
@@ -54,8 +54,20 @@ Since the private registry cannot be configured after the cluster is created, yo
 1. Select **☰ > Cluster Management**.
 1. On the **Clusters** page, click **Create**.
 1. Choose a cluster type.
-1. In the **Cluster Configuration** go to the **Registries** tab and select **Pull images for Rancher from a private registry**.
-1. Enter the registry hostname and credentials.
+1. In the **Cluster Configuration** go to the **Registries** tab.
+1. Check the box next to **Enable cluster scoped container registry for Rancher system container images**.
+1. Enter the registry hostname.
+1. Under **Authentication** select **Create a HTTP Basic Auth Secret** and fill in the credential fields.
 1. Click **Create**.
 
 **Result:** The new cluster pulls images from the private registry.
+
+### Working with Private Registry Credentials
+
+When working with private registries, it is important to ensure that any secrets created for these registries are properly backed up. By default, when you add a private registry credential secret through the process outlined above, it is included in backup operations.
+
+However, if you create credential secrets outside of the Rancher GUI (using kubectl, or Terraform), you must take an extra step to ensure they are backed up effectively. When creating these secrets, make sure to add the `fleet.cattle.io/managed=true` label to indicate that this secret should be included in backups created by Rancher Backups.
+
+For example, if you have a custom private registry named "my-private-registry" and create a secret called "my-reg-creds" for it, apply the `fleet.cattle.io/managed=true` label to this secret. This ensures that your backup process captures this secret providing easy restoration if needed.
+
+By following this guidance, you can ensure that all your private registry credentials are backed up and easily accessible in the event of a restore or migration.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
@@ -64,7 +64,7 @@ Since the private registry cannot be configured after the cluster is created, yo
 
 ### Working with Private Registry Credentials
 
-When working with private registries, it is important to ensure that any secrets created for these registries are properly backed up. By default, when you add a private registry credential secret through the process outlined above, it is included in backup operations.
+When working with private registries, it is important to ensure that any secrets created for these registries are properly backed up. By default, when you add a private registry credential secret through the process outlined above, it is included in backup operations using Rancher Backups.
 
 However, if you create credential secrets outside of the Rancher GUI (using kubectl, or Terraform), you must take an extra step to ensure they are backed up effectively. When creating these secrets, make sure to add the `fleet.cattle.io/managed=true` label to indicate that this secret should be included in backups created by Rancher Backups.
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
@@ -66,7 +66,7 @@ Since the private registry cannot be configured after the cluster is created, yo
 
 When working with private registries, it is important to ensure that any secrets created for these registries are properly backed up. By default, when you add a private registry credential secret through the process outlined above, it is included in backup operations using Rancher Backups.
 
-However, if you create credential secrets outside of the Rancher GUI (using kubectl, or Terraform), you must take an extra step to ensure they are backed up effectively. When creating these secrets, make sure to add the `fleet.cattle.io/managed=true` label to indicate that this secret should be included in backups created by Rancher Backups.
+However, if you create a credential secret outside of the Rancher GUI, such as by using kubectl or Terraform, you must add the `fleet.cattle.io/managed=true` label to indicate that the secret should be included in backups created by Rancher Backups.
 
 For example, if you have a custom private registry named "my-private-registry" and create a secret called "my-reg-creds" for it, apply the `fleet.cattle.io/managed=true` label to this secret. This ensures that your backup process captures the secret, providing easy restoration if needed.
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
@@ -64,7 +64,7 @@ Since the private registry cannot be configured after the cluster is created, yo
 
 ### Working with Private Registry Credentials
 
-When working with private registries, it is important to ensure that any secrets created for these registries are properly backed up. By default, when you add a private registry credential secret through the process outlined above, it is included in backup operations using Rancher Backups.
+When working with private registries, it is important to ensure that any secrets created for these registries are properly backed up. When you add a private registry credential secret through the Rancher GUI, the secret is included in backup operations using Rancher Backups.
 
 However, if you create a credential secret outside of the Rancher GUI, such as by using kubectl or Terraform, you must add the `fleet.cattle.io/managed=true` label to indicate that the secret should be included in backups created by Rancher Backups.
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
@@ -64,7 +64,7 @@ Since the private registry cannot be configured after the cluster is created, yo
 
 ### Working with Private Registry Credentials
 
-When working with private registries, it is important to ensure that any secrets created for these registries are properly backed up. When you add a private registry credential secret through the Rancher GUI, the secret is included in backup operations using Rancher Backups.
+When working with private registries, it is important to ensure that any secrets created for these registries are properly backed up. When you add a private registry credential secret through the Rancher GUI and select **Create a HTTP Basic Auth Secret**, the secret is included in backup operations using Rancher Backups.
 
 However, if you create a credential secret outside of the Rancher GUI, such as by using kubectl or Terraform, you must add the `fleet.cattle.io/managed=true` label to indicate that the secret should be included in backups created by Rancher Backups.
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
@@ -70,4 +70,4 @@ However, if you create credential secrets outside of the Rancher GUI (using kube
 
 For example, if you have a custom private registry named "my-private-registry" and create a secret called "my-reg-creds" for it, apply the `fleet.cattle.io/managed=true` label to this secret. This ensures that your backup process captures this secret providing easy restoration if needed.
 
-By following this guidance, you can ensure that all your private registry credentials are backed up and easily accessible in the event of a restore or migration.
+By following this guidance, you can ensure that all of your private registry credentials are backed up and easily accessible in the event of a restore or migration.

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
@@ -68,6 +68,6 @@ When working with private registries, it is important to ensure that any secrets
 
 However, if you create credential secrets outside of the Rancher GUI (using kubectl, or Terraform), you must take an extra step to ensure they are backed up effectively. When creating these secrets, make sure to add the `fleet.cattle.io/managed=true` label to indicate that this secret should be included in backups created by Rancher Backups.
 
-For example, if you have a custom private registry named "my-private-registry" and create a secret called "my-reg-creds" for it, apply the `fleet.cattle.io/managed=true` label to this secret. This ensures that your backup process captures this secret providing easy restoration if needed.
+For example, if you have a custom private registry named "my-private-registry" and create a secret called "my-reg-creds" for it, apply the `fleet.cattle.io/managed=true` label to this secret. This ensures that your backup process captures the secret, providing easy restoration if needed.
 
 By following this guidance, you can ensure that all of your private registry credentials are backed up and easily accessible in the event of a restore or migration.

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry.md
@@ -39,23 +39,20 @@ However, you'll need to do some additional steps if you're trying to set a names
 
 1. Select **☰ > Cluster Management**.
 1. Find the RKE2 cluster in the list and click **⋮ >Edit Config**.
-1. From the **Cluster config** menu, select **Registries**.
-1. In the **Registries** pane, select the **Configure advanced containerd mirroring and registry authentication options** option.
-1. In the text fields under **Mirrors**, enter the **Registry Hostname** and **Mirror Endpoints**.
-1. Click **Save**.
-1. Repeat as necessary for each downstream RKE2 cluster.
-
-## Configure a Private Registry with Credentials when Creating a Cluster
-
-There is no global way to set up a private registry with authorization for every Rancher-provisioned cluster. Therefore, if you want a Rancher-provisioned cluster to pull images from a private registry that requires credentials, you'll have to pass the registry credentials through the advanced cluster options every time you create a new cluster. 
-
-Since the private registry cannot be configured after the cluster is created, you'll need to perform these steps during initial cluster setup.
-
-1. Select **☰ > Cluster Management**.
-1. On the **Clusters** page, click **Create**.
-1. Choose a cluster type.
-1. In the **Cluster Configuration** go to the **Registries** tab and select **Pull images for Rancher from a private registry**.
-1. Enter the registry hostname and credentials.
+1. In the **Cluster Configuration** go to the **Registries** tab.
+1. Check the box next to **Enable cluster scoped container registry for Rancher system container images**.
+1. Enter the registry hostname.
+1. Under **Authentication** select **Create a HTTP Basic Auth Secret** and fill in the credential fields.
 1. Click **Create**.
 
 **Result:** The new cluster pulls images from the private registry.
+
+### Working with Private Registry Credentials
+
+When working with private registries, it is important to ensure that any secrets created for these registries are properly backed up. When you add a private registry credential secret through the Rancher GUI and select **Create a HTTP Basic Auth Secret**, the secret is included in backup operations using Rancher Backups.
+
+However, if you create a credential secret outside of the Rancher GUI, such as by using kubectl or Terraform, you must add the `fleet.cattle.io/managed=true` label to indicate that the secret should be included in backups created by Rancher Backups.
+
+For example, if you have a custom private registry named "my-private-registry" and create a secret called "my-reg-creds" for it, apply the `fleet.cattle.io/managed=true` label to this secret. This ensures that your backup process captures the secret, providing easy restoration if needed.
+
+By following this guidance, you can ensure that all of your private registry credentials are backed up and easily accessible in the event of a restore or migration.


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes https://github.com/rancher/rancher/issues/44033

BRO PRs:
https://github.com/rancher/backup-restore-operator/pull/480
https://github.com/rancher/backup-restore-operator/pull/486

## Description

This PR helps correct missing documentation to inform Private Registry users how to ensure custom created credential secrets are backed up. I corrected the outdated steps with old terms and added the new section about secrets and rancher backups.

The PRs needed to fix part of it on BRO side didn't make it for 2.9.0; so we are waiting for 2.9.1 (and equivalent 2.8.x). Once the current release for 2.9.0 is done, we can merge those PRs and then merge these docs upon release.

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->

A more "complete" solution for this seems to be adding some controller logic that will:
1. See request for new/update cluster w/ Registry auth in use,
2. looks up the secret(s) to verify rancher created it (matching expected name),
3. If secret doesn't match name then append (or update) label `fleet.cattle.io/managed=true`.
