### PR TITLE
Sanitize title using intermediate var in workflow

### DIFF
--- a/.github/workflows/create-issue.yml
+++ b/.github/workflows/create-issue.yml
@@ -21,9 +21,11 @@ jobs:
     - name: Create issue
       env:
         GH_TOKEN: ${{ github.token }}
+        REPO_TYPE: ${{ contains( github.repository, 'product-docs') && 'Product' || 'Community' }}
+        PR_TITLE: ${{ github.event.pull_request.title }}
       run: |
         gh issue create \
-          --repo rancher/rancher-docs \
-          --title 'Port Community docs PR #${{github.event.pull_request.number}}: ${{github.event.pull_request.title}}' \
-          --body 'Reference: https://github.com/${{github.repository}}/pull/${{github.event.pull_request.number}}' \
-          --label port/community-product 
+          --repo ${{ github.repository }} \
+          --title "Port $REPO_TYPE docs PR #${{ github.event.pull_request.number }}: $PR_TITLE" \
+          --body "Reference: https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}" \
+          --label port/community-product


### PR DESCRIPTION
## Description

The current workflow breaks if the PR title contains quotes or backticks. This [suggestion](https://github.com/orgs/community/discussions/27065#discussioncomment-3798970) points to these [docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable) suggesting using an intermediate variable and is also recommended for handling untrusted input.

This PR also adjusts the title in the new issue with 'Product' vs 'Community' depending on the context.