### PR TITLE
adding rancher-istio deprecation notice

### DIFF
--- a/docs/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
+++ b/docs/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
@@ -6,6 +6,14 @@ title: Istio Setup Guides
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide"/>
 </head>
 
+:::note
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.rancher.com/t/deprecation-of-rancher-istio/45043/1).
+
+:::
+
 This section describes how to enable Istio and start using it in your projects.
 
 If you use Istio for traffic management, you will need to allow external traffic to the cluster. In that case, you will need to follow all of the steps below.

--- a/docs/integrations-in-rancher/istio/istio.md
+++ b/docs/integrations-in-rancher/istio/istio.md
@@ -6,6 +6,14 @@ title: Istio
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio"/>
 </head>
 
+:::note
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.rancher.com/t/deprecation-of-rancher-istio/45043/1).
+
+:::
+
 [Istio](https://istio.io/) is an open-source tool that makes it easier for DevOps teams to observe, secure, control, and troubleshoot the traffic within a complex network of microservices.
 
 As a network of microservices changes and grows, the interactions between them can become increasingly difficult to manage and understand. In such a situation, it is useful to have a service mesh as a separate infrastructure layer. Istio's service mesh lets you manipulate traffic between microservices without changing the microservices directly.

--- a/versioned_docs/version-2.11/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
+++ b/versioned_docs/version-2.11/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
@@ -6,6 +6,14 @@ title: Istio Setup Guides
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide"/>
 </head>
 
+:::note
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.rancher.com/t/deprecation-of-rancher-istio/45043/1).
+
+:::
+
 This section describes how to enable Istio and start using it in your projects.
 
 If you use Istio for traffic management, you will need to allow external traffic to the cluster. In that case, you will need to follow all of the steps below.

--- a/versioned_docs/version-2.11/integrations-in-rancher/istio/istio.md
+++ b/versioned_docs/version-2.11/integrations-in-rancher/istio/istio.md
@@ -6,6 +6,14 @@ title: Istio
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio"/>
 </head>
 
+:::note
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.rancher.com/t/deprecation-of-rancher-istio/45043/1).
+
+:::
+
 [Istio](https://istio.io/) is an open-source tool that makes it easier for DevOps teams to observe, secure, control, and troubleshoot the traffic within a complex network of microservices.
 
 As a network of microservices changes and grows, the interactions between them can become increasingly difficult to manage and understand. In such a situation, it is useful to have a service mesh as a separate infrastructure layer. Istio's service mesh lets you manipulate traffic between microservices without changing the microservices directly.


### PR DESCRIPTION
Rancher-istio will be deprecated according to the following timeline:

- Rancher `2.11`: Deprecation announcement
- Rancher `2.12`: Deprecation configuration
- Rancher `2.13`: Removed
