### PR TITLE
Extend Istio deprecation warning to all subpages

### DIFF
--- a/docs/how-to-guides/advanced-user-guides/istio-setup-guide/enable-istio-in-cluster.md
+++ b/docs/how-to-guides/advanced-user-guides/istio-setup-guide/enable-istio-in-cluster.md
@@ -6,6 +6,14 @@ title: Enable Istio in the Cluster
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide/enable-istio-in-cluster"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 :::note Prerequisites:
 
 - Only a user with the `cluster-admin` [Kubernetes default role](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) assigned can configure and install Istio in a Kubernetes cluster.

--- a/docs/how-to-guides/advanced-user-guides/istio-setup-guide/enable-istio-in-namespace.md
+++ b/docs/how-to-guides/advanced-user-guides/istio-setup-guide/enable-istio-in-namespace.md
@@ -6,6 +6,14 @@ title: Enable Istio in a Namespace
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide/enable-istio-in-namespace"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 You will need to manually enable Istio in each namespace that you want to be tracked or controlled by Istio. When Istio is enabled in a namespace, the Envoy sidecar proxy will be automatically injected into all new workloads that are deployed in the namespace.
 
 This namespace setting will only affect new workloads in the namespace. Any preexisting workloads will need to be re-deployed to leverage the sidecar auto injection.

--- a/docs/how-to-guides/advanced-user-guides/istio-setup-guide/generate-and-view-traffic.md
+++ b/docs/how-to-guides/advanced-user-guides/istio-setup-guide/generate-and-view-traffic.md
@@ -6,6 +6,14 @@ title: Generate and View Traffic from Istio
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide/generate-and-view-traffic"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 ## The Kiali Traffic Graph
 
 The Istio overview page provides a link to the Kiali dashboard. From the Kiali dashboard, you can view graphs for each namespace. The Kiali graph provides a powerful way to visualize the topology of your Istio service mesh. It shows you which services communicate with each other.

--- a/docs/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
+++ b/docs/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
@@ -6,7 +6,7 @@ title: Istio Setup Guides
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide"/>
 </head>
 
