### PR TITLE
Document workaround for migrating across distributions

### DIFF
--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -142,7 +142,7 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
 
 :::note Important:
 
-When migrating Rancher between different Kubernetes distributions (e.g. from K3s to RKE2), the object representing the local cluster has to be modified to allow Rancher to detect the new distribution. After the restoration is completed, and **before** bringing up Rancher on the new cluster, edit the local cluster object:
+When migrating Rancher between any two different Kubernetes distributions (e.g. from K3s to RKE2), the object representing the local cluster has to be modified to allow Rancher to detect the new distribution. After the restoration is completed, and **before** bringing up Rancher on the new cluster, edit the local cluster object:
 
 ```bash
 kubectl edit clusters.management.cattle.io local

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -153,7 +153,7 @@ kubectl edit clusters.management.cattle.io local
 1. Remove the entire `status.version` map.
 1. Remove the label with the key `provider.cattle.io` in `metadata.labels`.
 1. Remove the annotation with the key `management.cattle.io/current-cluster-controllers-version` in `metadata.annotations`.
-1. Remove any of `spec.rke2Config` or `spec.k3sConfig`, the entire map, if present.
+1. Remove the entire `spec.rke2Config` or `spec.k3sConfig` map, if present.
 1. Save the changes.
 
 Note that removing `spec.rke2Config` or `spec.k3sConfig` will erase your distribution-specific upgrade configuration for the local cluster. It can be [reconfigured](../../../getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md) if the new distribution is configurable for the local cluster.

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -142,7 +142,7 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
 
 :::note Important:
 
-When migrating Rancher between different Kubernetes distributions (e.g. from K3s to RKE2), the object representing the local cluster has to be modified to allow Rancher to detect the new distribution. After the restoration is completed, and **before** bringing up rancher on the new cluster, edit the local cluster object:
+When migrating Rancher between different Kubernetes distributions (e.g. from K3s to RKE2), the object representing the local cluster has to be modified to allow Rancher to detect the new distribution. After the restoration is completed, and **before** bringing up Rancher on the new cluster, edit the local cluster object:
 
 ```bash
 kubectl edit clusters.management.cattle.io local

--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -140,6 +140,26 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
 
    1. Once the Restore resource has the status `Completed`, you can continue the cert-manager and Rancher installation.
 
