### PR TITLE
Set max-old-space-size for yarn start due to memory issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "NODE_OPTIONS='--max-old-space-size=7168' docusaurus start",
     "build": "NODE_OPTIONS='--max-old-space-size=7168' docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
## Description

We've received feedback that using `yarn start` to preview the docs also encounters the `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` error that's observed during `yarn build`.

This PR applies the same [memory setting](https://github.com/rancher/rancher-docs/blob/main/package.json#L8) that we already have for `yarn build`.