### PR TITLE
Fix external links

### DIFF
--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -27,15 +27,13 @@ This Quick Start Guide is divided into different tasks for easier consumption.
 
 ## Prerequisites
 
-- An [Equinix Metal account](https://metal.equinix.com/developers/docs/accounts/users/)
-- An [Equinix Metal project](https://metal.equinix.com/developers/docs/accounts/projects/)
+- An [Equinix Metal account](https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/)
+- An [Equinix Metal project](https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/)
 
 
 ### 1. Provision a Equinix Metal Host
 
-Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the [Equinix Metal deployment documentation](https://metal.equinix.com/developers/docs/deploy/on-demand/). You can find additional documentation on Equinix Metal server types and prices below:
-  - [Equinix Metal Server Types](https://metal.equinix.com/developers/docs/servers/about/)
-  - [Equinix Metal Pricing](https://metal.equinix.com/developers/docs/servers/server-specs/)
+Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the [Equinix Metal deployment documentation](https://deploy.equinix.com/developers/docs/metal/deploy/on-demand/). You can find additional information on Equinix Metal server types in the [Equinix Metal Documentation](https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/).
 
 :::note Notes:
 

--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
@@ -131,7 +131,7 @@ cloud-init clean -s -l
 
 ### Windows Preparation
 
-Windows has a utility called [sysprep](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation) that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
+Windows has a utility called [sysprep](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation?view=windows-11) that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
 
 ```PowerShell
 sysprep.exe /generalize /shutdown /oobe

--- a/docs/integrations-in-rancher/istio/istio.md
+++ b/docs/integrations-in-rancher/istio/istio.md
@@ -63,7 +63,7 @@ For Istio installations `103.1.0+up1.19.6` and later, Kiali uses a token value f
 
 Our Istio installer includes a quick-start, all-in-one installation of [Jaeger,](https://www.jaegertracing.io/) a tool used for tracing distributed systems.
 
-Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the [Jaeger documentation.](https://www.jaegertracing.io/docs/latest/operator/#production-strategy)
+Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the [Jaeger documentation.](https://www.jaegertracing.io/docs/1.65/operator/#production-strategy)
 
 ## Prerequisites
 

--- a/docs/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
+++ b/docs/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
@@ -66,7 +66,7 @@ In general, you want to scrape data from all the workloads running in your clust
 
 ### About Prometheus Exporters
 
-Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports by SysDig on [promcat.io](https://promcat.io/) and on [ExporterHub](https://exporterhub.io/).
+Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports on [ExporterHub](https://exporterhub.io/).
 
 ### Prometheus support in Programming Languages and Frameworks
 

--- a/docs/reference-guides/monitoring-v2-configuration/examples.md
+++ b/docs/reference-guides/monitoring-v2-configuration/examples.md
@@ -12,7 +12,7 @@ See the official prometheus-operator GitHub repo for an example [ServiceMonitor]
 
 ## PodMonitor
 
-See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/user-guides/getting-started/#using-podmonitors) for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
+See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors) for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
 
 ## PrometheusRule
 
@@ -20,7 +20,7 @@ A PrometheusRule contains the alerting and recording rules that you would usuall
 
 For a more fine-grained approach, the `ruleSelector` field on a Prometheus resource can select which PrometheusRules should be loaded onto Prometheus, based on the labels attached to the PrometheusRules resources.
 
-See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/user-guides/alerting/) for an example PrometheusRule.
+See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/developer/alerting/) for an example PrometheusRule.
 
 ## Alertmanager Config
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -23,15 +23,13 @@ title: Rancher Equinix Metal 快速入门
 
 ## 先决条件
 
-- [Equinix Metal 账号](https://metal.equinix.com/developers/docs/accounts/users/)
-- [Equinix Metal 项目](https://metal.equinix.com/developers/docs/accounts/projects/)
+- [Equinix Metal 账号](https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/)
+- [Equinix Metal 项目](https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/)
 
 
 ### 1. 配置 Equinix Metal 主机
 
-开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 [Equinix Metal 部署](https://metal.equinix.com/developers/docs/deploy/on-demand/)。以下链接介绍 Equinix Metal Server 的类型以及价格：
-- [Equinix Metal Server 类型](https://metal.equinix.com/developers/docs/servers/about/)
-- [Equinix Metal 价格](https://metal.equinix.com/developers/docs/servers/server-specs/)
+开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 [Equinix Metal 部署](https://metal.equinix.com/developers/docs/deploy/on-demand/)。You can find additional information on Equinix Metal server types in the [Equinix Metal Documentation](https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/).
 
 :::note 注意事项：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
@@ -129,7 +129,7 @@ cloud-init clean -s -l
 
 ### Windows 准备
 
-Windows 有一个名为 [sysprep](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation) 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
+Windows 有一个名为 [sysprep](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation?view=windows-11) 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
 
 ```PowerShell
 sysprep.exe /generalize /shutdown /oobe

--- a/i18n/zh/docusaurus-plugin-content-docs/current/integrations-in-rancher/istio/istio.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/integrations-in-rancher/istio/istio.md
@@ -50,7 +50,7 @@ Kiali 是一个全面的可视化辅助工具，用于绘制整个服务网格�
 
 Jaeger 是用于跟踪分布式系统的工具。我们的 Istio 安装程序包括能快速启动的一体化 [Jaeger](https://www.jaegertracing.io/) 安装。
 
-请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/latest/operator/#production-strategy)。
+请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/1.65/operator/#production-strategy)。
 
 ## 先决条件
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
@@ -62,7 +62,7 @@ Prometheus 不是用于长期存储指标的，它只用于短期存储。
 
 ### 关于 Prometheus Exporters
 
-许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 [promcat.io](https://promcat.io/) 和 [ExporterHub](https://exporterhub.io/) 上找到一个由 SysDig 策划的 exporter 列表。
+许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 [ExporterHub](https://exporterhub.io/) 上找到一个策划的 exporter 列表。
 
 ### Prometheus 的编程语言和框架支持
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference-guides/monitoring-v2-configuration/examples.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference-guides/monitoring-v2-configuration/examples.md
@@ -8,7 +8,7 @@ title: 示例
 
 ## PodMonitor
 
-你可以在[此处](https://github.com/prometheus-operator/prometheus-operator/blob/master/example/user-guides/getting-started/example-app-pod-monitor.yaml)找到 PodMonitor 示例，还可以在[此处](https://github.com/prometheus-operator/prometheus-operator/blob/master/example/user-guides/getting-started/prometheus-pod-monitor.yaml)找到引用它的 Prometheus 资源示例。
+你可以在[此处](https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors)找到 PodMonitor 示例和引用它的 Prometheus 资源示例。
 
 ## PrometheusRule
 
@@ -16,7 +16,7 @@ PrometheusRule 包含你通常放置在 [Prometheus 规则文件](https://promet
 
 要在集群中更细粒度地应用 PrometheusRules，你可以使用 Prometheus 资源的 ruleSelector 字段，从而根据添加到 PrometheusRules 资源的标签来选择要加载到 Prometheus 上的 PrometheusRule。
 
-你可以在[此页面](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/alerting.md)找到 PrometheusRule 示例。
+你可以在[此页面](https://prometheus-operator.dev/docs/developer/alerting/)找到 PrometheusRule 示例。
 
 ## Alertmanager 配置
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.10/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.10/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -23,15 +23,13 @@ title: Rancher Equinix Metal 快速入门
 
 ## 先决条件
 
-- [Equinix Metal 账号](https://metal.equinix.com/developers/docs/accounts/users/)
-- [Equinix Metal 项目](https://metal.equinix.com/developers/docs/accounts/projects/)
+- [Equinix Metal 账号](https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/)
+- [Equinix Metal 项目](https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/)
 
 
 ### 1. 配置 Equinix Metal 主机
 
-开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 [Equinix Metal 部署](https://metal.equinix.com/developers/docs/deploy/on-demand/)。以下链接介绍 Equinix Metal Server 的类型以及价格：
-- [Equinix Metal Server 类型](https://metal.equinix.com/developers/docs/servers/about/)
-- [Equinix Metal 价格](https://metal.equinix.com/developers/docs/servers/server-specs/)
+开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 [Equinix Metal 部署](https://metal.equinix.com/developers/docs/deploy/on-demand/)。You can find additional information on Equinix Metal server types in the [Equinix Metal Documentation](https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/).
 
 :::note 注意事项：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.10/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.10/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
@@ -129,7 +129,7 @@ cloud-init clean -s -l
 
 ### Windows 准备
 
-Windows 有一个名为 [sysprep](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation) 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
+Windows 有一个名为 [sysprep](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation?view=windows-11) 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
 
 ```PowerShell
 sysprep.exe /generalize /shutdown /oobe

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.10/integrations-in-rancher/istio/istio.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.10/integrations-in-rancher/istio/istio.md
@@ -50,7 +50,7 @@ Kiali 是一个全面的可视化辅助工具，用于绘制整个服务网格�
 
 Jaeger 是用于跟踪分布式系统的工具。我们的 Istio 安装程序包括能快速启动的一体化 [Jaeger](https://www.jaegertracing.io/) 安装。
 
-请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/latest/operator/#production-strategy)。
+请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/1.65/operator/#production-strategy)。
 
 ## 先决条件
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.10/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.10/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
@@ -62,7 +62,7 @@ Prometheus 不是用于长期存储指标的，它只用于短期存储。
 
 ### 关于 Prometheus Exporters
 
-许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 [promcat.io](https://promcat.io/) 和 [ExporterHub](https://exporterhub.io/) 上找到一个由 SysDig 策划的 exporter 列表。
+许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 [ExporterHub](https://exporterhub.io/) 上找到一个策划的 exporter 列表。
 
 ### Prometheus 的编程语言和框架支持
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.10/reference-guides/monitoring-v2-configuration/examples.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.10/reference-guides/monitoring-v2-configuration/examples.md
@@ -16,7 +16,7 @@ PrometheusRule 包含你通常放置在 [Prometheus 规则文件](https://promet
 
 要在集群中更细粒度地应用 PrometheusRules，你可以使用 Prometheus 资源的 ruleSelector 字段，从而根据添加到 PrometheusRules 资源的标签来选择要加载到 Prometheus 上的 PrometheusRule。
 
-你可以在[此页面](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/alerting.md)找到 PrometheusRule 示例。
+你可以在[此页面](https://prometheus-operator.dev/docs/developer/alerting/)找到 PrometheusRule 示例。
 
 ## Alertmanager 配置
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.11/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.11/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -23,15 +23,13 @@ title: Rancher Equinix Metal 快速入门
 
 ## 先决条件
 
-- [Equinix Metal 账号](https://metal.equinix.com/developers/docs/accounts/users/)
-- [Equinix Metal 项目](https://metal.equinix.com/developers/docs/accounts/projects/)
+- [Equinix Metal 账号](https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/)
+- [Equinix Metal 项目](https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/)
 
 
 ### 1. 配置 Equinix Metal 主机
 
-开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 [Equinix Metal 部署](https://metal.equinix.com/developers/docs/deploy/on-demand/)。以下链接介绍 Equinix Metal Server 的类型以及价格：
-- [Equinix Metal Server 类型](https://metal.equinix.com/developers/docs/servers/about/)
-- [Equinix Metal 价格](https://metal.equinix.com/developers/docs/servers/server-specs/)
+开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 [Equinix Metal 部署](https://metal.equinix.com/developers/docs/deploy/on-demand/)。You can find additional information on Equinix Metal server types in the [Equinix Metal Documentation](https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/).
 
 :::note 注意事项：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.11/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.11/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
@@ -129,7 +129,7 @@ cloud-init clean -s -l
 
 ### Windows 准备
 
-Windows 有一个名为 [sysprep](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation) 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
+Windows 有一个名为 [sysprep](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation?view=windows-11) 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
 
 ```PowerShell
 sysprep.exe /generalize /shutdown /oobe

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.11/integrations-in-rancher/istio/istio.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.11/integrations-in-rancher/istio/istio.md
@@ -50,7 +50,7 @@ Kiali 是一个全面的可视化辅助工具，用于绘制整个服务网格�
 
 Jaeger 是用于跟踪分布式系统的工具。我们的 Istio 安装程序包括能快速启动的一体化 [Jaeger](https://www.jaegertracing.io/) 安装。
 
-请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/latest/operator/#production-strategy)。
+请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/1.65/operator/#production-strategy)。
 
 ## 先决条件
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.11/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.11/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
@@ -62,7 +62,7 @@ Prometheus 不是用于长期存储指标的，它只用于短期存储。
 
 ### 关于 Prometheus Exporters
 
-许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 [promcat.io](https://promcat.io/) 和 [ExporterHub](https://exporterhub.io/) 上找到一个由 SysDig 策划的 exporter 列表。
+许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 [ExporterHub](https://exporterhub.io/) 上找到一个策划的 exporter 列表。
 
 ### Prometheus 的编程语言和框架支持
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.11/reference-guides/monitoring-v2-configuration/examples.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.11/reference-guides/monitoring-v2-configuration/examples.md
@@ -16,7 +16,7 @@ PrometheusRule 包含你通常放置在 [Prometheus 规则文件](https://promet
 
 要在集群中更细粒度地应用 PrometheusRules，你可以使用 Prometheus 资源的 ruleSelector 字段，从而根据添加到 PrometheusRules 资源的标签来选择要加载到 Prometheus 上的 PrometheusRule。
 
-你可以在[此页面](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/alerting.md)找到 PrometheusRule 示例。
+你可以在[此页面](https://prometheus-operator.dev/docs/developer/alerting/)找到 PrometheusRule 示例。
 
 ## Alertmanager 配置
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -23,15 +23,13 @@ title: Rancher Equinix Metal 快速入门
 
 ## 先决条件
 
-- [Equinix Metal 账号](https://metal.equinix.com/developers/docs/accounts/users/)
-- [Equinix Metal 项目](https://metal.equinix.com/developers/docs/accounts/projects/)
+- [Equinix Metal 账号](https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/)
+- [Equinix Metal 项目](https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/)
 
 
 ### 1. 配置 Equinix Metal 主机
 
-开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 [Equinix Metal 部署](https://metal.equinix.com/developers/docs/deploy/on-demand/)。以下链接介绍 Equinix Metal Server 的类型以及价格：
-- [Equinix Metal Server 类型](https://metal.equinix.com/developers/docs/servers/about/)
-- [Equinix Metal 价格](https://metal.equinix.com/developers/docs/servers/server-specs/)
+开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 [Equinix Metal 部署](https://metal.equinix.com/developers/docs/deploy/on-demand/)。You can find additional information on Equinix Metal server types in the [Equinix Metal Documentation](https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/).
 
 :::note 注意事项：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
@@ -129,7 +129,7 @@ cloud-init clean -s -l
 
 ### Windows 准备
 
-Windows 有一个名为 [sysprep](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation) 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
+Windows 有一个名为 [sysprep](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation?view=windows-11) 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
 
 ```PowerShell
 sysprep.exe /generalize /shutdown /oobe

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/integrations-in-rancher/istio/istio.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/integrations-in-rancher/istio/istio.md
@@ -50,7 +50,7 @@ Kiali 是一个全面的可视化辅助工具，用于绘制整个服务网格�
 
 Jaeger 是用于跟踪分布式系统的工具。我们的 Istio 安装程序包括能快速启动的一体化 [Jaeger](https://www.jaegertracing.io/) 安装。
 
-请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/latest/operator/#production-strategy)。
+请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/1.65/operator/#production-strategy)。
 
 ## 先决条件
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/pages-for-subheaders/istio.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/pages-for-subheaders/istio.md
@@ -47,7 +47,7 @@ Kiali 是一个全面的可视化辅助工具，用于绘制整个服务网格�
 
 Jaeger 是用于跟踪分布式系统的工具。我们的 Istio 安装程序包括能快速启动的一体化 [Jaeger](https://www.jaegertracing.io/) 安装。
 
-请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/latest/operator/#production-strategy)。
+请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/1.65/operator/#production-strategy)。
 
 ## 先决条件
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
@@ -62,7 +62,7 @@ Prometheus 不是用于长期存储指标的，它只用于短期存储。
 
 ### 关于 Prometheus Exporters
 
-许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 [promcat.io](https://promcat.io/) 和 [ExporterHub](https://exporterhub.io/) 上找到一个由 SysDig 策划的 exporter 列表。
+许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 [ExporterHub](https://exporterhub.io/) 上找到一个策划的 exporter 列表。
 
 ### Prometheus 的编程语言和框架支持
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/monitoring-v2-configuration/examples.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/monitoring-v2-configuration/examples.md
@@ -16,7 +16,7 @@ PrometheusRule 包含你通常放置在 [Prometheus 规则文件](https://promet
 
 要在集群中更细粒度地应用 PrometheusRules，你可以使用 Prometheus 资源的 ruleSelector 字段，从而根据添加到 PrometheusRules 资源的标签来选择要加载到 Prometheus 上的 PrometheusRule。
 
-你可以在[此页面](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/alerting.md)找到 PrometheusRule 示例。
+你可以在[此页面](https://prometheus-operator.dev/docs/developer/alerting/)找到 PrometheusRule 示例。
 
 ### Alertmanager 配置
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -27,15 +27,13 @@ title: Rancher Equinix Metal 快速入门
 
 ## 先决条件
 
-- [Equinix Metal 账号](https://metal.equinix.com/developers/docs/accounts/users/)
-- [Equinix Metal 项目](https://metal.equinix.com/developers/docs/accounts/projects/)
+- [Equinix Metal 账号](https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/)
+- [Equinix Metal 项目](https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/)
 
 
 ### 1. 配置 Equinix Metal 主机
 
-开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 [Equinix Metal 部署](https://metal.equinix.com/developers/docs/deploy/on-demand/)。以下链接介绍 Equinix Metal Server 的类型以及价格：
-- [Equinix Metal Server 类型](https://metal.equinix.com/developers/docs/servers/about/)
-- [Equinix Metal 价格](https://metal.equinix.com/developers/docs/servers/server-specs/)
+开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 [Equinix Metal 部署](https://metal.equinix.com/developers/docs/deploy/on-demand/)。You can find additional information on Equinix Metal server types in the [Equinix Metal Documentation](https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/).
 
 :::note 注意事项：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
@@ -129,7 +129,7 @@ cloud-init clean -s -l
 
 ### Windows 准备
 
-Windows 有一个名为 [sysprep](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation) 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
+Windows 有一个名为 [sysprep](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation?view=windows-11) 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
 
 ```PowerShell
 sysprep.exe /generalize /shutdown /oobe

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7/integrations-in-rancher/istio/istio.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7/integrations-in-rancher/istio/istio.md
@@ -50,7 +50,7 @@ Kiali 是一个全面的可视化辅助工具，用于绘制整个服务网格�
 
 Jaeger 是用于跟踪分布式系统的工具。我们的 Istio 安装程序包括能快速启动的一体化 [Jaeger](https://www.jaegertracing.io/) 安装。
 
-请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/latest/operator/#production-strategy)。
+请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/1.65/operator/#production-strategy)。
 
 ## 先决条件
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7/pages-for-subheaders/istio.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7/pages-for-subheaders/istio.md
@@ -47,7 +47,7 @@ Kiali 是一个全面的可视化辅助工具，用于绘制整个服务网格�
 
 Jaeger 是用于跟踪分布式系统的工具。我们的 Istio 安装程序包括能快速启动的一体化 [Jaeger](https://www.jaegertracing.io/) 安装。
 
-请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/latest/operator/#production-strategy)。
+请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/1.65/operator/#production-strategy)。
 
 ## 先决条件
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
@@ -62,7 +62,7 @@ Prometheus 不是用于长期存储指标的，它只用于短期存储。
 
 ### 关于 Prometheus Exporters
 
-许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 [promcat.io](https://promcat.io/) 和 [ExporterHub](https://exporterhub.io/) 上找到一个由 SysDig 策划的 exporter 列表。
+许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 [ExporterHub](https://exporterhub.io/) 上找到一个策划的 exporter 列表。
 
 ### Prometheus 的编程语言和框架支持
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7/reference-guides/monitoring-v2-configuration/examples.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7/reference-guides/monitoring-v2-configuration/examples.md
@@ -16,7 +16,7 @@ PrometheusRule 包含你通常放置在 [Prometheus 规则文件](https://promet
 
 要在集群中更细粒度地应用 PrometheusRules，你可以使用 Prometheus 资源的 ruleSelector 字段，从而根据添加到 PrometheusRules 资源的标签来选择要加载到 Prometheus 上的 PrometheusRule。
 
-你可以在[此页面](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/alerting.md)找到 PrometheusRule 示例。
+你可以在[此页面](https://prometheus-operator.dev/docs/developer/alerting/)找到 PrometheusRule 示例。
 
 ### Alertmanager 配置
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.8/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.8/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -23,15 +23,13 @@ title: Rancher Equinix Metal 快速入门
 
 ## 先决条件
 
-- [Equinix Metal 账号](https://metal.equinix.com/developers/docs/accounts/users/)
-- [Equinix Metal 项目](https://metal.equinix.com/developers/docs/accounts/projects/)
+- [Equinix Metal 账号](https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/)
+- [Equinix Metal 项目](https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/)
 
 
 ### 1. 配置 Equinix Metal 主机
 
-开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 [Equinix Metal 部署](https://metal.equinix.com/developers/docs/deploy/on-demand/)。以下链接介绍 Equinix Metal Server 的类型以及价格：
-- [Equinix Metal Server 类型](https://metal.equinix.com/developers/docs/servers/about/)
-- [Equinix Metal 价格](https://metal.equinix.com/developers/docs/servers/server-specs/)
+开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 [Equinix Metal 部署](https://metal.equinix.com/developers/docs/deploy/on-demand/)。You can find additional information on Equinix Metal server types in the [Equinix Metal Documentation](https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/).
 
 :::note 注意事项：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.8/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.8/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
@@ -129,7 +129,7 @@ cloud-init clean -s -l
 
 ### Windows 准备
 
-Windows 有一个名为 [sysprep](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation) 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
+Windows 有一个名为 [sysprep](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation?view=windows-11) 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
 
 ```PowerShell
 sysprep.exe /generalize /shutdown /oobe

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.8/integrations-in-rancher/istio/istio.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.8/integrations-in-rancher/istio/istio.md
@@ -50,7 +50,7 @@ Kiali 是一个全面的可视化辅助工具，用于绘制整个服务网格�
 
 Jaeger 是用于跟踪分布式系统的工具。我们的 Istio 安装程序包括能快速启动的一体化 [Jaeger](https://www.jaegertracing.io/) 安装。
 
-请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/latest/operator/#production-strategy)。
+请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/1.65/operator/#production-strategy)。
 
 ## 先决条件
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.8/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.8/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
@@ -62,7 +62,7 @@ Prometheus 不是用于长期存储指标的，它只用于短期存储。
 
 ### 关于 Prometheus Exporters
 
-许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 [promcat.io](https://promcat.io/) 和 [ExporterHub](https://exporterhub.io/) 上找到一个由 SysDig 策划的 exporter 列表。
+许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 [ExporterHub](https://exporterhub.io/) 上找到一个策划的 exporter 列表。
 
 ### Prometheus 的编程语言和框架支持
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.8/reference-guides/monitoring-v2-configuration/examples.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.8/reference-guides/monitoring-v2-configuration/examples.md
@@ -16,7 +16,7 @@ PrometheusRule 包含你通常放置在 [Prometheus 规则文件](https://promet
 
 要在集群中更细粒度地应用 PrometheusRules，你可以使用 Prometheus 资源的 ruleSelector 字段，从而根据添加到 PrometheusRules 资源的标签来选择要加载到 Prometheus 上的 PrometheusRule。
 
-你可以在[此页面](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/alerting.md)找到 PrometheusRule 示例。
+你可以在[此页面](https://prometheus-operator.dev/docs/developer/alerting/)找到 PrometheusRule 示例。
 
 ## Alertmanager 配置
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.9/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.9/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -23,15 +23,13 @@ title: Rancher Equinix Metal 快速入门
 
 ## 先决条件
 
-- [Equinix Metal 账号](https://metal.equinix.com/developers/docs/accounts/users/)
-- [Equinix Metal 项目](https://metal.equinix.com/developers/docs/accounts/projects/)
+- [Equinix Metal 账号](https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/)
+- [Equinix Metal 项目](https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/)
 
 
 ### 1. 配置 Equinix Metal 主机
 
-开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 [Equinix Metal 部署](https://metal.equinix.com/developers/docs/deploy/on-demand/)。以下链接介绍 Equinix Metal Server 的类型以及价格：
-- [Equinix Metal Server 类型](https://metal.equinix.com/developers/docs/servers/about/)
-- [Equinix Metal 价格](https://metal.equinix.com/developers/docs/servers/server-specs/)
+开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 [Equinix Metal 部署](https://metal.equinix.com/developers/docs/deploy/on-demand/)。You can find additional information on Equinix Metal server types in the [Equinix Metal Documentation](https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/).
 
 :::note 注意事项：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.9/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.9/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
@@ -129,7 +129,7 @@ cloud-init clean -s -l
 
 ### Windows 准备
 
-Windows 有一个名为 [sysprep](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation) 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
+Windows 有一个名为 [sysprep](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation?view=windows-11) 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
 
 ```PowerShell
 sysprep.exe /generalize /shutdown /oobe

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.9/integrations-in-rancher/istio/istio.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.9/integrations-in-rancher/istio/istio.md
@@ -50,7 +50,7 @@ Kiali 是一个全面的可视化辅助工具，用于绘制整个服务网格�
 
 Jaeger 是用于跟踪分布式系统的工具。我们的 Istio 安装程序包括能快速启动的一体化 [Jaeger](https://www.jaegertracing.io/) 安装。
 
-请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/latest/operator/#production-strategy)。
+请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/1.65/operator/#production-strategy)。
 
 ## 先决条件
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.9/pages-for-subheaders/istio.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.9/pages-for-subheaders/istio.md
@@ -47,7 +47,7 @@ Kiali 是一个全面的可视化辅助工具，用于绘制整个服务网格�
 
 Jaeger 是用于跟踪分布式系统的工具。我们的 Istio 安装程序包括能快速启动的一体化 [Jaeger](https://www.jaegertracing.io/) 安装。
 
-请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/latest/operator/#production-strategy)。
+请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 [Jaeger 文档](https://www.jaegertracing.io/docs/1.65/operator/#production-strategy)。
 
 ## 先决条件
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.9/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.9/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
@@ -62,7 +62,7 @@ Prometheus 不是用于长期存储指标的，它只用于短期存储。
 
 ### 关于 Prometheus Exporters
 
-许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 [promcat.io](https://promcat.io/) 和 [ExporterHub](https://exporterhub.io/) 上找到一个由 SysDig 策划的 exporter 列表。
+许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 [ExporterHub](https://exporterhub.io/) 上找到一个策划的 exporter 列表。
 
 ### Prometheus 的编程语言和框架支持
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.9/reference-guides/monitoring-v2-configuration/examples.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.9/reference-guides/monitoring-v2-configuration/examples.md
@@ -16,7 +16,7 @@ PrometheusRule 包含你通常放置在 [Prometheus 规则文件](https://promet
 
 要在集群中更细粒度地应用 PrometheusRules，你可以使用 Prometheus 资源的 ruleSelector 字段，从而根据添加到 PrometheusRules 资源的标签来选择要加载到 Prometheus 上的 PrometheusRule。
 
-你可以在[此页面](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/alerting.md)找到 PrometheusRule 示例。
+你可以在[此页面](https://prometheus-operator.dev/docs/developer/alerting/)找到 PrometheusRule 示例。
 
 ### Alertmanager 配置
 

--- a/versioned_docs/version-2.10/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/versioned_docs/version-2.10/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -27,15 +27,13 @@ This Quick Start Guide is divided into different tasks for easier consumption.
 
 ## Prerequisites
 
-- An [Equinix Metal account](https://metal.equinix.com/developers/docs/accounts/users/)
-- An [Equinix Metal project](https://metal.equinix.com/developers/docs/accounts/projects/)
+- An [Equinix Metal account](https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/)
+- An [Equinix Metal project](https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/)
 
 
 ### 1. Provision a Equinix Metal Host
 
-Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the [Equinix Metal deployment documentation](https://metal.equinix.com/developers/docs/deploy/on-demand/). You can find additional documentation on Equinix Metal server types and prices below:
-  - [Equinix Metal Server Types](https://metal.equinix.com/developers/docs/servers/about/)
-  - [Equinix Metal Pricing](https://metal.equinix.com/developers/docs/servers/server-specs/)
+Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the [Equinix Metal deployment documentation](https://deploy.equinix.com/developers/docs/metal/deploy/on-demand/). You can find additional information on Equinix Metal server types in the [Equinix Metal Documentation](https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/).
 
 :::note Notes:
 

--- a/versioned_docs/version-2.10/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
+++ b/versioned_docs/version-2.10/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
@@ -131,7 +131,7 @@ cloud-init clean -s -l
 
 ### Windows Preparation
 
-Windows has a utility called [sysprep](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation) that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
+Windows has a utility called [sysprep](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation?view=windows-11) that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
 
 ```PowerShell
 sysprep.exe /generalize /shutdown /oobe

--- a/versioned_docs/version-2.10/integrations-in-rancher/istio/istio.md
+++ b/versioned_docs/version-2.10/integrations-in-rancher/istio/istio.md
@@ -55,7 +55,7 @@ For Istio installations `103.1.0+up1.19.6` and later, Kiali uses a token value f
 
 Our Istio installer includes a quick-start, all-in-one installation of [Jaeger,](https://www.jaegertracing.io/) a tool used for tracing distributed systems.
 
-Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the [Jaeger documentation.](https://www.jaegertracing.io/docs/latest/operator/#production-strategy)
+Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the [Jaeger documentation.](https://www.jaegertracing.io/docs/1.65/operator/#production-strategy)
 
 ## Prerequisites
 

--- a/versioned_docs/version-2.10/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
+++ b/versioned_docs/version-2.10/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
@@ -66,7 +66,7 @@ In general, you want to scrape data from all the workloads running in your clust
 
 ### About Prometheus Exporters
 
-Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports by SysDig on [promcat.io](https://promcat.io/) and on [ExporterHub](https://exporterhub.io/).
+Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports on [ExporterHub](https://exporterhub.io/).
 
 ### Prometheus support in Programming Languages and Frameworks
 

--- a/versioned_docs/version-2.10/reference-guides/monitoring-v2-configuration/examples.md
+++ b/versioned_docs/version-2.10/reference-guides/monitoring-v2-configuration/examples.md
@@ -12,7 +12,7 @@ See the official prometheus-operator GitHub repo for an example [ServiceMonitor]
 
 ## PodMonitor
 
-See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/user-guides/getting-started/#using-podmonitors) for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
+See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors) for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
 
 ## PrometheusRule
 
@@ -20,7 +20,7 @@ A PrometheusRule contains the alerting and recording rules that you would usuall
 
 For a more fine-grained approach, the `ruleSelector` field on a Prometheus resource can select which PrometheusRules should be loaded onto Prometheus, based on the labels attached to the PrometheusRules resources.
 
-See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/user-guides/alerting/) for an example PrometheusRule.
+See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/developer/alerting/) for an example PrometheusRule.
 
 ## Alertmanager Config
 

--- a/versioned_docs/version-2.11/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/versioned_docs/version-2.11/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -27,15 +27,13 @@ This Quick Start Guide is divided into different tasks for easier consumption.
 
 ## Prerequisites
 
-- An [Equinix Metal account](https://metal.equinix.com/developers/docs/accounts/users/)
-- An [Equinix Metal project](https://metal.equinix.com/developers/docs/accounts/projects/)
+- An [Equinix Metal account](https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/)
+- An [Equinix Metal project](https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/)
 
 
 ### 1. Provision a Equinix Metal Host
 
-Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the [Equinix Metal deployment documentation](https://metal.equinix.com/developers/docs/deploy/on-demand/). You can find additional documentation on Equinix Metal server types and prices below:
-  - [Equinix Metal Server Types](https://metal.equinix.com/developers/docs/servers/about/)
-  - [Equinix Metal Pricing](https://metal.equinix.com/developers/docs/servers/server-specs/)
+Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the [Equinix Metal deployment documentation](https://deploy.equinix.com/developers/docs/metal/deploy/on-demand/). You can find additional information on Equinix Metal server types in the [Equinix Metal Documentation](https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/).
 
 :::note Notes:
 

--- a/versioned_docs/version-2.11/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
+++ b/versioned_docs/version-2.11/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
@@ -131,7 +131,7 @@ cloud-init clean -s -l
 
 ### Windows Preparation
 
-Windows has a utility called [sysprep](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation) that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
+Windows has a utility called [sysprep](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation?view=windows-11) that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
 
 ```PowerShell
 sysprep.exe /generalize /shutdown /oobe

--- a/versioned_docs/version-2.11/integrations-in-rancher/istio/istio.md
+++ b/versioned_docs/version-2.11/integrations-in-rancher/istio/istio.md
@@ -63,7 +63,7 @@ For Istio installations `103.1.0+up1.19.6` and later, Kiali uses a token value f
 
 Our Istio installer includes a quick-start, all-in-one installation of [Jaeger,](https://www.jaegertracing.io/) a tool used for tracing distributed systems.
 
-Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the [Jaeger documentation.](https://www.jaegertracing.io/docs/latest/operator/#production-strategy)
+Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the [Jaeger documentation.](https://www.jaegertracing.io/docs/1.65/operator/#production-strategy)
 
 ## Prerequisites
 

--- a/versioned_docs/version-2.11/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
+++ b/versioned_docs/version-2.11/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
@@ -66,7 +66,7 @@ In general, you want to scrape data from all the workloads running in your clust
 
 ### About Prometheus Exporters
 
-Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports by SysDig on [promcat.io](https://promcat.io/) and on [ExporterHub](https://exporterhub.io/).
+Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports on [ExporterHub](https://exporterhub.io/).
 
 ### Prometheus support in Programming Languages and Frameworks
 

--- a/versioned_docs/version-2.11/reference-guides/monitoring-v2-configuration/examples.md
+++ b/versioned_docs/version-2.11/reference-guides/monitoring-v2-configuration/examples.md
@@ -12,7 +12,7 @@ See the official prometheus-operator GitHub repo for an example [ServiceMonitor]
 
 ## PodMonitor
 
-See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/user-guides/getting-started/#using-podmonitors) for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
+See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors) for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
 
 ## PrometheusRule
 
@@ -20,7 +20,7 @@ A PrometheusRule contains the alerting and recording rules that you would usuall
 
 For a more fine-grained approach, the `ruleSelector` field on a Prometheus resource can select which PrometheusRules should be loaded onto Prometheus, based on the labels attached to the PrometheusRules resources.
 
-See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/user-guides/alerting/) for an example PrometheusRule.
+See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/developer/alerting/) for an example PrometheusRule.
 
 ## Alertmanager Config
 

--- a/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/versioned_docs/version-2.6/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -27,15 +27,13 @@ This Quick Start Guide is divided into different tasks for easier consumption.
 
 ## Prerequisites
 
-- An [Equinix Metal account](https://metal.equinix.com/developers/docs/accounts/users/)
-- An [Equinix Metal project](https://metal.equinix.com/developers/docs/accounts/projects/)
+- An [Equinix Metal account](https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/)
+- An [Equinix Metal project](https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/)
 
 
 ### 1. Provision a Equinix Metal Host
 
-Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, CLI, or API. You can find instructions for each deployment type on the [Equinix Metal deployment documentation](https://metal.equinix.com/developers/docs/deploy/on-demand/). You can find additional documentation on Equinix Metal server types and prices below:
-  - [Equinix Metal Server Types](https://metal.equinix.com/developers/docs/servers/about/)
-  - [Equinix Metal Pricing](https://metal.equinix.com/developers/docs/servers/server-specs/)
+Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, CLI, or API. You can find instructions for each deployment type on the [Equinix Metal deployment documentation](https://deploy.equinix.com/developers/docs/metal/deploy/on-demand/). You can find additional information on Equinix Metal server types in the [Equinix Metal Documentation](https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/).
 
 :::note Notes:
 

--- a/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
+++ b/versioned_docs/version-2.6/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
@@ -131,7 +131,7 @@ cloud-init clean -s -l
 
 ### Windows Preparation
 
-Windows has a utility called [sysprep](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation) that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
+Windows has a utility called [sysprep](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation?view=windows-11) that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
 
 ```PowerShell
 sysprep.exe /generalize /shutdown /oobe

--- a/versioned_docs/version-2.6/integrations-in-rancher/istio/istio.md
+++ b/versioned_docs/version-2.6/integrations-in-rancher/istio/istio.md
@@ -51,7 +51,7 @@ You can check the health of the service mesh, or drill down to see the incoming 
 
 Our Istio installer includes a quick-start, all-in-one installation of [Jaeger,](https://www.jaegertracing.io/) a tool used for tracing distributed systems.
 
-Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the [Jaeger documentation.](https://www.jaegertracing.io/docs/latest/operator/#production-strategy)
+Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the [Jaeger documentation.](https://www.jaegertracing.io/docs/1.65/operator/#production-strategy)
 
 ## Prerequisites
 

--- a/versioned_docs/version-2.6/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
+++ b/versioned_docs/version-2.6/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
@@ -66,7 +66,7 @@ In general, you want to scrape data from all the workloads running in your clust
 
 ### About Prometheus Exporters
 
-Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports by SysDig on [promcat.io](https://promcat.io/) and on [ExporterHub](https://exporterhub.io/).
+Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports on [ExporterHub](https://exporterhub.io/).
 
 ### Prometheus support in Programming Languages and Frameworks
 

--- a/versioned_docs/version-2.6/reference-guides/monitoring-v2-configuration/examples.md
+++ b/versioned_docs/version-2.6/reference-guides/monitoring-v2-configuration/examples.md
@@ -12,7 +12,7 @@ See the official prometheus-operator GitHub repo for an example [ServiceMonitor]
 
 ## PodMonitor
 
-See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/user-guides/getting-started/#using-podmonitors) for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
+See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors) for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
 
 ## PrometheusRule
 
@@ -20,7 +20,7 @@ A PrometheusRule contains the alerting and recording rules that you would usuall
 
 For a more fine-grained approach, the `ruleSelector` field on a Prometheus resource can select which PrometheusRules should be loaded onto Prometheus, based on the labels attached to the PrometheusRules resources.
 
-See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/user-guides/alerting/) for an example PrometheusRule.
+See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/developer/alerting/) for an example PrometheusRule.
 
 ## Alertmanager Config
 

--- a/versioned_docs/version-2.7/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/versioned_docs/version-2.7/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -27,15 +27,13 @@ This Quick Start Guide is divided into different tasks for easier consumption.
 
 ## Prerequisites
 
-- An [Equinix Metal account](https://metal.equinix.com/developers/docs/accounts/users/)
-- An [Equinix Metal project](https://metal.equinix.com/developers/docs/accounts/projects/)
+- An [Equinix Metal account](https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/)
+- An [Equinix Metal project](https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/)
 
 
 ### 1. Provision a Equinix Metal Host
 
-Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the [Equinix Metal deployment documentation](https://metal.equinix.com/developers/docs/deploy/on-demand/). You can find additional documentation on Equinix Metal server types and prices below:
-  - [Equinix Metal Server Types](https://metal.equinix.com/developers/docs/servers/about/)
-  - [Equinix Metal Pricing](https://metal.equinix.com/developers/docs/servers/server-specs/)
+Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the [Equinix Metal deployment documentation](https://deploy.equinix.com/developers/docs/metal/deploy/on-demand/). You can find additional information on Equinix Metal server types in the [Equinix Metal Documentation](https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/).
 
 :::note Notes:
 

--- a/versioned_docs/version-2.7/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
+++ b/versioned_docs/version-2.7/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
@@ -131,7 +131,7 @@ cloud-init clean -s -l
 
 ### Windows Preparation
 
-Windows has a utility called [sysprep](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation) that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
+Windows has a utility called [sysprep](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation?view=windows-11) that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
 
 ```PowerShell
 sysprep.exe /generalize /shutdown /oobe

--- a/versioned_docs/version-2.7/integrations-in-rancher/istio/istio.md
+++ b/versioned_docs/version-2.7/integrations-in-rancher/istio/istio.md
@@ -55,7 +55,7 @@ For Istio installations `103.1.0+up1.19.6` and later, Kiali uses a token value f
 
 Our Istio installer includes a quick-start, all-in-one installation of [Jaeger,](https://www.jaegertracing.io/) a tool used for tracing distributed systems.
 
-Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the [Jaeger documentation.](https://www.jaegertracing.io/docs/latest/operator/#production-strategy)
+Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the [Jaeger documentation.](https://www.jaegertracing.io/docs/1.65/operator/#production-strategy)
 
 ## Prerequisites
 

--- a/versioned_docs/version-2.7/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
+++ b/versioned_docs/version-2.7/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
@@ -66,7 +66,7 @@ In general, you want to scrape data from all the workloads running in your clust
 
 ### About Prometheus Exporters
 
-Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports by SysDig on [promcat.io](https://promcat.io/) and on [ExporterHub](https://exporterhub.io/).
+Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports on [ExporterHub](https://exporterhub.io/).
 
 ### Prometheus support in Programming Languages and Frameworks
 

--- a/versioned_docs/version-2.7/reference-guides/monitoring-v2-configuration/examples.md
+++ b/versioned_docs/version-2.7/reference-guides/monitoring-v2-configuration/examples.md
@@ -12,7 +12,7 @@ See the official prometheus-operator GitHub repo for an example [ServiceMonitor]
 
 ## PodMonitor
 
-See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/user-guides/getting-started/#using-podmonitors) for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
+See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors) for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
 
 ## PrometheusRule
 
@@ -20,7 +20,7 @@ A PrometheusRule contains the alerting and recording rules that you would usuall
 
 For a more fine-grained approach, the `ruleSelector` field on a Prometheus resource can select which PrometheusRules should be loaded onto Prometheus, based on the labels attached to the PrometheusRules resources.
 
-See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/user-guides/alerting/) for an example PrometheusRule.
+See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/developer/alerting/) for an example PrometheusRule.
 
 ## Alertmanager Config
 

--- a/versioned_docs/version-2.8/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/versioned_docs/version-2.8/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -27,15 +27,13 @@ This Quick Start Guide is divided into different tasks for easier consumption.
 
 ## Prerequisites
 
-- An [Equinix Metal account](https://metal.equinix.com/developers/docs/accounts/users/)
-- An [Equinix Metal project](https://metal.equinix.com/developers/docs/accounts/projects/)
+- An [Equinix Metal account](https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/)
+- An [Equinix Metal project](https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/)
 
 
 ### 1. Provision a Equinix Metal Host
 
-Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, CLI, or API. You can find instructions for each deployment type on the [Equinix Metal deployment documentation](https://metal.equinix.com/developers/docs/deploy/on-demand/). You can find additional documentation on Equinix Metal server types and prices below:
-  - [Equinix Metal Server Types](https://metal.equinix.com/developers/docs/servers/about/)
-  - [Equinix Metal Pricing](https://metal.equinix.com/developers/docs/servers/server-specs/)
+Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, CLI, or API. You can find instructions for each deployment type on the [Equinix Metal deployment documentation](https://deploy.equinix.com/developers/docs/metal/deploy/on-demand/). You can find additional information on Equinix Metal server types in the [Equinix Metal Documentation](https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/).
 
 :::note Notes:
 

--- a/versioned_docs/version-2.8/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
+++ b/versioned_docs/version-2.8/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
@@ -131,7 +131,7 @@ cloud-init clean -s -l
 
 ### Windows Preparation
 
-Windows has a utility called [sysprep](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation) that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
+Windows has a utility called [sysprep](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation?view=windows-11) that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
 
 ```PowerShell
 sysprep.exe /generalize /shutdown /oobe

--- a/versioned_docs/version-2.8/integrations-in-rancher/istio/istio.md
+++ b/versioned_docs/version-2.8/integrations-in-rancher/istio/istio.md
@@ -55,7 +55,7 @@ For Istio installations `103.1.0+up1.19.6` and later, Kiali uses a token value f
 
 Our Istio installer includes a quick-start, all-in-one installation of [Jaeger,](https://www.jaegertracing.io/) a tool used for tracing distributed systems.
 
-Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the [Jaeger documentation.](https://www.jaegertracing.io/docs/latest/operator/#production-strategy)
+Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the [Jaeger documentation.](https://www.jaegertracing.io/docs/1.65/operator/#production-strategy)
 
 ## Prerequisites
 

--- a/versioned_docs/version-2.8/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
+++ b/versioned_docs/version-2.8/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
@@ -66,7 +66,7 @@ In general, you want to scrape data from all the workloads running in your clust
 
 ### About Prometheus Exporters
 
-Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports by SysDig on [promcat.io](https://promcat.io/) and on [ExporterHub](https://exporterhub.io/).
+Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports on [ExporterHub](https://exporterhub.io/).
 
 ### Prometheus support in Programming Languages and Frameworks
 

--- a/versioned_docs/version-2.8/reference-guides/monitoring-v2-configuration/examples.md
+++ b/versioned_docs/version-2.8/reference-guides/monitoring-v2-configuration/examples.md
@@ -12,7 +12,7 @@ See the official prometheus-operator GitHub repo for an example [ServiceMonitor]
 
 ## PodMonitor
 
-See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/user-guides/getting-started/#using-podmonitors) for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
+See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors) for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
 
 ## PrometheusRule
 
@@ -20,7 +20,7 @@ A PrometheusRule contains the alerting and recording rules that you would usuall
 
 For a more fine-grained approach, the `ruleSelector` field on a Prometheus resource can select which PrometheusRules should be loaded onto Prometheus, based on the labels attached to the PrometheusRules resources.
 
-See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/user-guides/alerting/) for an example PrometheusRule.
+See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/developer/alerting/) for an example PrometheusRule.
 
 ## Alertmanager Config
 

--- a/versioned_docs/version-2.9/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/versioned_docs/version-2.9/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -27,15 +27,13 @@ This Quick Start Guide is divided into different tasks for easier consumption.
 
 ## Prerequisites
 
-- An [Equinix Metal account](https://metal.equinix.com/developers/docs/accounts/users/)
-- An [Equinix Metal project](https://metal.equinix.com/developers/docs/accounts/projects/)
+- An [Equinix Metal account](https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/)
+- An [Equinix Metal project](https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/)
 
 
 ### 1. Provision a Equinix Metal Host
 
-Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the [Equinix Metal deployment documentation](https://metal.equinix.com/developers/docs/deploy/on-demand/). You can find additional documentation on Equinix Metal server types and prices below:
-  - [Equinix Metal Server Types](https://metal.equinix.com/developers/docs/servers/about/)
-  - [Equinix Metal Pricing](https://metal.equinix.com/developers/docs/servers/server-specs/)
+Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the [Equinix Metal deployment documentation](https://deploy.equinix.com/developers/docs/metal/deploy/on-demand/). You can find additional information on Equinix Metal server types in the [Equinix Metal Documentation](https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/).
 
 :::note Notes:
 

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
@@ -131,7 +131,7 @@ cloud-init clean -s -l
 
 ### Windows Preparation
 
-Windows has a utility called [sysprep](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation) that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
+Windows has a utility called [sysprep](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation?view=windows-11) that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
 
 ```PowerShell
 sysprep.exe /generalize /shutdown /oobe

--- a/versioned_docs/version-2.9/integrations-in-rancher/istio/istio.md
+++ b/versioned_docs/version-2.9/integrations-in-rancher/istio/istio.md
@@ -55,7 +55,7 @@ For Istio installations `103.1.0+up1.19.6` and later, Kiali uses a token value f
 
 Our Istio installer includes a quick-start, all-in-one installation of [Jaeger,](https://www.jaegertracing.io/) a tool used for tracing distributed systems.
 
-Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the [Jaeger documentation.](https://www.jaegertracing.io/docs/latest/operator/#production-strategy)
+Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the [Jaeger documentation.](https://www.jaegertracing.io/docs/1.65/operator/#production-strategy)
 
 ## Prerequisites
 

--- a/versioned_docs/version-2.9/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
+++ b/versioned_docs/version-2.9/reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.md
@@ -66,7 +66,7 @@ In general, you want to scrape data from all the workloads running in your clust
 
 ### About Prometheus Exporters
 
-Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports by SysDig on [promcat.io](https://promcat.io/) and on [ExporterHub](https://exporterhub.io/).
+Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports on [ExporterHub](https://exporterhub.io/).
 
 ### Prometheus support in Programming Languages and Frameworks
 

--- a/versioned_docs/version-2.9/reference-guides/monitoring-v2-configuration/examples.md
+++ b/versioned_docs/version-2.9/reference-guides/monitoring-v2-configuration/examples.md
@@ -12,7 +12,7 @@ See the official prometheus-operator GitHub repo for an example [ServiceMonitor]
 
 ## PodMonitor
 
-See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/user-guides/getting-started/#using-podmonitors) for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
+See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors) for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
 
 ## PrometheusRule
 
@@ -20,7 +20,7 @@ A PrometheusRule contains the alerting and recording rules that you would usuall
 
 For a more fine-grained approach, the `ruleSelector` field on a Prometheus resource can select which PrometheusRules should be loaded onto Prometheus, based on the labels attached to the PrometheusRules resources.
 
-See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/user-guides/alerting/) for an example PrometheusRule.
+See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/developer/alerting/) for an example PrometheusRule.
 
 ## Alertmanager Config
 


### PR DESCRIPTION
## Description

- Promcat is [no longer active](https://github.com/sysdiglabs/promcat-resources/issues/265) so I removed the link completely.
- Jaeger has docs for v2 and v1. The v2 docs have a stable/static "latest" link, but the v1 docs which we point to don't. I've hardcoded it to the most recent released version. 