### PR TITLE
Re-syncing Glossary - v2.9 Docs/Versioned Sidebars

### DIFF
--- a/versioned_docs/version-2.9/glossary.md
+++ b/versioned_docs/version-2.9/glossary.md
@@ -1,0 +1,17 @@
+---
+title: Glossary
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/glossary"/>
+</head>
+
+This page covers Rancher-specific terminology and symbols which might be unfamiliar, or which differ between Rancher versions.
+
+```mdx-code-block
+import Glossary, {toc as GlossaryTOC} from "/shared-files/_glossary.md"
+
+<Glossary />
+
+export const toc = GlossaryTOC;
+```

--- a/versioned_sidebars/version-2.0-2.4-sidebars.json
+++ b/versioned_sidebars/version-2.0-2.4-sidebars.json
@@ -1316,6 +1316,6 @@
               ]
     },
         "contribute-to-rancher",
-    "glossary"
+        "glossary"
   ]
 }

--- a/versioned_sidebars/version-2.0-2.4-sidebars.json
+++ b/versioned_sidebars/version-2.0-2.4-sidebars.json
@@ -1315,6 +1315,7 @@
                 }
               ]
     },
-        "contribute-to-rancher"
+        "contribute-to-rancher",
+    "glossary"
   ]
 }

--- a/versioned_sidebars/version-2.5-sidebars.json
+++ b/versioned_sidebars/version-2.5-sidebars.json
@@ -1249,6 +1249,7 @@
                 }
               ]
     },
-        "contribute-to-rancher"
+        "contribute-to-rancher",
+    "glossary"
   ]
 }

--- a/versioned_sidebars/version-2.5-sidebars.json
+++ b/versioned_sidebars/version-2.5-sidebars.json
@@ -1250,6 +1250,6 @@
               ]
     },
         "contribute-to-rancher",
-    "glossary"
+        "glossary"
   ]
 }

--- a/versioned_sidebars/version-2.6-sidebars.json
+++ b/versioned_sidebars/version-2.6-sidebars.json
@@ -1238,6 +1238,7 @@
         }
       ]
     },
-    "contribute-to-rancher"
+    "contribute-to-rancher",
+    "glossary"
   ]
 }

--- a/versioned_sidebars/version-2.7-sidebars.json
+++ b/versioned_sidebars/version-2.7-sidebars.json
@@ -1311,6 +1311,7 @@
         }
       ]
     },
-    "contribute-to-rancher"
+    "contribute-to-rancher",
+    "glossary"
   ]
 }

--- a/versioned_sidebars/version-2.8-sidebars.json
+++ b/versioned_sidebars/version-2.8-sidebars.json
@@ -1318,6 +1318,7 @@
         "api/v3-rancher-api-guide"
       ]
     },
-    "contribute-to-rancher"
+    "contribute-to-rancher",
+    "glossary"
   ]
 }

--- a/versioned_sidebars/version-2.9-sidebars.json
+++ b/versioned_sidebars/version-2.9-sidebars.json
@@ -1322,6 +1322,7 @@
         "api/v3-rancher-api-guide"
       ]
     },
-    "contribute-to-rancher"
+    "contribute-to-rancher",
+    "glossary"
   ]
 }


### PR DESCRIPTION
Unsure as to how the page was removed from the versioned sidebars. However, this PR re-syncs the Glossary file with v2.9 docs and re-syncs the versioned sidebars that were missing the `"glossary"` field.