### PR TITLE
Update file size limit to 30MB

### DIFF
--- a/versioned_docs/version-2.9/integrations-in-rancher/rancher-extensions.md
+++ b/versioned_docs/version-2.9/integrations-in-rancher/rancher-extensions.md
@@ -29,7 +29,7 @@ When you enable extension support for the first time, it creates resources, such
 
 By default, Rancher caches every extension file in the file system. You can change that behavior by setting `plugin.noCache` to `true`.
 
-Rancher does have a cached file size limit of 20MB. If an extension has a file bigger than that, the cache is disabled and `plugin.noCache` is set to `true`, regardless of user input.
+Rancher does have a cached file size limit of 30MB. If an extension has a file bigger than that, the cache is disabled and `plugin.noCache` is set to `true`, regardless of user input.
 
 
 ## Installing Extensions


### PR DESCRIPTION
Please check the issue for more details.

### Summary 

- Update the default file size cache to 30 MB because rancher codebase updated itself in release 2.9 and release 2.10 branches. 2.10 edit will be made in another PR.