### PR TITLE
Update suse-vale-styleguide dependency

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,7 +1,7 @@
-StylesPath = .github/styles
+StylesPath = .github/styles/suse-vale-styleguide
 
 [formtats]
 mdx = md
 
 [*.md]
-BasedOnStyles = suse-vale-styleguide
+BasedOnStyles = common


### PR DESCRIPTION
## Description

Bump our submodule reference up to https://github.com/openSUSE/suse-vale-styleguide/commit/037b0e6c65ed1d76abbe87afce3109affb92d122 (2024-08-01) as it's now 4 months outdated. The file structure has changed upstream so I've updated our vale.ini to reflect this.
