### PR TITLE
2.11: Remove banner with incorrect release status

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -187,7 +187,7 @@ module.exports = {
             '2.11': {
               label: 'v2.11 (Unreleased)',
               path: 'v2.11',
-              banner: 'unreleased'
+              banner: 'none'
             },
             '2.10': {
               label: 'v2.10',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -185,7 +185,7 @@ module.exports = {
               label: 'Latest',
             },
             '2.11': {
-              label: 'v2.11 (Unreleased)',
+              label: 'v2.11',
               path: 'v2.11',
               banner: 'none'
             },


### PR DESCRIPTION
## Description

Current banner still shows v2.11 as unreleased.