### PR TITLE
Remove untranslated zh footer file

### DIFF
--- a/i18n/zh/docusaurus-theme-classic/footer.json
+++ b/i18n/zh/docusaurus-theme-classic/footer.json
@@ -1,6 +1,0 @@
-{
-  "copyright": {
-    "message": "Copyright © 2024 SUSE Rancher. All Rights Reserved.",
-    "description": "The footer copyright"
-  }
-}


### PR DESCRIPTION
The file has not been translated so it's not necessary (and the copyright year is outdated).