### PR TITLE
Add archive notice to v2.8

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -202,7 +202,7 @@ module.exports = {
             2.8: {
               label: 'v2.8',
               path: 'v2.8',
-              banner: 'none'
+              className: 'toArchive'
             },
             2.7: {
               label: 'v2.7',


### PR DESCRIPTION
Add the archive notice banner to Rancher v2.8 as its [End of Life date](https://www.suse.com/lifecycle/#suse-rancher-prime) is approaching.