### PR TITLE
Detail resourceset usage in Backup docs

### DIFF
--- a/docs/reference-guides/backup-restore-configuration/backup-configuration.md
+++ b/docs/reference-guides/backup-restore-configuration/backup-configuration.md
@@ -31,7 +31,7 @@ While you can create your own ResourceSets to back up custom applications, two R
 
 `rancher-resource-set-basic` does not include any secrets in the backup files to safeguard confidential information. You are responsible for recording any secrets and redeploying them safely. 
 
-The full option, however, backs up all essential Secrets to ensure Rancher continues running smoothly after a restore or migration. In this case the user is heavily advised to enable encryption with a strong key to prevent sensitive information from being stored in plain-text.
+`rancher-resource-set-full` includes all essential secrets in the backup files to ensure Rancher continues running smoothly after a restore or migration. To avoid storing sensitive information in plain text, we strongly advise you to enable encryption with a strong key.
 
 :::note Important:
 

--- a/docs/reference-guides/backup-restore-configuration/backup-configuration.md
+++ b/docs/reference-guides/backup-restore-configuration/backup-configuration.md
@@ -35,7 +35,7 @@ While you can create your own ResourceSets to back up custom applications, two R
 
 :::note Important:
 
-A third resourceSet `rancher-resource-set` is also included by default with the Operator. This is a legacy definition, currently deprecated and no longer maintained, being kept only for compatibility reasons. It will be removed in Rancher v2.12. Please update your Backup CRs to use either `rancher-resource-set-full` or `rancher-resource-set-basic`.
+`rancher-resource-set` is also included by default with the `rancher-backup` operator. However, this ResourceSet is deprecated and is only being kept for backwards compatibility reasons. `rancher-resource-set` will be removed in Rancher v2.12. Please update your Backup custom resources to use either `rancher-resource-set-full` or `rancher-resource-set-basic`.
 
 :::
 

--- a/docs/reference-guides/backup-restore-configuration/backup-configuration.md
+++ b/docs/reference-guides/backup-restore-configuration/backup-configuration.md
@@ -29,7 +29,7 @@ Select the first option to perform a one-time backup, or select the second optio
 
 While you can create your own ResourceSets to back up custom applications, two ResourceSets specifically for backing up Rancher are officially maintained and created by default by the `rancher-backup` operator. We refer to these as `rancher-resource-set-basic` and `rancher-resource-set-full`.  The difference between them is whether they include secrets or not in the backups. 
 
-When choosing the basic option, no Kubernetes Secrets will be backed up to prevent confidential information from being inserted in the backup files, so the user is responsible for keeping and re-deploying them safely. 
+`rancher-resource-set-basic` does not include any secrets in the backup files to safeguard confidential information. You are responsible for recording any secrets and redeploying them safely. 
 
 The full option, however, backs up all essential Secrets to ensure Rancher continues running smoothly after a restore or migration. In this case the user is heavily advised to enable encryption with a strong key to prevent sensitive information from being stored in plain-text.
 

--- a/docs/reference-guides/backup-restore-configuration/backup-configuration.md
+++ b/docs/reference-guides/backup-restore-configuration/backup-configuration.md
@@ -27,7 +27,7 @@ Select the first option to perform a one-time backup, or select the second optio
 
 ## ResourceSet
 
-While users can create their own resourceSets to backup custom applications, two resourceSets for backing up Rancher itself are officially maintained and are created by default with the `rancher-backup` operator. These are called `rancher-resource-set-basic` and `rancher-resource-set-full`. The difference between them is whether they include secrets or not in the backups. 
+While you can create your own ResourceSets to back up custom applications, two ResourceSets specifically for backing up Rancher are officially maintained and created by default by the `rancher-backup` operator. We refer to these as `rancher-resource-set-basic` and `rancher-resource-set-full`.  The difference between them is whether they include secrets or not in the backups. 
 
 When choosing the basic option, no Kubernetes Secrets will be backed up to prevent confidential information from being inserted in the backup files, so the user is responsible for keeping and re-deploying them safely. 
 

