### PR TITLE
Remove extra image captions

### DIFF
--- a/archived_docs/en/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/archived_docs/en/version-2.0-2.4/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -23,7 +23,5 @@ For information on how Rancher works, regardless of the installation method, ref
 - The Ingress controller will redirect HTTP to HTTPS and terminate SSL/TLS on port TCP/443.
 - The Ingress controller will forward traffic to port TCP/80 on the pod in the Rancher deployment.
 
-<figcaption>Kubernetes Rancher install with layer 4 load balancer, depicting SSL termination at ingress controllers</figcaption>
-
 ![High-availability Kubernetes Installation of Rancher](/img/ha/rancher2ha.svg)
 <sup>Kubernetes Rancher install with Layer 4 load balancer (TCP), depicting SSL termination at ingress controllers</sup>

--- a/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -23,7 +23,5 @@ For information on how Rancher works, regardless of the installation method, ref
 - The Ingress controller will redirect HTTP to HTTPS and terminate SSL/TLS on port TCP/443.
 - The Ingress controller will forward traffic to port TCP/80 on the pod in the Rancher deployment.
 
-<figcaption>Kubernetes Rancher install with layer 4 load balancer, depicting SSL termination at ingress controllers</figcaption>
-
 ![High-availability Kubernetes Installation of Rancher](/img/ha/rancher2ha.svg)
 <sup>Kubernetes Rancher install with Layer 4 load balancer (TCP), depicting SSL termination at ingress controllers</sup>

--- a/docs/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
+++ b/docs/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
@@ -61,9 +61,6 @@ Once Prometheus determines that an alert needs to be fired, alerts are forwarded
 
 - Routes and receivers are also stored in the Kubernetes API via the Alertmanager Secret. When the Secret is updated, Alertmanager is also updated automatically. Note that routing occurs via labels only (not via annotations, etc.).
 
-<figcaption>How data flows through the monitoring application:</figcaption>
-
-
 ## 2. How Prometheus Works
 
 ### Storing Time Series Data

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -19,7 +19,5 @@ Rancher Server 的数据存储在 etcd 中。etcd 数据库可以在所有三个
 - Ingress Controller 会把 HTTP 重定向到 HTTPS，在 TCP/443 端口终结 SSL/TLS。
 - Ingress Controller 会把流量转发到 Rancher deployment 的 Pod 上的 TCP/80 端口。
 
-<figcaption>使用 4 层负载均衡器在 Kubernetes 集群中安装 Rancher：Ingress Controller 的 SSL 终止：</figcaption>
-
 ![Rancher 的高可用 Kubernetes 安装](/img/ha/rancher2ha.svg)
 <sup>使用 4 层负载均衡器在 Kubernetes 集群中安装 Rancher：Ingress Controller 的 SSL 终止</sup>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
@@ -56,9 +56,6 @@ PrometheusRule 用于定义指标或时间序列数据库查询触发告警的�
 
 - 路由和接收器也通过 Alertmanager Secret 存储在 Kubernetes API 中。当 Secret 更新时，Alertmanager 也会自动更新。请注意，路由仅通过标签发生（而不是通过注释等）。
 
-<figcaption>数据如何流经 Monitoring 应用程序</figcaption>
-
-
 ## 2. Prometheus 的工作原理
 
 ### 存储时间序列数据

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.10/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.10/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -19,7 +19,5 @@ Rancher Server 的数据存储在 etcd 中。etcd 数据库可以在所有三个
 - Ingress Controller 会把 HTTP 重定向到 HTTPS，在 TCP/443 端口终结 SSL/TLS。
 - Ingress Controller 会把流量转发到 Rancher deployment 的 Pod 上的 TCP/80 端口。
 
-<figcaption>使用 4 层负载均衡器在 Kubernetes 集群中安装 Rancher：Ingress Controller 的 SSL 终止：</figcaption>
-
 ![Rancher 的高可用 Kubernetes 安装](/img/ha/rancher2ha.svg)
 <sup>使用 4 层负载均衡器在 Kubernetes 集群中安装 Rancher：Ingress Controller 的 SSL 终止</sup>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.10/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.10/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
@@ -56,9 +56,6 @@ PrometheusRule 用于定义指标或时间序列数据库查询触发告警的�
 
 - 路由和接收器也通过 Alertmanager Secret 存储在 Kubernetes API 中。当 Secret 更新时，Alertmanager 也会自动更新。请注意，路由仅通过标签发生（而不是通过注释等）。
 
