### PR TITLE
Add prerequisite for AKS import

### DIFF
--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -35,6 +35,8 @@ Since, by default, Google Kubernetes Engine (GKE) doesn't grant the `cluster-adm
 
 To successfully import or provision EKS, AKS, and GKE clusters from Rancher, the cluster must have at least one managed node group. 
 
+AKS clusters can be imported only if local accounts are enabled. If a cluster is configured to use Microsoft Entra ID for authentication, then Rancher will not be able to import it and report an error.
+
 EKS Anywhere clusters can be imported/registered into Rancher with an API address and credentials, as with any downstream cluster. EKS Anywhere clusters are treated as imported clusters and do not have full lifecycle support from Rancher. 
 
 GKE Autopilot clusters aren't supported. See [Compare GKE Autopilot and Standard](https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison) for more information about the differences between GKE modes.
@@ -286,3 +288,17 @@ To annotate a registered cluster,
 6. Click **Save**.
 
 **Result:** The annotation does not give the capabilities to the cluster, but it does indicate to Rancher that the cluster has those capabilities.
+
+## Troubleshooting
+
+This section lists some of the most common errors that may occur when importing a cluster, along with steps to troubleshoot them.
+
+### AKS
+
+#### Error: Getting static credential is not allowed because this cluster is set to disable local accounts.
+
+* This may occur if your cluster has disabled local accounts. Enable local accounts before attempting to import the cluster again:
+
+  ```
+  az aks update --resource-group <resource-group> --name <cluster-name> --enable-local-accounts
+  ```

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -291,13 +291,15 @@ To annotate a registered cluster,
 
 ## Troubleshooting
 
-This section lists some of the most common errors that may occur when importing a cluster, along with steps to troubleshoot them.
+This section lists some of the most common errors that may occur when importing a cluster and provides steps to troubleshoot them.
 
 ### AKS
 
