### PR TITLE
Fix broken links

### DIFF
--- a/docs/integrations-in-rancher/cluster-api/cluster-api.md
+++ b/docs/integrations-in-rancher/cluster-api/cluster-api.md
@@ -9,6 +9,6 @@ title: Cluster API (CAPI) with Rancher Turtles
 [Rancher Turtles](https://turtles.docs.rancher.com/) is a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/#operators-in-kubernetes) that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
 
 - Import CAPI clusters into Rancher, by installing the Rancher Cluster Agent in CAPI provisioned clusters.
-- Configure the [CAPI Operator](https://turtles.docs.rancher.com/turtles/next/en/reference-guides/rancher-turtles-chart/values.html#cluster-api-operator-values).
+- Configure the [CAPI Operator](https://turtles.docs.rancher.com/turtles/next/en/operator/chart.html#_cluster_api_operator_values).
 
 The [Overview](./overview.md) section outlines installation options, Rancher Turtles architecture, and a brief demo. For more details, see the [Rancher Turtles documentation](https://turtles.docs.rancher.com/).

--- a/docs/integrations-in-rancher/cluster-api/overview.md
+++ b/docs/integrations-in-rancher/cluster-api/overview.md
@@ -92,7 +92,7 @@ By adding the Turtles repository via the Rancher UI, Rancher can process the ins
 1. Click **Rancher Turtles - the Cluster API Extension**.
 1. Click **Install > Next > Install**.
 
-This process uses the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from the Rancher UI or you can [manually install the chart via Helm](#installing-via-helm). For details about available values, see the Rancher Turtles [Helm chart reference guide](https://turtles.docs.rancher.com/turtles/next/en/reference-guides/rancher-turtles-chart/values.html).
+This process uses the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from the Rancher UI or you can [manually install the chart via Helm](#installing-via-helm). For details about available values, see the Rancher Turtles [Helm chart reference guide](https://turtles.docs.rancher.com/turtles/next/en/operator/chart.html).
 
 The installation may take a few minutes and after completing you can see the following new deployments in the cluster:
 
@@ -177,7 +177,7 @@ stringData:
 
 :::info
 
-For detailed information on the values supported by the chart and their usage, refer to [Helm chart options](https://turtles.docs.rancher.com/turtles/next/en/reference-guides/rancher-turtles-chart/values.html)
+For detailed information on the values supported by the chart and their usage, refer to [Helm chart options](https://turtles.docs.rancher.com/turtles/next/en/operator/chart.html).
 
 :::
 
@@ -185,7 +185,7 @@ For detailed information on the values supported by the chart and their usage, r
 
 :::note
 
-Remember that if you opt for this installation option, you must manage the CAPI Operator installation yourself. You can follow the [CAPI Operator guide](https://turtles.docs.rancher.com/turtles/next/en/contributing/install_capi_operator.html) in the Rancher Turtles documentation for assistance.
+Remember that if you opt for this installation option, you must manage the CAPI Operator installation yourself. You can follow the [manual installation guide](https://turtles.docs.rancher.com/turtles/next/en/operator/manual.html) in the Rancher Turtles documentation for assistance.
 
 :::
 

--- a/versioned_docs/version-2.10/integrations-in-rancher/cluster-api/cluster-api.md
+++ b/versioned_docs/version-2.10/integrations-in-rancher/cluster-api/cluster-api.md
@@ -9,6 +9,6 @@ title: Cluster API (CAPI) with Rancher Turtles
 [Rancher Turtles](https://turtles.docs.rancher.com/) is a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/#operators-in-kubernetes) that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
 
 - Import CAPI clusters into Rancher, by installing the Rancher Cluster Agent in CAPI provisioned clusters.
-- Configure the [CAPI Operator](https://turtles.docs.rancher.com/turtles/next/en/reference-guides/rancher-turtles-chart/values.html#cluster-api-operator-values).
+- Configure the [CAPI Operator](https://turtles.docs.rancher.com/turtles/v0.17/en/operator/chart.html#_cluster_api_operator_values).
 
 The [Overview](./overview.md) section outlines installation options, Rancher Turtles architecture, and a brief demo. For more details, see the [Rancher Turtles documentation](https://turtles.docs.rancher.com/).

--- a/versioned_docs/version-2.10/integrations-in-rancher/cluster-api/overview.md
+++ b/versioned_docs/version-2.10/integrations-in-rancher/cluster-api/overview.md
@@ -92,7 +92,7 @@ By adding the Turtles repository via the Rancher UI, Rancher can process the ins
 1. Click **Rancher Turtles - the Cluster API Extension**.
 1. Click **Install > Next > Install**.
 
-This process uses the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from the Rancher UI or you can [manually install the chart via Helm](#installing-via-helm). For details about available values, see the Rancher Turtles [Helm chart reference guide](https://turtles.docs.rancher.com/turtles/next/en/reference-guides/rancher-turtles-chart/values.html).
+This process uses the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from the Rancher UI or you can [manually install the chart via Helm](#installing-via-helm). For details about available values, see the Rancher Turtles [Helm chart reference guide](https://turtles.docs.rancher.com/turtles/v0.17/en/operator/chart.html).
 
 The installation may take a few minutes and after completing you can see the following new deployments in the cluster:
 
@@ -177,7 +177,7 @@ stringData:
 
 :::info
 
-For detailed information on the values supported by the chart and their usage, refer to [Helm chart options](https://turtles.docs.rancher.com/turtles/next/en/reference-guides/rancher-turtles-chart/values.html)
+For detailed information on the values supported by the chart and their usage, refer to [Helm chart options](https://turtles.docs.rancher.com/turtles/v0.17/en/operator/chart.html).
 
 :::
 
@@ -185,7 +185,7 @@ For detailed information on the values supported by the chart and their usage, r
 
 :::note
 
-Remember that if you opt for this installation option, you must manage the CAPI Operator installation yourself. You can follow the [CAPI Operator guide](https://turtles.docs.rancher.com/turtles/next/en/contributing/install_capi_operator.html) in the Rancher Turtles documentation for assistance.
+Remember that if you opt for this installation option, you must manage the CAPI Operator installation yourself. You can follow the [manual installation guide](https://turtles.docs.rancher.com/turtles/v0.17/en/operator/manual.html) in the Rancher Turtles documentation for assistance.
 
 :::
 

--- a/versioned_docs/version-2.11/integrations-in-rancher/cluster-api/cluster-api.md
+++ b/versioned_docs/version-2.11/integrations-in-rancher/cluster-api/cluster-api.md
@@ -9,6 +9,6 @@ title: Cluster API (CAPI) with Rancher Turtles
 [Rancher Turtles](https://turtles.docs.rancher.com/) is a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/#operators-in-kubernetes) that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
 
 - Import CAPI clusters into Rancher, by installing the Rancher Cluster Agent in CAPI provisioned clusters.
-- Configure the [CAPI Operator](https://turtles.docs.rancher.com/turtles/next/en/reference-guides/rancher-turtles-chart/values.html#cluster-api-operator-values).
+- Configure the [CAPI Operator](https://turtles.docs.rancher.com/turtles/v0.18/en/operator/chart.html#_cluster_api_operator_values).
 
 The [Overview](./overview.md) section outlines installation options, Rancher Turtles architecture, and a brief demo. For more details, see the [Rancher Turtles documentation](https://turtles.docs.rancher.com/).

--- a/versioned_docs/version-2.11/integrations-in-rancher/cluster-api/overview.md
+++ b/versioned_docs/version-2.11/integrations-in-rancher/cluster-api/overview.md
@@ -92,7 +92,7 @@ By adding the Turtles repository via the Rancher UI, Rancher can process the ins
 1. Click **Rancher Turtles - the Cluster API Extension**.
 1. Click **Install > Next > Install**.
 
-This process uses the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from the Rancher UI or you can [manually install the chart via Helm](#installing-via-helm). For details about available values, see the Rancher Turtles [Helm chart reference guide](https://turtles.docs.rancher.com/turtles/next/en/reference-guides/rancher-turtles-chart/values.html).
+This process uses the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from the Rancher UI or you can [manually install the chart via Helm](#installing-via-helm). For details about available values, see the Rancher Turtles [Helm chart reference guide](https://turtles.docs.rancher.com/turtles/v0.18/en/operator/chart.html).
 
 The installation may take a few minutes and after completing you can see the following new deployments in the cluster:
 
@@ -177,7 +177,7 @@ stringData:
 
 :::info
 
-For detailed information on the values supported by the chart and their usage, refer to [Helm chart options](https://turtles.docs.rancher.com/turtles/next/en/reference-guides/rancher-turtles-chart/values.html)
+For detailed information on the values supported by the chart and their usage, refer to [Helm chart options](https://turtles.docs.rancher.com/turtles/v0.18/en/operator/chart.html).
 
 :::
 
@@ -185,7 +185,7 @@ For detailed information on the values supported by the chart and their usage, r
 
 :::note
 
-Remember that if you opt for this installation option, you must manage the CAPI Operator installation yourself. You can follow the [CAPI Operator guide](https://turtles.docs.rancher.com/turtles/next/en/contributing/install_capi_operator.html) in the Rancher Turtles documentation for assistance.
+Remember that if you opt for this installation option, you must manage the CAPI Operator installation yourself. You can follow the [manual installation guide](https://turtles.docs.rancher.com/turtles/v0.18/en/operator/manual.html) in the Rancher Turtles documentation for assistance.
 
 :::
 

--- a/versioned_docs/version-2.9/integrations-in-rancher/cluster-api/cluster-api.md
+++ b/versioned_docs/version-2.9/integrations-in-rancher/cluster-api/cluster-api.md
@@ -9,6 +9,6 @@ title: Cluster API (CAPI) with Rancher Turtles
 [Rancher Turtles](https://turtles.docs.rancher.com/) is a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/#operators-in-kubernetes) that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
 
 - Import CAPI clusters into Rancher, by installing the Rancher Cluster Agent in CAPI provisioned clusters.
-- Configure the [CAPI Operator](https://turtles.docs.rancher.com/turtles/next/en/reference-guides/rancher-turtles-chart/values.html#cluster-api-operator-values).
+- Configure the [CAPI Operator](https://turtles.docs.rancher.com/turtles/v0.15/en/reference-guides/rancher-turtles-chart/values.html#_cluster_api_operator_values).
 
 The [Overview](./overview.md) section outlines installation options, Rancher Turtles architecture, and a brief demo. For more details, see the [Rancher Turtles documentation](https://turtles.docs.rancher.com/).

--- a/versioned_docs/version-2.9/integrations-in-rancher/cluster-api/overview.md
+++ b/versioned_docs/version-2.9/integrations-in-rancher/cluster-api/overview.md
@@ -92,7 +92,7 @@ By adding the Turtles repository via the Rancher UI, Rancher can process the ins
 1. Click **Rancher Turtles - the Cluster API Extension**.
 1. Click **Install > Next > Install**.
 
-This process uses the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from the Rancher UI or you can [manually install the chart via Helm](#installing-via-helm). For details about available values, see the Rancher Turtles [Helm chart reference guide](https://turtles.docs.rancher.com/turtles/next/en/reference-guides/rancher-turtles-chart/values.html).
+This process uses the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from the Rancher UI or you can [manually install the chart via Helm](#installing-via-helm). For details about available values, see the Rancher Turtles [Helm chart reference guide](https://turtles.docs.rancher.com/turtles/v0.15/en/reference-guides/rancher-turtles-chart/values.html).
 
 The installation may take a few minutes and after completing you can see the following new deployments in the cluster:
 
@@ -177,7 +177,7 @@ stringData:
 
 :::info
 
-For detailed information on the values supported by the chart and their usage, refer to [Helm chart options](https://turtles.docs.rancher.com/turtles/next/en/reference-guides/rancher-turtles-chart/values.html)
+For detailed information on the values supported by the chart and their usage, refer to [Helm chart options](https://turtles.docs.rancher.com/turtles/v0.15/en/reference-guides/rancher-turtles-chart/values.html).
 
 :::
 


### PR DESCRIPTION
## Description

Fix broken links. See also https://github.com/rancher/rancher-product-docs/pull/267 and https://github.com/rancher/rancher-product-docs/pull/257.

## Comments

Not sure about the CAPI Operator guide content we should refer to but the current link is broken. Same for older Turtles versions.