-:::note
+:::warning
 
 [Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
 

--- a/docs/how-to-guides/advanced-user-guides/istio-setup-guide/set-up-istio-gateway.md
+++ b/docs/how-to-guides/advanced-user-guides/istio-setup-guide/set-up-istio-gateway.md
@@ -6,6 +6,14 @@ title: Set up the Istio Gateway
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide/set-up-istio-gateway"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 The gateway to each cluster can have its own port or load balancer, which is unrelated to a service mesh. By default, each Rancher-provisioned cluster has one NGINX ingress controller allowing traffic into the cluster.
 
 You can use the Nginx Ingress controller with or without Istio installed. If this is the only gateway to your cluster, Istio will be able to route traffic from service to service, but Istio will not be able to receive traffic from outside the cluster.

--- a/docs/how-to-guides/advanced-user-guides/istio-setup-guide/set-up-traffic-management.md
+++ b/docs/how-to-guides/advanced-user-guides/istio-setup-guide/set-up-traffic-management.md
@@ -6,6 +6,14 @@ title: Set up Istio's Components for Traffic Management
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide/set-up-traffic-management"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 A central advantage of traffic management in Istio is that it allows dynamic request routing. Some common applications for dynamic request routing include canary deployments and blue/green deployments. The two key resources in Istio traffic management are *virtual services* and *destination rules*.
 
 - [Virtual services](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/) intercept and direct traffic to your Kubernetes services, allowing you to divide percentages of traffic from a request to different services. You can use them to define a set of routing rules to apply when a host is addressed.

--- a/docs/how-to-guides/advanced-user-guides/istio-setup-guide/use-istio-sidecar.md
+++ b/docs/how-to-guides/advanced-user-guides/istio-setup-guide/use-istio-sidecar.md
@@ -6,6 +6,14 @@ title: Add Deployments and Services with the Istio Sidecar
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide/use-istio-sidecar"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 :::note Prerequisite:
 
 To enable Istio for a workload, the cluster and namespace must have the Istio app installed.

--- a/docs/integrations-in-rancher/istio/configuration-options/configuration-options.md
+++ b/docs/integrations-in-rancher/istio/configuration-options/configuration-options.md
@@ -6,6 +6,14 @@ title: Configuration Options
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/configuration-options"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 ### Egress Support
 
 By default the Egress gateway is disabled, but can be enabled on install or upgrade through the values.yaml or via the [overlay file](#overlay-file).

--- a/docs/integrations-in-rancher/istio/configuration-options/install-istio-on-rke2-cluster.md
+++ b/docs/integrations-in-rancher/istio/configuration-options/install-istio-on-rke2-cluster.md
@@ -6,6 +6,14 @@ title: Additional Steps for Installing Istio on RKE2 and K3s Clusters
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/configuration-options/install-istio-on-rke2-cluster"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 When installing or upgrading the Istio Helm chart through **Apps,**
 
 1. If you are installing the chart, click **Customize Helm options before install** and click **Next**.

--- a/docs/integrations-in-rancher/istio/configuration-options/pod-security-policies.md
+++ b/docs/integrations-in-rancher/istio/configuration-options/pod-security-policies.md
@@ -6,6 +6,14 @@ title: Enable Istio with Pod Security Policies
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/configuration-options/pod-security-policies"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 If you have restrictive Pod Security Policies enabled, then Istio may not be able to function correctly, because it needs certain permissions in order to install itself and manage pod infrastructure. In this section, we will configure a cluster with PSPs enabled for an Istio install, and also set up the Istio CNI plugin.
 
 The Istio CNI plugin removes the need for each application pod to have a privileged `NET_ADMIN` container. For further information, see the [Istio CNI Plugin docs](https://istio.io/docs/setup/additional-setup/cni). Please note that the [Istio CNI Plugin is in alpha](https://istio.io/about/feature-stages/).

--- a/docs/integrations-in-rancher/istio/configuration-options/project-network-isolation.md
+++ b/docs/integrations-in-rancher/istio/configuration-options/project-network-isolation.md
@@ -6,6 +6,14 @@ title: Additional Steps for Project Network Isolation
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/configuration-options/project-network-isolation"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 In clusters where:
 
 - You are using the Canal network plugin with Rancher before v2.5.8, or you are using Rancher v2.5.8+ with an any RKE network plug-in that supports the enforcement of Kubernetes network policies, such as Canal or the Cisco ACI plugin

--- a/docs/integrations-in-rancher/istio/configuration-options/selectors-and-scrape-configurations.md
+++ b/docs/integrations-in-rancher/istio/configuration-options/selectors-and-scrape-configurations.md
@@ -6,6 +6,14 @@ title: Selectors and Scrape Configs
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/configuration-options/selectors-and-scrape-configurations"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 The Monitoring app sets `prometheus.prometheusSpec.ignoreNamespaceSelectors=false`, which enables monitoring across all namespaces by default.
 
 This ensures you can view traffic, metrics and graphs for resources deployed in a namespace with `istio-injection=enabled` label.

--- a/docs/integrations-in-rancher/istio/cpu-and-memory-allocations.md
+++ b/docs/integrations-in-rancher/istio/cpu-and-memory-allocations.md
@@ -6,6 +6,14 @@ title: CPU and Memory Allocations
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/cpu-and-memory-allocations"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 This section describes the minimum recommended computing resources for the Istio components in a cluster.
 
 The CPU and memory allocations for each component are [configurable.](#configuring-resource-allocations)

--- a/docs/integrations-in-rancher/istio/disable-istio.md
+++ b/docs/integrations-in-rancher/istio/disable-istio.md
@@ -6,6 +6,14 @@ title: Disabling Istio
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/disable-istio"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 This section describes how to uninstall Istio in a cluster or disable a namespace, or workload.
 
 ## Uninstall Istio in a Cluster

--- a/docs/integrations-in-rancher/istio/istio.md
+++ b/docs/integrations-in-rancher/istio/istio.md
@@ -6,7 +6,7 @@ title: Istio
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio"/>
 </head>
 
-:::note
+:::warning
 
 [Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
 

--- a/docs/integrations-in-rancher/istio/rbac-for-istio.md
+++ b/docs/integrations-in-rancher/istio/rbac-for-istio.md
@@ -6,6 +6,14 @@ title: Role-based Access Control
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/rbac-for-istio"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 This section describes the permissions required to access Istio features.
 
 The rancher istio chart installs three `ClusterRoles`

--- a/versioned_docs/version-2.11/how-to-guides/advanced-user-guides/istio-setup-guide/enable-istio-in-cluster.md
+++ b/versioned_docs/version-2.11/how-to-guides/advanced-user-guides/istio-setup-guide/enable-istio-in-cluster.md
@@ -6,6 +6,14 @@ title: Enable Istio in the Cluster
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide/enable-istio-in-cluster"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 :::note Prerequisites:
 
 - Only a user with the `cluster-admin` [Kubernetes default role](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) assigned can configure and install Istio in a Kubernetes cluster.

--- a/versioned_docs/version-2.11/how-to-guides/advanced-user-guides/istio-setup-guide/enable-istio-in-namespace.md
+++ b/versioned_docs/version-2.11/how-to-guides/advanced-user-guides/istio-setup-guide/enable-istio-in-namespace.md
@@ -6,6 +6,14 @@ title: Enable Istio in a Namespace
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide/enable-istio-in-namespace"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 You will need to manually enable Istio in each namespace that you want to be tracked or controlled by Istio. When Istio is enabled in a namespace, the Envoy sidecar proxy will be automatically injected into all new workloads that are deployed in the namespace.
 
 This namespace setting will only affect new workloads in the namespace. Any preexisting workloads will need to be re-deployed to leverage the sidecar auto injection.

--- a/versioned_docs/version-2.11/how-to-guides/advanced-user-guides/istio-setup-guide/generate-and-view-traffic.md
+++ b/versioned_docs/version-2.11/how-to-guides/advanced-user-guides/istio-setup-guide/generate-and-view-traffic.md
@@ -6,6 +6,14 @@ title: Generate and View Traffic from Istio
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide/generate-and-view-traffic"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 ## The Kiali Traffic Graph
 
 The Istio overview page provides a link to the Kiali dashboard. From the Kiali dashboard, you can view graphs for each namespace. The Kiali graph provides a powerful way to visualize the topology of your Istio service mesh. It shows you which services communicate with each other.

--- a/versioned_docs/version-2.11/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
+++ b/versioned_docs/version-2.11/how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide.md
@@ -6,7 +6,7 @@ title: Istio Setup Guides
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide"/>
 </head>
 
-:::note
+:::warning
 
 [Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
 

--- a/versioned_docs/version-2.11/how-to-guides/advanced-user-guides/istio-setup-guide/set-up-istio-gateway.md
+++ b/versioned_docs/version-2.11/how-to-guides/advanced-user-guides/istio-setup-guide/set-up-istio-gateway.md
@@ -6,6 +6,14 @@ title: Set up the Istio Gateway
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide/set-up-istio-gateway"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 The gateway to each cluster can have its own port or load balancer, which is unrelated to a service mesh. By default, each Rancher-provisioned cluster has one NGINX ingress controller allowing traffic into the cluster.
 
 You can use the Nginx Ingress controller with or without Istio installed. If this is the only gateway to your cluster, Istio will be able to route traffic from service to service, but Istio will not be able to receive traffic from outside the cluster.

--- a/versioned_docs/version-2.11/how-to-guides/advanced-user-guides/istio-setup-guide/set-up-traffic-management.md
+++ b/versioned_docs/version-2.11/how-to-guides/advanced-user-guides/istio-setup-guide/set-up-traffic-management.md
@@ -6,6 +6,14 @@ title: Set up Istio's Components for Traffic Management
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide/set-up-traffic-management"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 A central advantage of traffic management in Istio is that it allows dynamic request routing. Some common applications for dynamic request routing include canary deployments and blue/green deployments. The two key resources in Istio traffic management are *virtual services* and *destination rules*.
 
 - [Virtual services](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/) intercept and direct traffic to your Kubernetes services, allowing you to divide percentages of traffic from a request to different services. You can use them to define a set of routing rules to apply when a host is addressed.

--- a/versioned_docs/version-2.11/how-to-guides/advanced-user-guides/istio-setup-guide/use-istio-sidecar.md
+++ b/versioned_docs/version-2.11/how-to-guides/advanced-user-guides/istio-setup-guide/use-istio-sidecar.md
@@ -6,6 +6,14 @@ title: Add Deployments and Services with the Istio Sidecar
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/istio-setup-guide/use-istio-sidecar"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 :::note Prerequisite:
 
 To enable Istio for a workload, the cluster and namespace must have the Istio app installed.

--- a/versioned_docs/version-2.11/integrations-in-rancher/istio/configuration-options/configuration-options.md
+++ b/versioned_docs/version-2.11/integrations-in-rancher/istio/configuration-options/configuration-options.md
@@ -6,6 +6,14 @@ title: Configuration Options
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/configuration-options"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 ### Egress Support
 
 By default the Egress gateway is disabled, but can be enabled on install or upgrade through the values.yaml or via the [overlay file](#overlay-file).

--- a/versioned_docs/version-2.11/integrations-in-rancher/istio/configuration-options/install-istio-on-rke2-cluster.md
+++ b/versioned_docs/version-2.11/integrations-in-rancher/istio/configuration-options/install-istio-on-rke2-cluster.md
@@ -6,6 +6,14 @@ title: Additional Steps for Installing Istio on RKE2 and K3s Clusters
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/configuration-options/install-istio-on-rke2-cluster"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 When installing or upgrading the Istio Helm chart through **Apps,**
 
 1. If you are installing the chart, click **Customize Helm options before install** and click **Next**.

--- a/versioned_docs/version-2.11/integrations-in-rancher/istio/configuration-options/pod-security-policies.md
+++ b/versioned_docs/version-2.11/integrations-in-rancher/istio/configuration-options/pod-security-policies.md
@@ -6,6 +6,14 @@ title: Enable Istio with Pod Security Policies
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/configuration-options/pod-security-policies"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 If you have restrictive Pod Security Policies enabled, then Istio may not be able to function correctly, because it needs certain permissions in order to install itself and manage pod infrastructure. In this section, we will configure a cluster with PSPs enabled for an Istio install, and also set up the Istio CNI plugin.
 
 The Istio CNI plugin removes the need for each application pod to have a privileged `NET_ADMIN` container. For further information, see the [Istio CNI Plugin docs](https://istio.io/docs/setup/additional-setup/cni). Please note that the [Istio CNI Plugin is in alpha](https://istio.io/about/feature-stages/).

--- a/versioned_docs/version-2.11/integrations-in-rancher/istio/configuration-options/project-network-isolation.md
+++ b/versioned_docs/version-2.11/integrations-in-rancher/istio/configuration-options/project-network-isolation.md
@@ -6,6 +6,14 @@ title: Additional Steps for Project Network Isolation
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/configuration-options/project-network-isolation"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 In clusters where:
 
 - You are using the Canal network plugin with Rancher before v2.5.8, or you are using Rancher v2.5.8+ with an any RKE network plug-in that supports the enforcement of Kubernetes network policies, such as Canal or the Cisco ACI plugin

--- a/versioned_docs/version-2.11/integrations-in-rancher/istio/configuration-options/selectors-and-scrape-configurations.md
+++ b/versioned_docs/version-2.11/integrations-in-rancher/istio/configuration-options/selectors-and-scrape-configurations.md
@@ -6,6 +6,14 @@ title: Selectors and Scrape Configs
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/configuration-options/selectors-and-scrape-configurations"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 The Monitoring app sets `prometheus.prometheusSpec.ignoreNamespaceSelectors=false`, which enables monitoring across all namespaces by default.
 
 This ensures you can view traffic, metrics and graphs for resources deployed in a namespace with `istio-injection=enabled` label.

--- a/versioned_docs/version-2.11/integrations-in-rancher/istio/cpu-and-memory-allocations.md
+++ b/versioned_docs/version-2.11/integrations-in-rancher/istio/cpu-and-memory-allocations.md
@@ -6,6 +6,14 @@ title: CPU and Memory Allocations
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/cpu-and-memory-allocations"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 This section describes the minimum recommended computing resources for the Istio components in a cluster.
 
 The CPU and memory allocations for each component are [configurable.](#configuring-resource-allocations)

--- a/versioned_docs/version-2.11/integrations-in-rancher/istio/disable-istio.md
+++ b/versioned_docs/version-2.11/integrations-in-rancher/istio/disable-istio.md
@@ -6,6 +6,14 @@ title: Disabling Istio
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/disable-istio"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 This section describes how to uninstall Istio in a cluster or disable a namespace, or workload.
 
 ## Uninstall Istio in a Cluster

--- a/versioned_docs/version-2.11/integrations-in-rancher/istio/istio.md
+++ b/versioned_docs/version-2.11/integrations-in-rancher/istio/istio.md
@@ -6,7 +6,7 @@ title: Istio
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio"/>
 </head>
 
-:::note
+:::warning
 
 [Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
 

--- a/versioned_docs/version-2.11/integrations-in-rancher/istio/rbac-for-istio.md
+++ b/versioned_docs/version-2.11/integrations-in-rancher/istio/rbac-for-istio.md
@@ -6,6 +6,14 @@ title: Role-based Access Control
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/integrations-in-rancher/istio/rbac-for-istio"/>
 </head>
 
+:::warning
+
+[Rancher-Istio](https://github.com/rancher/charts/tree/release-v2.11/charts/rancher-istio) will be deprecated in Rancher v2.12.0; turn to the [SUSE Rancher Application Collection](https://apps.rancher.io) build of Istio for enhanced security (included in SUSE Rancher Prime subscriptions).
+
+Detailed information can be found in [this announcement](https://forums.suse.com/t/deprecation-of-rancher-istio/45043).
+
+:::
+
 This section describes the permissions required to access Istio features.
 
 The rancher istio chart installs three `ClusterRoles`


### PR DESCRIPTION
## Description

The original [PR](https://github.com/rancher/rancher-docs/pull/1627) only added the announcement to the category index page of the Istio sections, but the notice could be missed if users donn't navigate through the index. This PR adds the notice to all subpages as well.