### PR TITLE
Configure dependabot for vale rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+  - package-ecosystem: gitsubmodule
+    schedule:
+        interval: "daily"
+    directory: /
+    


### PR DESCRIPTION
## Description

Set up dependabot so we don't need to manually track when new changes are made upstream.