### PR TITLE
Update wording for navigation "about" item

### DIFF
--- a/docs/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
+++ b/docs/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
@@ -89,7 +89,7 @@ After new Kubernetes versions are loaded into the Rancher setup, additional step
 To download the system images for the private registry: 
 
 1. Click **☰** in the top left corner.
-1. Click **version number** at the bottom of the left navigation.
+1. At the bottom of the left navigation, click the Rancher version number.
 1. Download the OS specific image lists for Linux or Windows.
 1. Download `rancher-images.txt`.
 1. Prepare the private registry using the same steps during the [air gap install](other-installation-methods/air-gapped-helm-cli-install/publish-images.md), but instead of using the `rancher-images.txt` from the releases page, use the one obtained from the previous steps.

--- a/docs/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
+++ b/docs/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
@@ -89,7 +89,7 @@ After new Kubernetes versions are loaded into the Rancher setup, additional step
 To download the system images for the private registry: 
 
 1. Click **☰** in the top left corner.
-1. Click **About** at the bottom of the left navigation.
+1. Click **version number** at the bottom of the left navigation.
 1. Download the OS specific image lists for Linux or Windows.
 1. Download `rancher-images.txt`.
 1. Prepare the private registry using the same steps during the [air gap install](other-installation-methods/air-gapped-helm-cli-install/publish-images.md), but instead of using the `rancher-images.txt` from the releases page, use the one obtained from the previous steps.

--- a/docs/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/docs/reference-guides/cli-with-rancher/rancher-cli.md
@@ -14,7 +14,7 @@ The Rancher CLI (Command Line Interface) is a unified tool that you can use to i
 The binary can be downloaded directly from the UI.
 
 1. In the upper left corner, click **☰**.
-1. At the bottom of the navigation sidebar menu, click **About**.
+1. At the bottom of the navigation sidebar menu, Rancher's **version number** is displayed. Click on it to view needed details.
 1. Under the **CLI Downloads section**, there are links to download the binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
 
 ## Requirements

--- a/docs/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/docs/reference-guides/cli-with-rancher/rancher-cli.md
@@ -14,7 +14,7 @@ The Rancher CLI (Command Line Interface) is a unified tool that you can use to i
 The binary can be downloaded directly from the UI.
 
 1. In the upper left corner, click **☰**.
-1. At the bottom of the navigation sidebar menu, Rancher's **version number** is displayed. Click on it to view needed details.
+1. At the bottom of the navigation sidebar menu, click the Rancher version number.
 1. Under the **CLI Downloads section**, there are links to download the binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
 
 ## Requirements

--- a/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
@@ -85,7 +85,7 @@ Rancher Server 会定期刷新 `rke-metadata-config` 来下载新的 Kubernetes 
 要下载私有镜像仓库的系统镜像：
 
 1. 点击左上角的 **☰**。
-1. 点击左侧导航底部的**简介**。
+1. 点击左侧导航底部的Rancher版本号。
 1. 下载适用于 Linux 或 Windows 操作系统的镜像。
 1. 下载 `rancher-images.txt`。
 1. 使用[离线环境安装](other-installation-methods/air-gapped-helm-cli-install/publish-images.md)时使用的步骤准备私有镜像仓库，但不要使用发布页面中的 `rancher-images.txt`，而是使用上一个步骤中获取的文件。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference-guides/cli-with-rancher/rancher-cli.md
@@ -14,7 +14,7 @@ Rancher CLI（命令行界面）是一个命令行工具，可用于与 Rancher 
 你可以直接 UI 下载二进制文件。
 
 1. 点击左上角的 **☰**。