-<figcaption>数据如何流经 Monitoring 应用程序</figcaption>
-
-
 ## 2. Prometheus 的工作原理
 
 ### 存储时间序列数据

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -19,7 +19,5 @@ Rancher Server 的数据存储在 etcd 中。etcd 数据库可以在所有三个
 - Ingress Controller 会把 HTTP 重定向到 HTTPS，在 TCP/443 端口终结 SSL/TLS。
 - Ingress Controller 会把流量转发到 Rancher deployment 的 Pod 上的 TCP/80 端口。
 
-<figcaption>使用 4 层负载均衡器在 Kubernetes 集群中安装 Rancher：Ingress Controller 的 SSL 终止：</figcaption>
-
 ![Rancher 的高可用 Kubernetes 安装](/img/ha/rancher2ha.svg)
 <sup>使用 4 层负载均衡器在 Kubernetes 集群中安装 Rancher：Ingress Controller 的 SSL 终止</sup>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
@@ -56,9 +56,6 @@ PrometheusRule 用于定义指标或时间序列数据库查询触发告警的�
 
 - 路由和接收器也通过 Alertmanager Secret 存储在 Kubernetes API 中。当 Secret 更新时，Alertmanager 也会自动更新。请注意，路由仅通过标签发生（而不是通过注释等）。
 
-<figcaption>数据如何流经 Monitoring 应用程序</figcaption>
-
-
 ## 2. Prometheus 的工作原理
 
 ### 存储时间序列数据

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -19,7 +19,5 @@ Rancher Server 的数据存储在 etcd 中。etcd 数据库可以在所有三个
 - Ingress Controller 会把 HTTP 重定向到 HTTPS，在 TCP/443 端口终结 SSL/TLS。
 - Ingress Controller 会把流量转发到 Rancher deployment 的 Pod 上的 TCP/80 端口。
 
-<figcaption>使用 4 层负载均衡器在 Kubernetes 集群中安装 Rancher：Ingress Controller 的 SSL 终止：</figcaption>
-
 ![Rancher 的高可用 Kubernetes 安装](/img/ha/rancher2ha.svg)
 <sup>使用 4 层负载均衡器在 Kubernetes 集群中安装 Rancher：Ingress Controller 的 SSL 终止</sup>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
@@ -56,9 +56,6 @@ PrometheusRule 用于定义指标或时间序列数据库查询触发告警的�
 
 - 路由和接收器也通过 Alertmanager Secret 存储在 Kubernetes API 中。当 Secret 更新时，Alertmanager 也会自动更新。请注意，路由仅通过标签发生（而不是通过注释等）。
 
-<figcaption>数据如何流经 Monitoring 应用程序</figcaption>
-
-
 ## 2. Prometheus 的工作原理
 
 ### 存储时间序列数据

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.8/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.8/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -19,7 +19,5 @@ Rancher Server 的数据存储在 etcd 中。etcd 数据库可以在所有三个
 - Ingress Controller 会把 HTTP 重定向到 HTTPS，在 TCP/443 端口终结 SSL/TLS。
 - Ingress Controller 会把流量转发到 Rancher deployment 的 Pod 上的 TCP/80 端口。
 
-<figcaption>使用 4 层负载均衡器在 Kubernetes 集群中安装 Rancher：Ingress Controller 的 SSL 终止：</figcaption>
-
 ![Rancher 的高可用 Kubernetes 安装](/img/ha/rancher2ha.svg)
 <sup>使用 4 层负载均衡器在 Kubernetes 集群中安装 Rancher：Ingress Controller 的 SSL 终止</sup>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.8/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.8/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
@@ -56,9 +56,6 @@ PrometheusRule 用于定义指标或时间序列数据库查询触发告警的�
 
 - 路由和接收器也通过 Alertmanager Secret 存储在 Kubernetes API 中。当 Secret 更新时，Alertmanager 也会自动更新。请注意，路由仅通过标签发生（而不是通过注释等）。
 
-<figcaption>数据如何流经 Monitoring 应用程序</figcaption>
-
-
 ## 2. Prometheus 的工作原理
 
 ### 存储时间序列数据

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.9/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.9/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -19,7 +19,5 @@ Rancher Server 的数据存储在 etcd 中。etcd 数据库可以在所有三个
 - Ingress Controller 会把 HTTP 重定向到 HTTPS，在 TCP/443 端口终结 SSL/TLS。
 - Ingress Controller 会把流量转发到 Rancher deployment 的 Pod 上的 TCP/80 端口。
 