+:::note Important:
+
+When migrating Rancher between different Kubernetes distributions (e.g. from K3s to RKE2), the object representing the local cluster has to be modified to allow Rancher to detect the new distribution. After the restoration is completed, and **before** bringing up rancher on the new cluster, edit the local cluster object:
+
+```bash
+kubectl edit clusters.management.cattle.io local
+```
+
+1. Change the value of `status.driver` to `imported`.
+1. Remove `status.provider`.
+1. Remove the entire `status.version` map.
+1. Remove the label with the key `provider.cattle.io` in `metadata.labels`.
+1. Remove the annotation with the key `management.cattle.io/current-cluster-controllers-version` in `metadata.annotations`.
+1. Remove any of `spec.rke2Config` or `spec.k3sConfig`, the entire map, if present.
+1. Save the changes.
+
+Note that removing `spec.rke2Config` or `spec.k3sConfig` will erase your distribution-specific upgrade configuration for the local cluster. It can be [reconfigured](../../../getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md) if the new distribution is configurable for the local cluster.
+
+:::
+
 ### 3. Install cert-manager
 
 Follow the steps to [install cert-manager](../../../getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/install-upgrade-on-a-kubernetes-cluster.md#4-install-cert-manager) in the documentation about installing cert-manager on Kubernetes.

--- a/versioned_docs/version-2.10/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.10/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -142,7 +142,7 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
 
 :::note Important:
 
-When migrating Rancher between different Kubernetes distributions (e.g. from K3s to RKE2), the object representing the local cluster has to be modified to allow Rancher to detect the new distribution. After the restoration is completed, and **before** bringing up Rancher on the new cluster, edit the local cluster object:
+When migrating Rancher between any two different Kubernetes distributions (e.g. from K3s to RKE2), the object representing the local cluster has to be modified to allow Rancher to detect the new distribution. After the restoration is completed, and **before** bringing up Rancher on the new cluster, edit the local cluster object:
 
 ```bash
 kubectl edit clusters.management.cattle.io local

--- a/versioned_docs/version-2.10/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.10/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -153,7 +153,7 @@ kubectl edit clusters.management.cattle.io local
 1. Remove the entire `status.version` map.
 1. Remove the label with the key `provider.cattle.io` in `metadata.labels`.
 1. Remove the annotation with the key `management.cattle.io/current-cluster-controllers-version` in `metadata.annotations`.
-1. Remove any of `spec.rke2Config` or `spec.k3sConfig`, the entire map, if present.
+1. Remove the entire `spec.rke2Config` or `spec.k3sConfig` map, if present.
 1. Save the changes.
 
 Note that removing `spec.rke2Config` or `spec.k3sConfig` will erase your distribution-specific upgrade configuration for the local cluster. It can be [reconfigured](../../../getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md) if the new distribution is configurable for the local cluster.

--- a/versioned_docs/version-2.10/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.10/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -142,7 +142,7 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
 
 :::note Important:
 
-When migrating Rancher between different Kubernetes distributions (e.g. from K3s to RKE2), the object representing the local cluster has to be modified to allow Rancher to detect the new distribution. After the restoration is completed, and **before** bringing up rancher on the new cluster, edit the local cluster object:
+When migrating Rancher between different Kubernetes distributions (e.g. from K3s to RKE2), the object representing the local cluster has to be modified to allow Rancher to detect the new distribution. After the restoration is completed, and **before** bringing up Rancher on the new cluster, edit the local cluster object:
 
 ```bash
 kubectl edit clusters.management.cattle.io local

--- a/versioned_docs/version-2.10/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.10/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -140,6 +140,26 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
 
    1. Once the Restore resource has the status `Completed`, you can continue the cert-manager and Rancher installation.
 
+:::note Important:
+
+When migrating Rancher between different Kubernetes distributions (e.g. from K3s to RKE2), the object representing the local cluster has to be modified to allow Rancher to detect the new distribution. After the restoration is completed, and **before** bringing up rancher on the new cluster, edit the local cluster object:
+
+```bash
+kubectl edit clusters.management.cattle.io local
+```
+
+1. Change the value of `status.driver` to `imported`.
+1. Remove `status.provider`.
+1. Remove the entire `status.version` map.
+1. Remove the label with the key `provider.cattle.io` in `metadata.labels`.
+1. Remove the annotation with the key `management.cattle.io/current-cluster-controllers-version` in `metadata.annotations`.
+1. Remove any of `spec.rke2Config` or `spec.k3sConfig`, the entire map, if present.
+1. Save the changes.
+
+Note that removing `spec.rke2Config` or `spec.k3sConfig` will erase your distribution-specific upgrade configuration for the local cluster. It can be [reconfigured](../../../getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md) if the new distribution is configurable for the local cluster.
+
+:::
+
 ### 3. Install cert-manager
 
 Follow the steps to [install cert-manager](../../../getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/install-upgrade-on-a-kubernetes-cluster.md#4-install-cert-manager) in the documentation about installing cert-manager on Kubernetes.

--- a/versioned_docs/version-2.11/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.11/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -142,7 +142,7 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
 
 :::note Important:
 
-When migrating Rancher between different Kubernetes distributions (e.g. from K3s to RKE2), the object representing the local cluster has to be modified to allow Rancher to detect the new distribution. After the restoration is completed, and **before** bringing up Rancher on the new cluster, edit the local cluster object:
+When migrating Rancher between any two different Kubernetes distributions (e.g. from K3s to RKE2), the object representing the local cluster has to be modified to allow Rancher to detect the new distribution. After the restoration is completed, and **before** bringing up Rancher on the new cluster, edit the local cluster object:
 
 ```bash
 kubectl edit clusters.management.cattle.io local

--- a/versioned_docs/version-2.11/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.11/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -153,7 +153,7 @@ kubectl edit clusters.management.cattle.io local
 1. Remove the entire `status.version` map.
 1. Remove the label with the key `provider.cattle.io` in `metadata.labels`.
 1. Remove the annotation with the key `management.cattle.io/current-cluster-controllers-version` in `metadata.annotations`.
-1. Remove any of `spec.rke2Config` or `spec.k3sConfig`, the entire map, if present.
+1. Remove the entire `spec.rke2Config` or `spec.k3sConfig` map, if present.
 1. Save the changes.
 
 Note that removing `spec.rke2Config` or `spec.k3sConfig` will erase your distribution-specific upgrade configuration for the local cluster. It can be [reconfigured](../../../getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md) if the new distribution is configurable for the local cluster.

--- a/versioned_docs/version-2.11/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.11/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -142,7 +142,7 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
 
 :::note Important:
 
-When migrating Rancher between different Kubernetes distributions (e.g. from K3s to RKE2), the object representing the local cluster has to be modified to allow Rancher to detect the new distribution. After the restoration is completed, and **before** bringing up rancher on the new cluster, edit the local cluster object:
+When migrating Rancher between different Kubernetes distributions (e.g. from K3s to RKE2), the object representing the local cluster has to be modified to allow Rancher to detect the new distribution. After the restoration is completed, and **before** bringing up Rancher on the new cluster, edit the local cluster object:
 
 ```bash
 kubectl edit clusters.management.cattle.io local

--- a/versioned_docs/version-2.11/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.11/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -140,6 +140,26 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
 
    1. Once the Restore resource has the status `Completed`, you can continue the cert-manager and Rancher installation.
 
+:::note Important:
+
+When migrating Rancher between different Kubernetes distributions (e.g. from K3s to RKE2), the object representing the local cluster has to be modified to allow Rancher to detect the new distribution. After the restoration is completed, and **before** bringing up rancher on the new cluster, edit the local cluster object:
+
+```bash
+kubectl edit clusters.management.cattle.io local
+```
+
+1. Change the value of `status.driver` to `imported`.
+1. Remove `status.provider`.
+1. Remove the entire `status.version` map.
+1. Remove the label with the key `provider.cattle.io` in `metadata.labels`.
+1. Remove the annotation with the key `management.cattle.io/current-cluster-controllers-version` in `metadata.annotations`.
+1. Remove any of `spec.rke2Config` or `spec.k3sConfig`, the entire map, if present.
+1. Save the changes.
+
+Note that removing `spec.rke2Config` or `spec.k3sConfig` will erase your distribution-specific upgrade configuration for the local cluster. It can be [reconfigured](../../../getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md) if the new distribution is configurable for the local cluster.
+
+:::
+
 ### 3. Install cert-manager
 
 Follow the steps to [install cert-manager](../../../getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/install-upgrade-on-a-kubernetes-cluster.md#4-install-cert-manager) in the documentation about installing cert-manager on Kubernetes.


### PR DESCRIPTION
## Description

Migrating rancher across different Kubernetes distributions causes the local cluster object not to specify the correct distribution and driver.

This commit adds instructions for workaround to be applied after restoration for a migration and before bringing Rancher up, so that the local cluster will have the correct data for the new distribution it runs on.

See: https://github.com/rancher/rancher/issues/42158

### QA considerations for the workarounds

In my own tests, I've tried out the instructions migrating from `k3s` to `rke2`, from `rke1` to `rke2` and `k3s` to `rke1`.

Migrating between `k3s` and `rke2` or vice-versa should be equivalent, but not migrating from `rke2/k3s` to a non-`rke2`/`k3s` distribution (e.g. `rke1`) and vice-versa. The reason is that both `k3s` and `rke2` allow the local cluster to self-upgrade, but not `rke1` or other distributions.

A few points I think should be checked for validation:

- That the relevant fields are all OK in the local `clusters.management.cattle.io` object, as well as the `provider.cattle.io` label in the local `clusters.provisioning.cattle.io` object. They will be reconfigured after rancher is brought up if the workaround steps were previously applied.
- That if the cluster to which rancher is migrated is `rke2` or `k3s` it can correctly be upgraded, and its upgrade configuration is visible for the correct distribution, if available (`rke2` or `k3s`). This can be done by installing rancher on a k8s distribution older than the latest (either in the minor or patch version), in both the origin and target cluster, so that the local cluster can be [upgraded](https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes) after migration.