### PR TITLE
Removing Preview/Banner - v2.9 Docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -185,9 +185,9 @@ module.exports = {
               label: 'Latest',
             },
             2.9: {
-              label: 'v2.9 (Preview)',
+              label: 'v2.9',
               path: 'v2.9',
-              banner: 'unreleased'
+              banner: 'none'
             },
             2.8: {
               label: 'v2.8',


### PR DESCRIPTION
Removing "Preview" label and banner for v2.9 documentation after the v2.9.0 Rancher release.