### PR TITLE
Updating CAPI Page

### DIFF
--- a/docs/integrations-in-rancher/cluster-api/cluster-api.md
+++ b/docs/integrations-in-rancher/cluster-api/cluster-api.md
@@ -6,7 +6,7 @@ title: Cluster API (CAPI) with Rancher Turtles
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cluster-api"/>
 </head>
 
-[Rancher Turtles](https://turtles.docs.rancher.com/) is a [Rancher extension](../rancher-extensions.md) that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
+[Rancher Turtles](https://turtles.docs.rancher.com/) is a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/#operators-in-kubernetes) that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
 
 - Import CAPI clusters into Rancher, by installing the Rancher Cluster Agent in CAPI provisioned clusters.
 - Configure the [CAPI Operator](https://turtles.docs.rancher.com/reference-guides/rancher-turtles-chart/values#cluster-api-operator-values).

--- a/versioned_docs/version-2.7/integrations-in-rancher/cluster-api/cluster-api.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/cluster-api/cluster-api.md
@@ -6,7 +6,7 @@ title: Cluster API (CAPI) with Rancher Turtles
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cluster-api"/>
 </head>
 
-[Rancher Turtles](https://turtles.docs.rancher.com/) is a [Rancher extension](../rancher-extensions.md) that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
+[Rancher Turtles](https://turtles.docs.rancher.com/) is a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/#operators-in-kubernetes) that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
 
 - Import CAPI clusters into Rancher, by installing the Rancher Cluster Agent in CAPI provisioned clusters.
 - Configure the [CAPI Operator](https://turtles.docs.rancher.com/reference-guides/rancher-turtles-chart/values#cluster-api-operator-values).

--- a/versioned_docs/version-2.8/integrations-in-rancher/cluster-api/cluster-api.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/cluster-api/cluster-api.md
@@ -6,7 +6,7 @@ title: Cluster API (CAPI) with Rancher Turtles
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cluster-api"/>
 </head>
 
-[Rancher Turtles](https://turtles.docs.rancher.com/) is a [Rancher extension](../rancher-extensions.md) that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
+[Rancher Turtles](https://turtles.docs.rancher.com/) is a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/#operators-in-kubernetes) that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
 
 - Import CAPI clusters into Rancher, by installing the Rancher Cluster Agent in CAPI provisioned clusters.
 - Configure the [CAPI Operator](https://turtles.docs.rancher.com/reference-guides/rancher-turtles-chart/values#cluster-api-operator-values).

--- a/versioned_docs/version-2.9/integrations-in-rancher/cluster-api/cluster-api.md
+++ b/versioned_docs/version-2.9/integrations-in-rancher/cluster-api/cluster-api.md
@@ -6,7 +6,7 @@ title: Cluster API (CAPI) with Rancher Turtles
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/cluster-api"/>
 </head>
 
-[Rancher Turtles](https://turtles.docs.rancher.com/) is a [Rancher extension](../rancher-extensions.md) that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
+[Rancher Turtles](https://turtles.docs.rancher.com/) is a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/#operators-in-kubernetes) that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
 
 - Import CAPI clusters into Rancher, by installing the Rancher Cluster Agent in CAPI provisioned clusters.
 - Configure the [CAPI Operator](https://turtles.docs.rancher.com/reference-guides/rancher-turtles-chart/values#cluster-api-operator-values).


### PR DESCRIPTION
Updating the phrasing to "Kubernetes Operator" with link to concept definition in Kubernetes docs. The CAPI Operator is not a Rancher Extension currently. Update stems from Slack message captured below:

> I'm checking out Rancher Turtles and the first line of the [docs](https://ranchermanager.docs.rancher.com/v2.9/integrations-in-rancher/cluster-api) says:
[Rancher Turtles](https://turtles.docs.rancher.com/) is a [Rancher extension](https://ranchermanager.docs.rancher.com/v2.9/integrations-in-rancher/rancher-extensions) that manages the lifecycle of provisioned Kubernetes clusters,
However from what I can tell from the directions that follow, it's not a Rancher UI Extension.. You either enable it through Apps/Repositories & Apps/Charts in the UI or a series of helm commands. Are the docs incorrect or am I missing something?

