### PR TITLE
Review Fleet introduction

### DIFF
--- a/docs/integrations-in-rancher/fleet/overview.md
+++ b/docs/integrations-in-rancher/fleet/overview.md
@@ -6,10 +6,13 @@ title: Overview
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview"/>
 </head>
 
-Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/installation#configuration-for-multi-cluster). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
+## What is Continuous Delivery with Fleet?
 
-Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.
+Continuous Delivery is Rancher's GitOps functionality, which is provided via integration with Fleet.
 
+ - *Cluster engine*: Fleet is a container management and deployment engine designed to offer users more control on the local cluster and constant monitoring through GitOps. Fleet focuses not only on the ability to scale, but it also gives users a high degree of control and visibility to monitor exactly what is installed on the cluster.
+
+ - *Deployment management*: Fleet can manage deployments from git of raw Kubernetes YAML, Helm charts, Kustomize, or any combination of the three. Regardless of the source, all resources are dynamically turned into Helm charts, and Helm is used as the engine to deploy all resources in the cluster. As a result, users can enjoy a high degree of control, consistency, and auditability of their clusters.
 
 ## Architecture
 

--- a/versioned_docs/version-2.5/explanations/integrations-in-rancher/fleet-gitops-at-scale/fleet-gitops-at-scale.md
+++ b/versioned_docs/version-2.5/explanations/integrations-in-rancher/fleet-gitops-at-scale/fleet-gitops-at-scale.md
@@ -8,10 +8,13 @@ title: Continuous Delivery with Fleet
 
 _Available as of Rancher v2.5_
 
-Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/installation#configuration-for-multi-cluster). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
+## What is Continuous Delivery with Fleet?
 
-Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.
+Continuous Delivery is Rancher's GitOps functionality, which is provided via integration with Fleet.
 
+ - *Cluster engine*: Fleet is a container management and deployment engine designed to offer users more control on the local cluster and constant monitoring through GitOps. Fleet focuses not only on the ability to scale, but it also gives users a high degree of control and visibility to monitor exactly what is installed on the cluster.
+
+ - *Deployment management*: Fleet can manage deployments from git of raw Kubernetes YAML, Helm charts, Kustomize, or any combination of the three. Regardless of the source, all resources are dynamically turned into Helm charts, and Helm is used as the engine to deploy all resources in the cluster. As a result, users can enjoy a high degree of control, consistency, and auditability of their clusters.
 
 ## Architecture
 

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
@@ -8,10 +8,13 @@ title: Fleet - GitOps at Scale
 
 _Available as of Rancher v2.5_
 
-Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It's also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale.](https://fleet.rancher.io/installation#configuration-for-multi-cluster) By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
+## What is Continuous Delivery with Fleet?
 
-Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.
+Continuous Delivery is Rancher's GitOps functionality, which is provided via integration with Fleet.
 
+ - *Cluster engine*: Fleet is a container management and deployment engine designed to offer users more control on the local cluster and constant monitoring through GitOps. Fleet focuses not only on the ability to scale, but it also gives users a high degree of control and visibility to monitor exactly what is installed on the cluster.
+
+ - *Deployment management*: Fleet can manage deployments from git of raw Kubernetes YAML, Helm charts, Kustomize, or any combination of the three. Regardless of the source, all resources are dynamically turned into Helm charts, and Helm is used as the engine to deploy all resources in the cluster. As a result, users can enjoy a high degree of control, consistency, and auditability of their clusters.
 
 ## Architecture
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet.md
@@ -6,10 +6,13 @@ title: Continuous Delivery with Fleet
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet"/>
 </head>
 
-Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It's also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale.](https://fleet.rancher.io/installation#configuration-for-multi-cluster) By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
+## What is Continuous Delivery with Fleet?
 
-Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.
+Continuous Delivery is Rancher's GitOps functionality, which is provided via integration with Fleet.
 
+ - *Cluster engine*: Fleet is a container management and deployment engine designed to offer users more control on the local cluster and constant monitoring through GitOps. Fleet focuses not only on the ability to scale, but it also gives users a high degree of control and visibility to monitor exactly what is installed on the cluster.
+
+ - *Deployment management*: Fleet can manage deployments from git of raw Kubernetes YAML, Helm charts, Kustomize, or any combination of the three. Regardless of the source, all resources are dynamically turned into Helm charts, and Helm is used as the engine to deploy all resources in the cluster. As a result, users can enjoy a high degree of control, consistency, and auditability of their clusters.
 
 ## Architecture
 

--- a/versioned_docs/version-2.6/integrations-in-rancher/fleet-gitops-at-scale/fleet-gitops-at-scale.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/fleet-gitops-at-scale/fleet-gitops-at-scale.md
@@ -6,10 +6,13 @@ title: Continuous Delivery with Fleet
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet"/>
 </head>
 
-Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/installation#configuration-for-multi-cluster). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
+## What is Continuous Delivery with Fleet?
 
-Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.
+Continuous Delivery is Rancher's GitOps functionality, which is provided via integration with Fleet.
 