--- a/docs/reference-guides/backup-restore-configuration/backup-configuration.md
+++ b/docs/reference-guides/backup-restore-configuration/backup-configuration.md
@@ -25,6 +25,24 @@ Select the first option to perform a one-time backup, or select the second optio
 | `schedule` |  Provide the cron string for scheduling recurring backups.  |
 | `retentionCount` |  Provide the number of backup files to be retained.  |
 
+## ResourceSet
+
+While users can create their own resourceSets to backup custom applications, two resourceSets for backing up Rancher itself are officially maintained and are created by default with the `rancher-backup` operator. These are called `rancher-resource-set-basic` and `rancher-resource-set-full`. The difference between them is whether they include secrets or not in the backups. 
+
+When choosing the basic option, no Kubernetes Secrets will be backed up to prevent confidential information from being inserted in the backup files, so the user is responsible for keeping and re-deploying them safely. 
+
+The full option, however, backs up all essential Secrets to ensure Rancher continues running smoothly after a restore or migration. In this case the user is heavily advised to enable encryption with a strong key to prevent sensitive information from being stored in plain-text.
+
+:::note Important:
+
+A third resourceSet `rancher-resource-set` is also included by default with the Operator. This is a legacy definition, currently deprecated and no longer maintained, being kept only for compatibility reasons. It will be removed in Rancher v2.12. Please update your Backup CRs to use either `rancher-resource-set-full` or `rancher-resource-set-basic`.
+
+:::
+
+| YAML Directive Name | Description |
+| ---------------- | ---------------- |
+| `resourceSetName` |  Provide the name of the ResourceSet to define which resources will be included in this backup. |
+
 ## Encryption
 
 The rancher-backup gathers resources by making calls to the kube-apiserver. Objects returned by apiserver are decrypted, so even if [encryption at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) is enabled, even the encrypted objects gathered by the backup will be in plaintext.

--- a/docs/reference-guides/backup-restore-configuration/examples.md
+++ b/docs/reference-guides/backup-restore-configuration/examples.md
@@ -26,7 +26,7 @@ kind: Backup
 metadata:
   name: default-location-encrypted-backup
 spec:
-  resourceSetName: rancher-resource-set
+  resourceSetName: rancher-resource-set-full
   encryptionConfigSecretName: encryptionconfig
 ```
 
@@ -38,7 +38,7 @@ kind: Backup
 metadata:
   name: default-location-recurring-backup
 spec:
-  resourceSetName: rancher-resource-set
+  resourceSetName: rancher-resource-set-basic
   schedule: "@every 1h"
   retentionCount: 10
 ```
@@ -51,7 +51,7 @@ kind: Backup
 metadata:
   name: default-enc-recurring-backup
 spec:
-  resourceSetName: rancher-resource-set
+  resourceSetName: rancher-resource-set-full
   encryptionConfigSecretName: encryptionconfig
   schedule: "@every 1h"
   retentionCount: 3
@@ -72,7 +72,7 @@ spec:
       bucketName: rancherbackups
       endpoint: minio.xip.io
       endpointCA: <base64-encoded-cert>
-  resourceSetName: rancher-resource-set
+  resourceSetName: rancher-resource-set-full
   encryptionConfigSecretName: encryptionconfig
 ```
 
@@ -92,7 +92,7 @@ spec:
       folder: ecm1
       region: us-west-2
       endpoint: s3.us-west-2.amazonaws.com
-  resourceSetName: rancher-resource-set
+  resourceSetName: rancher-resource-set-full
   encryptionConfigSecretName: encryptionconfig
 ```
 
@@ -112,7 +112,7 @@ spec:
       folder: ecm1
       region: us-west-2
       endpoint: s3.us-west-2.amazonaws.com
-  resourceSetName: rancher-resource-set
+  resourceSetName: rancher-resource-set-full
   encryptionConfigSecretName: encryptionconfig
   schedule: "@every 1h"
   retentionCount: 10
@@ -134,7 +134,7 @@ spec:
       folder: ecm1
       region: us-west-2
       endpoint: s3.us-west-2.amazonaws.com
-  resourceSetName: rancher-resource-set
+  resourceSetName: rancher-resource-set-full
   encryptionConfigSecretName: encryptionconfig
 ```
 


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #[607](https://github.com/rancher/backup-restore-operator/issues/607)


## Description

Add an extra section to the Backups documentation to detail the available ResourceSet options and which one to choose.