-<figcaption>使用 4 层负载均衡器在 Kubernetes 集群中安装 Rancher：Ingress Controller 的 SSL 终止：</figcaption>
-
 ![Rancher 的高可用 Kubernetes 安装](/img/ha/rancher2ha.svg)
 <sup>使用 4 层负载均衡器在 Kubernetes 集群中安装 Rancher：Ingress Controller 的 SSL 终止</sup>

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.9/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.9/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
@@ -56,9 +56,6 @@ PrometheusRule 用于定义指标或时间序列数据库查询触发告警的�
 
 - 路由和接收器也通过 Alertmanager Secret 存储在 Kubernetes API 中。当 Secret 更新时，Alertmanager 也会自动更新。请注意，路由仅通过标签发生（而不是通过注释等）。
 
-<figcaption>数据如何流经 Monitoring 应用程序</figcaption>
-
-
 ## 2. Prometheus 的工作原理
 
 ### 存储时间序列数据

--- a/versioned_docs/version-2.10/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/versioned_docs/version-2.10/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -23,7 +23,5 @@ For information on how Rancher works, regardless of the installation method, ref
 - The Ingress controller will redirect HTTP to HTTPS and terminate SSL/TLS on port TCP/443.
 - The Ingress controller will forward traffic to port TCP/80 on the pod in the Rancher deployment.
 
-<figcaption>Kubernetes Rancher install with layer 4 load balancer, depicting SSL termination at ingress controllers</figcaption>
-
 ![High-availability Kubernetes Installation of Rancher](/img/ha/rancher2ha.svg)
 <sup>Kubernetes Rancher install with Layer 4 load balancer (TCP), depicting SSL termination at ingress controllers</sup>

--- a/versioned_docs/version-2.10/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
+++ b/versioned_docs/version-2.10/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
@@ -61,9 +61,6 @@ Once Prometheus determines that an alert needs to be fired, alerts are forwarded
 
 - Routes and receivers are also stored in the Kubernetes API via the Alertmanager Secret. When the Secret is updated, Alertmanager is also updated automatically. Note that routing occurs via labels only (not via annotations, etc.).
 
-<figcaption>How data flows through the monitoring application:</figcaption>
-
-
 ## 2. How Prometheus Works
 
 ### Storing Time Series Data

--- a/versioned_docs/version-2.5/explanations/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
+++ b/versioned_docs/version-2.5/explanations/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
@@ -61,9 +61,6 @@ Once Prometheus determines that an alert needs to be fired, alerts are forwarded
 
 - Routes and receivers are also stored in the Kubernetes API via the Alertmanager Secret. When the Secret is updated, Alertmanager is also updated automatically. Note that routing occurs via labels only (not via annotations, etc.).
 
-<figcaption>How data flows through the monitoring application:</figcaption>
-
-
 ## 2. How Prometheus Works
 
 ### Storing Time Series Data

--- a/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/versioned_docs/version-2.5/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -23,7 +23,5 @@ For information on how Rancher works, regardless of the installation method, ref
 - The Ingress controller will redirect HTTP to HTTPS and terminate SSL/TLS on port TCP/443.
 - The Ingress controller will forward traffic to port TCP/80 on the pod in the Rancher deployment.
 
-<figcaption>Kubernetes Rancher install with layer 4 load balancer, depicting SSL termination at ingress controllers</figcaption>
-
 ![High-availability Kubernetes Installation of Rancher](/img/ha/rancher2ha.svg)
 <sup>Kubernetes Rancher install with Layer 4 load balancer (TCP), depicting SSL termination at ingress controllers</sup>

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -23,7 +23,5 @@ For information on how Rancher works, regardless of the installation method, ref
 - The Ingress controller will redirect HTTP to HTTPS and terminate SSL/TLS on port TCP/443.
 - The Ingress controller will forward traffic to port TCP/80 on the pod in the Rancher deployment.
 
-<figcaption>Kubernetes Rancher install with layer 4 load balancer, depicting SSL termination at ingress controllers</figcaption>
-
 ![High-availability Kubernetes Installation of Rancher](/img/ha/rancher2ha.svg)
 <sup>Kubernetes Rancher install with Layer 4 load balancer (TCP), depicting SSL termination at ingress controllers</sup>

