### PR TITLE
Add missing support matrix links 2.9.2, 2.8.8, 2.8.6, 2.7.15

### DIFF
--- a/src/pages/versions.md
+++ b/src/pages/versions.md
@@ -21,7 +21,7 @@ Here you can find links to supporting documentation for the current released ver
     <td><b>v2.9.2</b></td>
     <td><a href="https://ranchermanager.docs.rancher.com/v2.9">Documentation</a></td>
     <td><a href="https://github.com/rancher/rancher/releases/tag/v2.9.2">Release Notes</a></td>
-    <td><center>N/A</center></td>
+    <td><a href="https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-9-2/">Support Matrix</a></td>
     <td><center>&#10003;</center></td>
     <td><center>&#10003;</center></td>
   </tr>
@@ -42,7 +42,7 @@ Here you can find links to supporting documentation for the current released ver
     <td><b>v2.8.8</b></td>
     <td><a href="https://ranchermanager.docs.rancher.com/v2.8">Documentation</a></td>
     <td><a href="https://github.com/rancher/rancher/releases/tag/v2.8.8">Release Notes</a></td>
-    <td><center>N/A</center></td>
+    <td><a href="https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-8-8/">Support Matrix</a></td>
     <td><center>&#10003;</center></td>
     <td><center>N/A</center></td>
   </tr>
@@ -63,26 +63,9 @@ Here you can find links to supporting documentation for the current released ver
     <td><b>v2.7.15</b></td>
     <td><a href="https://ranchermanager.docs.rancher.com/v2.7">Documentation</a></td>
     <td><a href="https://github.com/rancher/rancher/releases/tag/v2.7.15">Release Notes</a></td>
-    <td><center>N/A</center></td>
+    <td><a href="https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-7-15/">Support Matrix</a></td>
     <td><center>&#10003;</center></td>
     <td><center>N/A</center></td>
-  </tr>
-</table>
-
-Here you can find links to supporting documentation for the current released version of Rancher v2.6:
-
-<table>
-  <tr>
-    <th>Version</th>
-    <th>Documentation</th>
-    <th>Release Notes</th>
-    <th>Support Matrix</th>
-  </tr>
-  <tr>
-    <td><b>v2.6.14</b></td>
-    <td><a href="https://ranchermanager.docs.rancher.com/v2.6">Documentation</a></td>
-    <td><a href="https://github.com/rancher/rancher/releases/tag/v2.6.14">Release Notes</a></td>
-    <td><a href="https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-6-14/">Support Matrix</a></td>
   </tr>
 </table>
 
@@ -103,7 +86,7 @@ Here you can find links to supporting documentation for previous versions of Ran
     <td><b>v2.9.1</b></td>
     <td><a href="https://ranchermanager.docs.rancher.com/v2.9">Documentation</a></td>
     <td><a href="https://github.com/rancher/rancher/releases/tag/v2.9.1">Release Notes</a></td>
-    <td><center>https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-9-1/</center></td>
+    <td><a href="https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-9-1/">Support Matrix</a></td>
     <td><center>&#10003;</center></td>
     <td><center>&#10003;</center></td>
   </tr>
@@ -134,7 +117,7 @@ Here you can find links to supporting documentation for previous versions of Ran
     <td><b>v2.8.7</b></td>
     <td><a href="https://ranchermanager.docs.rancher.com/v2.8">Documentation</a></td>
     <td><a href="https://github.com/rancher/rancher/releases/tag/v2.8.7">Release Notes</a></td>
-    <td><center>https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-8-7/</center></td>
+    <td><a href="https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-8-7/">Support Matrix</a></td>
     <td><center>&#10003;</center></td>
     <td><center>N/A</center></td>
   </tr>
@@ -142,7 +125,7 @@ Here you can find links to supporting documentation for previous versions of Ran
     <td><b>v2.8.6</b></td>
     <td><a href="https://ranchermanager.docs.rancher.com/v2.8">Documentation</a></td>
     <td><a href="https://github.com/rancher/rancher/releases/tag/v2.8.6">Release Notes</a></td>
-    <td><center>N/A</center></td>
+    <td><a href="https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-8-6/">Support Matrix</a></td>
     <td><center>&#10003;</center></td>
     <td><center>N/A</center></td>
   </tr>
@@ -333,7 +316,9 @@ Here you can find links to supporting documentation for previous versions of Ran
 
 <br/>
 
-Here you can find links to supporting documentation for previous versions of Rancher v2.6:
+### Legacy Versions (EOL)
+
+Here you can find links to supporting documentation for legacy versions of Rancher v2.6:
 
 <table>
   <tr>
@@ -341,6 +326,12 @@ Here you can find links to supporting documentation for previous versions of Ran
     <th>Documentation</th>
     <th>Release Notes</th>
     <th>Support Matrix</th>
+  </tr>
+    <tr>
+    <td><b>v2.6.14</b></td>
+    <td><a href="https://ranchermanager.docs.rancher.com/v2.6">Documentation</a></td>
+    <td><a href="https://github.com/rancher/rancher/releases/tag/v2.6.14">Release Notes</a></td>
+    <td><a href="https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-6-14/">Support Matrix</a></td>
   </tr>
   <tr>
     <td><b>v2.6.13</b></td>
@@ -429,8 +420,6 @@ Here you can find links to supporting documentation for previous versions of Ran
 </table>
 
 <br/>
-
-### Legacy Versions (EOL)
 
 Here you can find links to supporting documentation for legacy versions of Rancher v2.5:
 


### PR DESCRIPTION
## Description

Add missing support matrix links 2.9.2, 2.8.8, 2.8.6, 2.7.15.

Also fixes incorrect syntax on 2.9.1, 2.8.7 links and move 2.6.x under EOL section.

