### PR TITLE
Remove white space from API ref page

### DIFF
--- a/docs/api/api-reference.mdx
+++ b/docs/api/api-reference.mdx
@@ -1,5 +1,6 @@
 ---
 title: API Reference
+hide_table_of_contents: true
 ---
 
 <head>

--- a/versioned_docs/version-2.8/api/api-reference.mdx
+++ b/versioned_docs/version-2.8/api/api-reference.mdx
@@ -1,5 +1,6 @@
 ---
 title: API Reference
+hide_table_of_contents: true
 ---
 
 <head>

--- a/versioned_docs/version-2.9/api/api-reference.mdx
+++ b/versioned_docs/version-2.9/api/api-reference.mdx
@@ -1,5 +1,6 @@
 ---
 title: API Reference
+hide_table_of_contents: true
 ---
 
 <head>


### PR DESCRIPTION
Fixes #1226 

## Description

Remove area reserved for table of contents causing white space.
