### PR TITLE
SEO adjustments

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -216,7 +216,8 @@ module.exports = {
             '2.0-2.4': {
               label: 'v2.0-v2.4 (Archived)',
               path: 'v2.0-v2.4',
-              banner: 'none'
+              banner: 'none',
+              noIndex: true
             },
           },
         },

--- a/versioned_docs/version-2.5/getting-started/installation-and-upgrade/advanced-options/enable-experimental-features/rancher-on-arm64.md
+++ b/versioned_docs/version-2.5/getting-started/installation-and-upgrade/advanced-options/enable-experimental-features/rancher-on-arm64.md
@@ -2,6 +2,10 @@
 title: "Running on ARM64 (Experimental)"
 ---
 
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/enable-experimental-features/rancher-on-arm64"/>
+</head>
+
 > **Important:**
 >
 > Running on an ARM64 platform is currently an experimental feature and is not yet officially supported in Rancher. Therefore, we do not recommend using ARM64 based nodes in a production environment.


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher-docs/issues/1536

## Description

Adds a canonical link to the ARM page for 2.5 as it was being shown as the top search engine result.

Also, disable search engines from indexing the 2.0-2.4 docs since it's now archived.
