### PR TITLE
FAQ: update messaging around Vault support

### DIFF
--- a/docs/faq/general-faq.md
+++ b/docs/faq/general-faq.md
@@ -24,7 +24,7 @@ Yes. Rancher supports [Istio](../integrations-in-rancher/istio/istio.md).
 
 ## Will Rancher v2.x support Hashicorp's Vault for storing secrets?
 
-Secrets management is on our roadmap but we haven't assigned it to a specific release yet.
+As of Rancher v2.9, Rancher [supports authentication with service account tokens](../how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/jwt-authentication.md), which is used by Vault and other integrations.
 
 ## Does Rancher v2.x support RKT containers as well?
 

--- a/versioned_docs/version-2.10/faq/general-faq.md
+++ b/versioned_docs/version-2.10/faq/general-faq.md
@@ -24,6 +24,8 @@ Yes. Rancher supports [Istio](../integrations-in-rancher/istio/istio.md).
 
 ## Will Rancher v2.x support Hashicorp's Vault for storing secrets?
 
+As of Rancher v2.9, Rancher [supports authentication with service account tokens](../how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/jwt-authentication.md), which is used by Vault and other integrations.
+
 Secrets management is on our roadmap but we haven't assigned it to a specific release yet.
 
 ## Does Rancher v2.x support RKT containers as well?

--- a/versioned_docs/version-2.9/faq/general-faq.md
+++ b/versioned_docs/version-2.9/faq/general-faq.md
@@ -24,7 +24,7 @@ Yes. Rancher supports [Istio](../integrations-in-rancher/istio/istio.md).
 
 ## Will Rancher v2.x support Hashicorp's Vault for storing secrets?
 
-Secrets management is on our roadmap but we haven't assigned it to a specific release yet.
+As of Rancher v2.9, Rancher [supports authentication with service account tokens](../how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/jwt-authentication.md), which is used by Vault and other integrations.
 
 ## Does Rancher v2.x support RKT containers as well?
 


### PR DESCRIPTION
Fixes #1373
SURE-8340

## Description

#1402 was initially opened to address the primary content update when service account token auth support was introduced, but our FAQ had an entry referencing Vault support that needed to be updated as well per https://github.com/rancher/rancher-docs/issues/1373#issuecomment-2276531636. This PR addresses the supplemental update to the FAQ around Vault's support status that led to #1373 being reopened.  