+ - *Cluster engine*: Fleet is a container management and deployment engine designed to offer users more control on the local cluster and constant monitoring through GitOps. Fleet focuses not only on the ability to scale, but it also gives users a high degree of control and visibility to monitor exactly what is installed on the cluster.
+
+ - *Deployment management*: Fleet can manage deployments from git of raw Kubernetes YAML, Helm charts, Kustomize, or any combination of the three. Regardless of the source, all resources are dynamically turned into Helm charts, and Helm is used as the engine to deploy all resources in the cluster. As a result, users can enjoy a high degree of control, consistency, and auditability of their clusters.
 
 ## Architecture
 

--- a/versioned_docs/version-2.7/integrations-in-rancher/fleet-gitops-at-scale/fleet-gitops-at-scale.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/fleet-gitops-at-scale/fleet-gitops-at-scale.md
@@ -6,10 +6,13 @@ title: Continuous Delivery with Fleet
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/deploy-apps-across-clusters/fleet"/>
 </head>
 
-Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/installation#configuration-for-multi-cluster). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
+## What is Continuous Delivery with Fleet?
 
-Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.
+Continuous Delivery is Rancher's GitOps functionality, which is provided via integration with Fleet.
 
+ - *Cluster engine*: Fleet is a container management and deployment engine designed to offer users more control on the local cluster and constant monitoring through GitOps. Fleet focuses not only on the ability to scale, but it also gives users a high degree of control and visibility to monitor exactly what is installed on the cluster.
+
+ - *Deployment management*: Fleet can manage deployments from git of raw Kubernetes YAML, Helm charts, Kustomize, or any combination of the three. Regardless of the source, all resources are dynamically turned into Helm charts, and Helm is used as the engine to deploy all resources in the cluster. As a result, users can enjoy a high degree of control, consistency, and auditability of their clusters.
 
 ## Architecture
 

--- a/versioned_docs/version-2.8/integrations-in-rancher/fleet/overview.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/fleet/overview.md
@@ -6,10 +6,13 @@ title: Overview
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview"/>
 </head>
 
-Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/installation#configuration-for-multi-cluster). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
+## What is Continuous Delivery with Fleet?
 
-Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.
+Continuous Delivery is Rancher's GitOps functionality, which is provided via integration with Fleet.
 
+ - *Cluster engine*: Fleet is a container management and deployment engine designed to offer users more control on the local cluster and constant monitoring through GitOps. Fleet focuses not only on the ability to scale, but it also gives users a high degree of control and visibility to monitor exactly what is installed on the cluster.
+
+ - *Deployment management*: Fleet can manage deployments from git of raw Kubernetes YAML, Helm charts, Kustomize, or any combination of the three. Regardless of the source, all resources are dynamically turned into Helm charts, and Helm is used as the engine to deploy all resources in the cluster. As a result, users can enjoy a high degree of control, consistency, and auditability of their clusters.
 
 ## Architecture
 

--- a/versioned_docs/version-2.9/integrations-in-rancher/fleet/overview.md
+++ b/versioned_docs/version-2.9/integrations-in-rancher/fleet/overview.md
@@ -6,10 +6,13 @@ title: Overview
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview"/>
 </head>
 
-Continuous Delivery with Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. It’s also lightweight enough that it works great for a [single cluster](https://fleet.rancher.io/installation#default-install) too, but it really shines when you get to a [large scale](https://fleet.rancher.io/installation#configuration-for-multi-cluster). By large scale we mean either a lot of clusters, a lot of deployments, or a lot of teams in a single organization.
+## What is Continuous Delivery with Fleet?
 
-Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.
+Continuous Delivery is Rancher's GitOps functionality, which is provided via integration with Fleet.
 
+ - *Cluster engine*: Fleet is a container management and deployment engine designed to offer users more control on the local cluster and constant monitoring through GitOps. Fleet focuses not only on the ability to scale, but it also gives users a high degree of control and visibility to monitor exactly what is installed on the cluster.
+
+ - *Deployment management*: Fleet can manage deployments from git of raw Kubernetes YAML, Helm charts, Kustomize, or any combination of the three. Regardless of the source, all resources are dynamically turned into Helm charts, and Helm is used as the engine to deploy all resources in the cluster. As a result, users can enjoy a high degree of control, consistency, and auditability of their clusters.
 
 ## Architecture
 


### PR DESCRIPTION
## Description

The current introduction paragraph to Fleet has multiple issues:
 - it claims outdated scalability claims that we have removed from websites and other documentation years ago (https://github.com/rancher/fleet-docs/commit/fc7bd30cf183695a39ebff75a87700a451ee4a4f)
 - it points to Fleet standalone installation instructions, which is misleading given this guide is all about integration in Rancher
 - it reiterates that Fleet is a standalone project. While true from a source code perspective, our current direction when it comes to users is to present it as an integrated functionality in Rancher

I removed the paragraph altogether and replaced it with the current introduction we give in [current official fleet docs](https://github.com/rancher/fleet-docs/blob/92675a9c46c67a74ad5d117c9c93ceb108f8f694/docs/index.md).

