### PR TITLE
[v2.11] Add documentation for aggregated clusterroles

### DIFF
--- a/docs/getting-started/installation-and-upgrade/installation-references/feature-flags.md
+++ b/docs/getting-started/installation-and-upgrade/installation-references/feature-flags.md
@@ -18,6 +18,7 @@ Some feature flags require a restart of the Rancher container. Features that req
 
 The following is a list of feature flags available in Rancher. If you've upgraded from a previous Rancher version, you may see additional flags in the Rancher UI, such as `proxy` or `dashboard` (both [discontinued](/versioned_docs/version-2.5/reference-guides/installation-references/feature-flags.md)):
 
+- `aggregated-roletemplates`: Use cluster role aggregation architecture for RoleTemplates, ProjectRoleTemplateBindings, and ClusterRoleTemplateBindings. See [Cluster Role Aggregation](../../../how-to-guides/advanced-user-guides/enable-experimental-features/cluster-role-aggregation.md) for more information.
 - `clean-stale-secrets`: Removes stale secrets from the `cattle-impersonation-system` namespace. This slowly cleans up old secrets which are no longer being used by the impersonation system.
 - `continuous-delivery`: Allows Fleet GitOps to be disabled separately from Fleet. See [Continuous Delivery.](../../../how-to-guides/advanced-user-guides/enable-experimental-features/continuous-delivery.md) for more information.
 - `fleet`: The Rancher provisioning framework in v2.6 and later requires Fleet. The flag will be automatically enabled when you upgrade, even if you disabled this flag in an earlier version of Rancher. See [Continuous Delivery with Fleet](../../../integrations-in-rancher/fleet/fleet.md) for more information.
@@ -38,6 +39,7 @@ The following table shows the availability and default values for some feature f
 
 | Feature Flag Name             | Default Value | Status       | Available As Of | Additional Information |
 | ----------------------------- | ------------- | ------------ | --------------- | ---------------------- |
+| `aggregated-roletemplates | `false` | Highly experimentatl | v2.11.0 | This flag value is locked on install and can't be changed. |
 | `clean-stale-secrets` | `true` | GA | v2.10.2 | |
 | `continuous-delivery` | `true` | GA | v2.6.0 | |
 | `external-rules` | v2.7.14: `false`, v2.8.5: `true` | Removed | v2.7.14, v2.8.5 | This flag affected [external `RoleTemplate` behavior](../../../how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/cluster-and-project-roles.md#external-roletemplate-behavior). It is removed in Rancher v2.9.0 and later as the behavior is enabled by default. |

--- a/docs/how-to-guides/advanced-user-guides/enable-experimental-features/cluster-role-aggregation.md
+++ b/docs/how-to-guides/advanced-user-guides/enable-experimental-features/cluster-role-aggregation.md
@@ -1,0 +1,19 @@
+---
+title: ClusterRole Aggregation
+---
+
+<head>
+  <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/enable-experimental-features/cluster-role-aggregation"/>
+</head>
+
+:::caution
+ClusterRole Aggregation is a highly experimental feature that changes the RBAC architecture used for RoleTemplates, ClusterRoleTemplateBindings and ProjectRoleTemplateBindings. **Not supported for production environments**. Meant exclusively for internal testing in v2.11. Expected to be available as a beta for users in v2.12 with a prospective GA in Rancher v2.13.
+:::
+
+ClusterRole aggregation implements RoleTemplates, ClusterRoleTemplateBindings and ProjectRoleTemplateBindings using the Kubernetes feature [Aggregated ClusterRoles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles). The new architecture results in a net reduction in RBAC objects (Roles, RoleBindings, ClusterRoles and ClusterRoleBindings) both in the Rancher cluster and the downstream clusters.
+
+Environment Variable Key | Default Value | Description
+--- | --- | ---
+`aggregated-roletemplates` | `false` | [Experimental] Make RoleTemplates use aggregation for generated RBAC roles
+
+The value of this feature flag is locked on install, which shows up in the UI as a lock symbol beside the feature flag. That means the feature can only be set on the first ever installation of Rancher. After that, attempting to modify the value will be denied.


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Original rancher/rancher issue: https://github.com/rancher/rancher/issues/46077

## Description

There is a new feature `ClusterRole Aggregation`. Currently it's only in Rancher v2.11 in order to allow our QA team to begin testing. It's hidden behind a feature flag for now, so I added information about the feature flag in the documentation. I also added a new page in the `enable-experimental-features` directory giving more details about the feature.

## Comments

The page related to the feature is pretty sparse, but that's largely because it's still in progress. While the overall architecture is set, the details aren't finalized and may change after testing. My primary goal is to discourage users from using this new feature without understanding that it is not well supported. When it's more ready (likely in v2.12) I will create a more comprehensive feature page.