### PR TITLE
Add issue template for release maintenance checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-maintenance-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-maintenance-checklist.md
@@ -1,0 +1,15 @@
+---
+name: Release Maintenance Task Checklist
+about: Track tasks that need to be done every release.
+title: '<VERSION> - Rancher Manager Release Maintenance Task Checklist'
+---
+
+This issue is to track tasks that need to be done every release regardless of whether the release has new feature content or not.
+
+- [ ] Update the [versions table](https://ranchermanager.docs.rancher.com/versions)
+- [ ] Update the [Rancher:webhook version mapping table](https://ranchermanager.docs.rancher.com/reference-guides/rancher-webhook)
+- [ ] Update the [CNI popularity table](https://ranchermanager.docs.rancher.com/faq/container-network-interface-providers#cni-community-popularity)
+- [ ] Update the [CSP adapter compatibility matrix](https://ranchermanager.docs.rancher.com/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/install-adapter#rancher-vs-adapter-compatibility-matrix):
+- [ ] Update the [deprecated features table](https://ranchermanager.docs.rancher.com/faq/deprecated-features):
+- [ ] Create a new [release](https://github.com/rancher/rancher-docs/releases)
+- [ ] Update Algolia search index

--- a/.github/ISSUE_TEMPLATE/request-a-new-feature.md
+++ b/.github/ISSUE_TEMPLATE/request-a-new-feature.md
@@ -1,9 +1,6 @@
 ---
 name: Request a New Feature
 about: For requesting new feature(s) to be added to the docs.
-title: ''
-labels: ''
-assignees: ''
 ---
 
 ## Related Issues

--- a/.github/ISSUE_TEMPLATE/request-an-update.md
+++ b/.github/ISSUE_TEMPLATE/request-an-update.md
@@ -1,9 +1,6 @@
 ---
 name: Request an Update
 about: For fixing docs errors/typos, adding needed/missing information, updating verbiage, deleting outdated info, etc.
-title: ''
-labels: ''
-assignees: ''
 ---
 
 ## Related Issues


### PR DESCRIPTION
## Description

We should take advantage of templates since It's a recurring issue that we create for each release.

Also cleaned up some optional fields that we specified, but didn't use in our other templates.