-1. 在导航侧边栏菜单底部，单击**简介**。
+1. 在导航侧边栏菜单底部，单击Rancher的版本号。
 1. 在 **CLI 下载**中，有 Windows、Mac 和 Linux 的二进制文件下载链接。你还可以访问我们的 CLI [发布页面](https://github.com/rancher/cli/releases)直接下载二进制文件。
 
 ## 要求

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.10/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.10/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
@@ -85,7 +85,7 @@ Rancher Server 会定期刷新 `rke-metadata-config` 来下载新的 Kubernetes 
 要下载私有镜像仓库的系统镜像：
 
 1. 点击左上角的 **☰**。
-1. 点击左侧导航底部的**简介**。
+1. 点击左侧导航底部的Rancher版本号。
 1. 下载适用于 Linux 或 Windows 操作系统的镜像。
 1. 下载 `rancher-images.txt`。
 1. 使用[离线环境安装](other-installation-methods/air-gapped-helm-cli-install/publish-images.md)时使用的步骤准备私有镜像仓库，但不要使用发布页面中的 `rancher-images.txt`，而是使用上一个步骤中获取的文件。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.10/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.10/reference-guides/cli-with-rancher/rancher-cli.md
@@ -14,7 +14,7 @@ Rancher CLI（命令行界面）是一个命令行工具，可用于与 Rancher 
 你可以直接 UI 下载二进制文件。
 
 1. 点击左上角的 **☰**。
-1. 在导航侧边栏菜单底部，单击**简介**。
+1. 在导航侧边栏菜单底部，单击Rancher的版本号。
 1. 在 **CLI 下载**中，有 Windows、Mac 和 Linux 的二进制文件下载链接。你还可以访问我们的 CLI [发布页面](https://github.com/rancher/cli/releases)直接下载二进制文件。
 
 ## 要求

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.11/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.11/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
@@ -85,7 +85,7 @@ Rancher Server 会定期刷新 `rke-metadata-config` 来下载新的 Kubernetes 
 要下载私有镜像仓库的系统镜像：
 
 1. 点击左上角的 **☰**。
-1. 点击左侧导航底部的**简介**。
+1. 点击左侧导航底部的Rancher版本号。
 1. 下载适用于 Linux 或 Windows 操作系统的镜像。
 1. 下载 `rancher-images.txt`。
 1. 使用[离线环境安装](other-installation-methods/air-gapped-helm-cli-install/publish-images.md)时使用的步骤准备私有镜像仓库，但不要使用发布页面中的 `rancher-images.txt`，而是使用上一个步骤中获取的文件。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.11/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.11/reference-guides/cli-with-rancher/rancher-cli.md
@@ -14,7 +14,7 @@ Rancher CLI（命令行界面）是一个命令行工具，可用于与 Rancher 
 你可以直接 UI 下载二进制文件。
 
 1. 点击左上角的 **☰**。
-1. 在导航侧边栏菜单底部，单击**简介**。
+1. 在导航侧边栏菜单底部，单击Rancher的版本号。
 1. 在 **CLI 下载**中，有 Windows、Mac 和 Linux 的二进制文件下载链接。你还可以访问我们的 CLI [发布页面](https://github.com/rancher/cli/releases)直接下载二进制文件。
 
 ## 要求

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.9/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.9/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
@@ -85,7 +85,7 @@ Rancher Server 会定期刷新 `rke-metadata-config` 来下载新的 Kubernetes 
 要下载私有镜像仓库的系统镜像：
 
 1. 点击左上角的 **☰**。
-1. 点击左侧导航底部的**简介**。
+1. 点击左侧导航底部的Rancher版本号。
 1. 下载适用于 Linux 或 Windows 操作系统的镜像。
 1. 下载 `rancher-images.txt`。
 1. 使用[离线环境安装](other-installation-methods/air-gapped-helm-cli-install/publish-images.md)时使用的步骤准备私有镜像仓库，但不要使用发布页面中的 `rancher-images.txt`，而是使用上一个步骤中获取的文件。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.9/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.9/reference-guides/cli-with-rancher/rancher-cli.md
@@ -14,7 +14,7 @@ Rancher CLI（命令行界面）是一个命令行工具，可用于与 Rancher 
 你可以直接 UI 下载二进制文件。
 
 1. 点击左上角的 **☰**。
-1. 在导航侧边栏菜单底部，单击**简介**。
+1. 在导航侧边栏菜单底部，单击Rancher的版本号。
 1. 在 **CLI 下载**中，有 Windows、Mac 和 Linux 的二进制文件下载链接。你还可以访问我们的 CLI [发布页面](https://github.com/rancher/cli/releases)直接下载二进制文件。
 
 ### 要求

--- a/versioned_docs/version-2.10/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
+++ b/versioned_docs/version-2.10/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
@@ -89,7 +89,7 @@ After new Kubernetes versions are loaded into the Rancher setup, additional step
 To download the system images for the private registry: 
 
 1. Click **☰** in the top left corner.
-1. Click **About** at the bottom of the left navigation.
+1. At the bottom of the left navigation, click the Rancher version number.
 1. Download the OS specific image lists for Linux or Windows.
 1. Download `rancher-images.txt`.
 1. Prepare the private registry using the same steps during the [air gap install](other-installation-methods/air-gapped-helm-cli-install/publish-images.md), but instead of using the `rancher-images.txt` from the releases page, use the one obtained from the previous steps.

--- a/versioned_docs/version-2.10/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/versioned_docs/version-2.10/reference-guides/cli-with-rancher/rancher-cli.md
@@ -14,7 +14,7 @@ The Rancher CLI (Command Line Interface) is a unified tool that you can use to i
 The binary can be downloaded directly from the UI.
 
 1. In the upper left corner, click **☰**.
-1. At the bottom of the navigation sidebar menu, click **About**.
+1. At the bottom of the navigation sidebar menu, click the Rancher version number.
 1. Under the **CLI Downloads section**, there are links to download the binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
 
 ## Requirements

--- a/versioned_docs/version-2.11/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
+++ b/versioned_docs/version-2.11/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
@@ -89,7 +89,7 @@ After new Kubernetes versions are loaded into the Rancher setup, additional step
 To download the system images for the private registry: 
 
 1. Click **☰** in the top left corner.
-1. Click **About** at the bottom of the left navigation.
+1. At the bottom of the left navigation, click the Rancher version number.
 1. Download the OS specific image lists for Linux or Windows.
 1. Download `rancher-images.txt`.
 1. Prepare the private registry using the same steps during the [air gap install](other-installation-methods/air-gapped-helm-cli-install/publish-images.md), but instead of using the `rancher-images.txt` from the releases page, use the one obtained from the previous steps.

--- a/versioned_docs/version-2.11/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/versioned_docs/version-2.11/reference-guides/cli-with-rancher/rancher-cli.md
@@ -14,7 +14,7 @@ The Rancher CLI (Command Line Interface) is a unified tool that you can use to i
 The binary can be downloaded directly from the UI.
 
 1. In the upper left corner, click **☰**.
-1. At the bottom of the navigation sidebar menu, click **About**.
+1. At the bottom of the navigation sidebar menu, click the Rancher version number.
 1. Under the **CLI Downloads section**, there are links to download the binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
 
 ## Requirements

--- a/versioned_docs/version-2.9/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
+++ b/versioned_docs/version-2.9/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
@@ -89,7 +89,7 @@ After new Kubernetes versions are loaded into the Rancher setup, additional step
 To download the system images for the private registry: 
 
 1. Click **☰** in the top left corner.
-1. Click **About** at the bottom of the left navigation.
+1. At the bottom of the left navigation, click the Rancher version number.
 1. Download the OS specific image lists for Linux or Windows.
 1. Download `rancher-images.txt`.
 1. Prepare the private registry using the same steps during the [air gap install](other-installation-methods/air-gapped-helm-cli-install/publish-images.md), but instead of using the `rancher-images.txt` from the releases page, use the one obtained from the previous steps.

--- a/versioned_docs/version-2.9/reference-guides/cli-with-rancher/rancher-cli.md
+++ b/versioned_docs/version-2.9/reference-guides/cli-with-rancher/rancher-cli.md
@@ -14,7 +14,7 @@ The Rancher CLI (Command Line Interface) is a unified tool that you can use to i
 The binary can be downloaded directly from the UI.
 
 1. In the upper left corner, click **☰**.
-1. At the bottom of the navigation sidebar menu, click **About**.
+1. At the bottom of the navigation sidebar menu, click the Rancher version number.
 1. Under the **CLI Downloads section**, there are links to download the binaries for Windows, Mac, and Linux. You can also check the [releases page for our CLI](https://github.com/rancher/cli/releases) for direct downloads of the binary.
 
 ## Requirements


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->


## Description
While deploying a local Rancher instance, I noticed that the documentation incorrectly references an "About" menu item in the navigation menu. However, there is no "About" page—instead, a version number is displayed.

This update corrects the references to align with the actual UI, improving clarity for users.
## Changes Made:

Replaced incorrect "About" references with "version number" in two documentation files:

*    docs/getting-started/installation-and-upgrade/upgrade-kubernetes-without-upgrading-rancher.md
*    docs/reference-guides/cli-with-rancher/rancher-cli.md

This ensures the documentation aligns with the current Rancher UI and improves clarity for users.


## Comments
The original wording differed slightly between the two files. Would it make sense to unify them for consistency?