### PR TITLE
[skip ci] Don't run gh pages deployment for issue template changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - '**/README.md'
+      - '**/.github/ISSUE_TEMPLATE/**'
 
 jobs:
   build:


### PR DESCRIPTION
## Description

Similar to https://github.com/rancher/rancher-docs/pull/1661, we also don't need to [publish to GitHub pages](https://github.com/rancher/rancher-docs/blob/main/.github/workflows/deploy.yml) if we're only making changes to files in .github/ISSUE_TEMPLATE.