-- The following error  may occur if local accounts are disabled in your cluster.
+- The following error may occur if local accounts are disabled in your cluster.
   ```sh
   Error: Getting static credential is not allowed because this cluster is set to disable local accounts.
+  ```
+
   To resolve this issue, enable local accounts before attempting to [import the cluster](#registering-a-cluster) again.
 
     ```sh

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -35,7 +35,7 @@ Since, by default, Google Kubernetes Engine (GKE) doesn't grant the `cluster-adm
 
 To successfully import or provision EKS, AKS, and GKE clusters from Rancher, the cluster must have at least one managed node group. 
 
-AKS clusters can be imported only if local accounts are enabled. If a cluster is configured to use Microsoft Entra ID for authentication, then Rancher will not be able to import it and report an error.
+AKS clusters can only be imported if local accounts are enabled. If a cluster is configured to use Microsoft Entra ID for authentication, Rancher will not be able to import the cluster and report an error.
 
 EKS Anywhere clusters can be imported/registered into Rancher with an API address and credentials, as with any downstream cluster. EKS Anywhere clusters are treated as imported clusters and do not have full lifecycle support from Rancher. 
 
@@ -295,10 +295,11 @@ This section lists some of the most common errors that may occur when importing 
 
 ### AKS
 
-#### Error: Getting static credential is not allowed because this cluster is set to disable local accounts.
+- The following error  may occur if local accounts are disabled in your cluster.
+  ```sh
+  Error: Getting static credential is not allowed because this cluster is set to disable local accounts.
+  To resolve this issue, enable local accounts before attempting to [import the cluster](#registering-a-cluster) again.
 
-* This may occur if your cluster has disabled local accounts. Enable local accounts before attempting to import the cluster again:
-
-  ```
-  az aks update --resource-group <resource-group> --name <cluster-name> --enable-local-accounts
-  ```
+    ```sh
+    az aks update --resource-group <resource-group> --name <cluster-name> --enable-local-accounts
+    ```

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration.md
@@ -8,7 +8,7 @@ title: AKS Cluster Configuration Reference
 
 ## Role-based Access Control
 
-When provisioning an AKS cluster in the Rancher UI, RBAC cannot be disabled. If role-based access control is disabled for the cluster in AKS, the cluster cannot be registered or imported into Rancher.
+When provisioning an AKS cluster in the Rancher UI, RBAC cannot be disabled. If role-based access control is disabled for the cluster in AKS, the cluster cannot be registered or imported into Rancher. In practice, this means that local accounts must be enabled in order to register an AKS cluster.  
 
 Rancher can configure member roles for AKS clusters in the same way as any other cluster. For more information, see the section on [role-based access control.](../../../how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.md)
 

--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration.md
@@ -8,7 +8,7 @@ title: AKS Cluster Configuration Reference
 
 ## Role-based Access Control
 
-When provisioning an AKS cluster in the Rancher UI, RBAC cannot be disabled. If role-based access control is disabled for the cluster in AKS, the cluster cannot be registered or imported into Rancher. In practice, this means that local accounts must be enabled in order to register an AKS cluster.  
+When provisioning an AKS cluster in the Rancher UI, RBAC cannot be disabled. If RBAC is disabled in the AKS cluster, the cluster cannot be registered or imported into Rancher. In practice, this means that local accounts must be enabled in order to register or import an AKS cluster. 
 
 Rancher can configure member roles for AKS clusters in the same way as any other cluster. For more information, see the section on [role-based access control.](../../../how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.md)
 

--- a/versioned_docs/version-2.10/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.10/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -35,6 +35,8 @@ Since, by default, Google Kubernetes Engine (GKE) doesn't grant the `cluster-adm
 
 To successfully import or provision EKS, AKS, and GKE clusters from Rancher, the cluster must have at least one managed node group. 
 
+AKS clusters can be imported only if local accounts are enabled. If a cluster is configured to use Microsoft Entra ID for authentication, then Rancher will not be able to import it and report an error.
+
 EKS Anywhere clusters can be imported/registered into Rancher with an API address and credentials, as with any downstream cluster. EKS Anywhere clusters are treated as imported clusters and do not have full lifecycle support from Rancher. 
 
 GKE Autopilot clusters aren't supported. See [Compare GKE Autopilot and Standard](https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison) for more information about the differences between GKE modes.
@@ -286,3 +288,17 @@ To annotate a registered cluster,
 6. Click **Save**.
 
 **Result:** The annotation does not give the capabilities to the cluster, but it does indicate to Rancher that the cluster has those capabilities.
+
+## Troubleshooting
+
+This section lists some of the most common errors that may occur when importing a cluster, along with steps to troubleshoot them.
+
+### AKS
+
+#### Error: Getting static credential is not allowed because this cluster is set to disable local accounts.
+
+* This may occur if your cluster has disabled local accounts. Enable local accounts before attempting to import the cluster again:
+
+  ```
+  az aks update --resource-group <resource-group> --name <cluster-name> --enable-local-accounts
+  ```

--- a/versioned_docs/version-2.10/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.10/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -295,10 +295,13 @@ This section lists some of the most common errors that may occur when importing 
 
 ### AKS
 
-#### Error: Getting static credential is not allowed because this cluster is set to disable local accounts.
-
-* This may occur if your cluster has disabled local accounts. Enable local accounts before attempting to import the cluster again:
-
+- The following error may occur if local accounts are disabled in your cluster.
+  ```sh
+  Error: Getting static credential is not allowed because this cluster is set to disable local accounts.
   ```
+
+  To resolve this issue, enable local accounts before attempting to [import the cluster](#registering-a-cluster) again.
+
+  ```sh
   az aks update --resource-group <resource-group> --name <cluster-name> --enable-local-accounts
   ```

--- a/versioned_docs/version-2.10/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration.md
+++ b/versioned_docs/version-2.10/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration.md
@@ -8,7 +8,7 @@ title: AKS Cluster Configuration Reference
 
 ## Role-based Access Control
 
-When provisioning an AKS cluster in the Rancher UI, RBAC cannot be disabled. If role-based access control is disabled for the cluster in AKS, the cluster cannot be registered or imported into Rancher.
+When provisioning an AKS cluster in the Rancher UI, RBAC cannot be disabled. If role-based access control is disabled for the cluster in AKS, the cluster cannot be registered or imported into Rancher. In practice, this means that local accounts must be enabled in order to register an AKS cluster.
 
 Rancher can configure member roles for AKS clusters in the same way as any other cluster. For more information, see the section on [role-based access control.](../../../how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.md)
 

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -291,14 +291,17 @@ To annotate a registered cluster,
 
 ## Troubleshooting
 
-This section lists some of the most common errors that may occur when importing a cluster, along with steps to troubleshoot them.
+This section lists some of the most common errors that may occur when importing a cluster and provides steps to troubleshoot them.
 
 ### AKS
 
-#### Error: Getting static credential is not allowed because this cluster is set to disable local accounts.
-
-* This may occur if your cluster has disabled local accounts. Enable local accounts before attempting to import the cluster again:
-
+- The following error may occur if local accounts are disabled in your cluster.
+  ```sh
+  Error: Getting static credential is not allowed because this cluster is set to disable local accounts. 
   ```
+
+  To resolve this issue, enable local accounts before attempting to [import the cluster](#registering-a-cluster) again.
+
+  ```sh
   az aks update --resource-group <resource-group> --name <cluster-name> --enable-local-accounts
   ```

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -35,6 +35,8 @@ Since, by default, Google Kubernetes Engine (GKE) doesn't grant the `cluster-adm
 
 To successfully import or provision EKS, AKS, and GKE clusters from Rancher, the cluster must have at least one managed node group. 
 
+AKS clusters can be imported only if local accounts are enabled. If a cluster is configured to use Microsoft Entra ID for authentication, then Rancher will not be able to import it and report an error.
+
 EKS Anywhere clusters can be imported/registered into Rancher with an API address and credentials, as with any downstream cluster. EKS Anywhere clusters are treated as imported clusters and do not have full lifecycle support from Rancher. 
 
 GKE Autopilot clusters aren't supported. See [Compare GKE Autopilot and Standard](https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison) for more information about the differences between GKE modes.
@@ -286,3 +288,17 @@ To annotate a registered cluster,
 6. Click **Save**.
 
 **Result:** The annotation does not give the capabilities to the cluster, but it does indicate to Rancher that the cluster has those capabilities.
+
+## Troubleshooting
+
+This section lists some of the most common errors that may occur when importing a cluster, along with steps to troubleshoot them.
+
+### AKS
+
+#### Error: Getting static credential is not allowed because this cluster is set to disable local accounts.
+
+* This may occur if your cluster has disabled local accounts. Enable local accounts before attempting to import the cluster again:
+
+  ```
+  az aks update --resource-group <resource-group> --name <cluster-name> --enable-local-accounts
+  ```

--- a/versioned_docs/version-2.9/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration.md
+++ b/versioned_docs/version-2.9/reference-guides/cluster-configuration/rancher-server-configuration/aks-cluster-configuration.md
@@ -8,7 +8,7 @@ title: AKS Cluster Configuration Reference
 
 ## Role-based Access Control
 
-When provisioning an AKS cluster in the Rancher UI, RBAC cannot be disabled. If role-based access control is disabled for the cluster in AKS, the cluster cannot be registered or imported into Rancher.
+When provisioning an AKS cluster in the Rancher UI, RBAC cannot be disabled. If role-based access control is disabled for the cluster in AKS, the cluster cannot be registered or imported into Rancher. In practice, this means that local accounts must be enabled in order to register an AKS cluster.
 
 Rancher can configure member roles for AKS clusters in the same way as any other cluster. For more information, see the section on [role-based access control.](../../../how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.md)
 


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes https://github.com/rancher/aks-operator/issues/743

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, remember to add a "MERGE ON RELEASE" label and set the proper milestone.

## Description

This PR adds a prerequisite as well as a troubleshooting section for importing AKS clusters.

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->