--- a/versioned_docs/version-2.6/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
@@ -61,9 +61,6 @@ Once Prometheus determines that an alert needs to be fired, alerts are forwarded
 
 - Routes and receivers are also stored in the Kubernetes API via the Alertmanager Secret. When the Secret is updated, Alertmanager is also updated automatically. Note that routing occurs via labels only (not via annotations, etc.).
 
-<figcaption>How data flows through the monitoring application:</figcaption>
-
-
 ## 2. How Prometheus Works
 
 ### Storing Time Series Data

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -23,7 +23,5 @@ For information on how Rancher works, regardless of the installation method, ref
 - The Ingress controller will redirect HTTP to HTTPS and terminate SSL/TLS on port TCP/443.
 - The Ingress controller will forward traffic to port TCP/80 on the pod in the Rancher deployment.
 
-<figcaption>Kubernetes Rancher install with layer 4 load balancer, depicting SSL termination at ingress controllers</figcaption>
-
 ![High-availability Kubernetes Installation of Rancher](/img/ha/rancher2ha.svg)
 <sup>Kubernetes Rancher install with Layer 4 load balancer (TCP), depicting SSL termination at ingress controllers</sup>

--- a/versioned_docs/version-2.7/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
@@ -61,9 +61,6 @@ Once Prometheus determines that an alert needs to be fired, alerts are forwarded
 
 - Routes and receivers are also stored in the Kubernetes API via the Alertmanager Secret. When the Secret is updated, Alertmanager is also updated automatically. Note that routing occurs via labels only (not via annotations, etc.).
 
-<figcaption>How data flows through the monitoring application:</figcaption>
-
-
 ## 2. How Prometheus Works
 
 ### Storing Time Series Data

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -23,7 +23,5 @@ For information on how Rancher works, regardless of the installation method, ref
 - The Ingress controller will redirect HTTP to HTTPS and terminate SSL/TLS on port TCP/443.
 - The Ingress controller will forward traffic to port TCP/80 on the pod in the Rancher deployment.
 
-<figcaption>Kubernetes Rancher install with layer 4 load balancer, depicting SSL termination at ingress controllers</figcaption>
-
 ![High-availability Kubernetes Installation of Rancher](/img/ha/rancher2ha.svg)
 <sup>Kubernetes Rancher install with Layer 4 load balancer (TCP), depicting SSL termination at ingress controllers</sup>

--- a/versioned_docs/version-2.8/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
@@ -61,9 +61,6 @@ Once Prometheus determines that an alert needs to be fired, alerts are forwarded
 
 - Routes and receivers are also stored in the Kubernetes API via the Alertmanager Secret. When the Secret is updated, Alertmanager is also updated automatically. Note that routing occurs via labels only (not via annotations, etc.).
 
-<figcaption>How data flows through the monitoring application:</figcaption>
-
-
 ## 2. How Prometheus Works
 
 ### Storing Time Series Data

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/kubernetes-cluster-setup/high-availability-installs.md
@@ -23,7 +23,5 @@ For information on how Rancher works, regardless of the installation method, ref
 - The Ingress controller will redirect HTTP to HTTPS and terminate SSL/TLS on port TCP/443.
 - The Ingress controller will forward traffic to port TCP/80 on the pod in the Rancher deployment.
 
-<figcaption>Kubernetes Rancher install with layer 4 load balancer, depicting SSL termination at ingress controllers</figcaption>
-
 ![High-availability Kubernetes Installation of Rancher](/img/ha/rancher2ha.svg)
 <sup>Kubernetes Rancher install with Layer 4 load balancer (TCP), depicting SSL termination at ingress controllers</sup>

--- a/versioned_docs/version-2.9/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
+++ b/versioned_docs/version-2.9/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.md
@@ -61,9 +61,6 @@ Once Prometheus determines that an alert needs to be fired, alerts are forwarded
 
 - Routes and receivers are also stored in the Kubernetes API via the Alertmanager Secret. When the Secret is updated, Alertmanager is also updated automatically. Note that routing occurs via labels only (not via annotations, etc.).
 
-<figcaption>How data flows through the monitoring application:</figcaption>
-
-
 ## 2. How Prometheus Works
 
 ### Storing Time Series Data


### PR DESCRIPTION
## Description

The image on `high-availability-installs.md` has 2 captions with the same text. One with `<figcaption>`, but the resulting rendering is indistinguishable from regular paragraph text. The other uses `<sup>` to try and emulate an actual caption. I opted to remove the `<figcaption>` instance due to the lack of formatting.

On `how-monitoring-works.md`, there's a figcaption instance that has no image surrounding it.