### PR TITLE
Use pull_request_target in workflow as PRs are from forks

### DIFF
--- a/.github/workflows/create-issue.yml
+++ b/.github/workflows/create-issue.yml
@@ -1,7 +1,7 @@
-name: Create issue to port to Product docs
+name: Create issue to track porting between Community and Product docs
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches: 
@@ -18,7 +18,7 @@ jobs:
     if: github.event.pull_request.merged == true && contains( github.event.pull_request.labels.*.name, 'port/community-product')
     runs-on: ubuntu-latest
     steps:
-    - name: Create issue to track porting between Community and Product docs
+    - name: Create issue
       env:
         GH_TOKEN: ${{ github.token }}
       run: |


### PR DESCRIPTION
## Description

After adding the workflow in https://github.com/rancher/rancher-docs/pull/1643, the [first run](https://github.com/rancher/rancher-docs/actions/runs/13317660827) of the action failed due to `GraphQL: Resource not accessible by integration (createIssue)`.

The [GitHub docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) indicate the `Maximum access for pull requests from public forked repositories` is only read, whereas the workflow needs write access to create an issue. 

Switching to pull_request_target to see if it fixes things as per the docs:

> When a workflow is triggered by the [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) event, the GITHUB_TOKEN is granted read/write repository permission, even when it is triggered from a public fork.