### PR TITLE
backup and restore: add warning not to use snapshots

### DIFF
--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-restore-usage-guide.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-restore-usage-guide.md
@@ -10,6 +10,14 @@ The Rancher Backups chart is our solution for disaster recovery and migration. T
 
 This chart is a very simple tool which has its hands in many different areas of the Rancher ecosystem. As a result, edge cases have arisen which lead to undocumented functionality. The purpose of this document is to highlight the proper and defined usage for Rancher Backups, as well as discussing some of these edge cases we’ve run into.
 
+:::caution
+
+While Kubernetes distributions like k3s and RKE2 offer [cluster configuration backups](https://docs.rke2.io/datastore/backup_restore) (etcd snapshots), these can sometimes cause issues with Rancher.
+
+For a reliable Rancher backup, we recommend using the Rancher Backup functionality described in this guide. Consider etcd snapshots as a last resort option.
+
+:::
+
 ## Functionality Overview
 
 ### Backup

--- a/versioned_docs/version-2.10/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-restore-usage-guide.md
+++ b/versioned_docs/version-2.10/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-restore-usage-guide.md
@@ -10,6 +10,14 @@ The Rancher Backups chart is our solution for disaster recovery and migration. T
 
 This chart is a very simple tool which has its hands in many different areas of the Rancher ecosystem. As a result, edge cases have arisen which lead to undocumented functionality. The purpose of this document is to highlight the proper and defined usage for Rancher Backups, as well as discussing some of these edge cases we’ve run into.
 
+:::caution
+
+While Kubernetes distributions like k3s and RKE2 offer [cluster configuration backups](https://docs.rke2.io/datastore/backup_restore) (etcd snapshots), these can sometimes cause issues with Rancher.
+
+For a reliable Rancher backup, we recommend using the Rancher Backup functionality described in this guide. Consider etcd snapshots as a last resort option.
+
+:::
+
 ## Functionality Overview
 
 ### Backup

--- a/versioned_docs/version-2.11/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-restore-usage-guide.md
+++ b/versioned_docs/version-2.11/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-restore-usage-guide.md
@@ -10,6 +10,14 @@ The Rancher Backups chart is our solution for disaster recovery and migration. T
 
 This chart is a very simple tool which has its hands in many different areas of the Rancher ecosystem. As a result, edge cases have arisen which lead to undocumented functionality. The purpose of this document is to highlight the proper and defined usage for Rancher Backups, as well as discussing some of these edge cases we’ve run into.
 
+:::caution
+
+While Kubernetes distributions like k3s and RKE2 offer [cluster configuration backups](https://docs.rke2.io/datastore/backup_restore) (etcd snapshots), these can sometimes cause issues with Rancher.
+
+For a reliable Rancher backup, we recommend using the Rancher Backup functionality described in this guide. Consider etcd snapshots as a last resort option.
+
+:::
+
 ## Functionality Overview
 
 ### Backup

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-restore-usage-guide.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-restore-usage-guide.md
@@ -10,6 +10,14 @@ The Rancher Backups chart is our solution for disaster recovery and migration. T
 
 This chart is a very simple tool which has its hands in many different areas of the Rancher ecosystem. As a result, edge cases have arisen which lead to undocumented functionality. The purpose of this document is to highlight the proper and defined usage for Rancher Backups, as well as discussing some of these edge cases we’ve run into.
 
+:::caution
+
+While Kubernetes distributions like k3s and RKE2 offer [cluster configuration backups](https://docs.rke2.io/datastore/backup_restore) (etcd snapshots), these can sometimes cause issues with Rancher.
+
+For a reliable Rancher backup, we recommend using the Rancher Backup functionality described in this guide. Consider etcd snapshots as a last resort option.
+
+:::
+
 ## Functionality Overview
 
 ### Backup

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-restore-usage-guide.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-restore-usage-guide.md
@@ -10,6 +10,14 @@ The Rancher Backups chart is our solution for disaster recovery and migration. T
 
 This chart is a very simple tool which has its hands in many different areas of the Rancher ecosystem. As a result, edge cases have arisen which lead to undocumented functionality. The purpose of this document is to highlight the proper and defined usage for Rancher Backups, as well as discussing some of these edge cases we’ve run into.
 
+:::caution
+
+While Kubernetes distributions like k3s and RKE2 offer [cluster configuration backups](https://docs.rke2.io/datastore/backup_restore) (etcd snapshots), these can sometimes cause issues with Rancher.
+
+For a reliable Rancher backup, we recommend using the Rancher Backup functionality described in this guide. Consider etcd snapshots as a last resort option.
+
+:::
+
 ## Functionality Overview
 
 ### Backup

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-restore-usage-guide.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-restore-usage-guide.md
@@ -10,6 +10,14 @@ The Rancher Backups chart is our solution for disaster recovery and migration. T
 
 This chart is a very simple tool which has its hands in many different areas of the Rancher ecosystem. As a result, edge cases have arisen which lead to undocumented functionality. The purpose of this document is to highlight the proper and defined usage for Rancher Backups, as well as discussing some of these edge cases we’ve run into.
 
+:::caution
+
+While Kubernetes distributions like k3s and RKE2 offer [cluster configuration backups](https://docs.rke2.io/datastore/backup_restore) (etcd snapshots), these can sometimes cause issues with Rancher.
+
+For a reliable Rancher backup, we recommend using the Rancher Backup functionality described in this guide. Consider etcd snapshots as a last resort option.
+
+:::
+
 ## Functionality Overview
 
 ### Backup

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-restore-usage-guide.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-restore-usage-guide.md
@@ -10,6 +10,14 @@ The Rancher Backups chart is our solution for disaster recovery and migration. T
 
 This chart is a very simple tool which has its hands in many different areas of the Rancher ecosystem. As a result, edge cases have arisen which lead to undocumented functionality. The purpose of this document is to highlight the proper and defined usage for Rancher Backups, as well as discussing some of these edge cases we’ve run into.
 
+:::caution
+
+While Kubernetes distributions like k3s and RKE2 offer [cluster configuration backups](https://docs.rke2.io/datastore/backup_restore) (etcd snapshots), these can sometimes cause issues with Rancher.
+
+For a reliable Rancher backup, we recommend using the Rancher Backup functionality described in this guide. Consider etcd snapshots as a last resort option.
+
+:::
+
 ## Functionality Overview
 
 ### Backup


### PR DESCRIPTION
## Description

Relying on etcd snapshots for the upstream ("local") cluster is known to cause issues.

The Backup and Restore Operator was created to avoid those.

We should clarify that to customers.

## Comments

I opened a PR instead of an issue in hopes that will help fixing the problem sooner - and also because it was the easiest way for me to communicate clearly what the problem is. I hope this helps