### PR TITLE
Updating "About rancher-selinux"

### DIFF
--- a/docs/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
+++ b/docs/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
@@ -6,9 +6,9 @@ title: About rancher-selinux
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux"/>
 </head>
 
-To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides a SELinux RPM. 
+To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides an SELinux RPM.
 
-The `rancher-selinux` RPM only contains policies for the [rancher-logging application.](https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging)
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 The `rancher-selinux` GitHub repository is [here.](https://github.com/rancher/rancher-selinux)
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
@@ -4,7 +4,7 @@ title: 关于 rancher-selinux
 
 要让 Rancher 使用 SELinux，你必须手动为 SELinux 节点启用一些功能。为了解决这个问题，Rancher 提供了一个 SELinux RPM。
 
-`rancher-selinux` RPM 仅包含 [rancher-logging 应用程序](https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging)的策略。
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 `rancher-selinux` 的 GitHub 仓库在[这里](https://github.com/rancher/rancher-selinux)。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.10/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.10/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
@@ -4,7 +4,7 @@ title: 关于 rancher-selinux
 
 要让 Rancher 使用 SELinux，你必须手动为 SELinux 节点启用一些功能。为了解决这个问题，Rancher 提供了一个 SELinux RPM。
 
-`rancher-selinux` RPM 仅包含 [rancher-logging 应用程序](https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging)的策略。
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 `rancher-selinux` 的 GitHub 仓库在[这里](https://github.com/rancher/rancher-selinux)。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.11/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.11/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
@@ -4,7 +4,7 @@ title: 关于 rancher-selinux
 
 要让 Rancher 使用 SELinux，你必须手动为 SELinux 节点启用一些功能。为了解决这个问题，Rancher 提供了一个 SELinux RPM。
 
-`rancher-selinux` RPM 仅包含 [rancher-logging 应用程序](https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging)的策略。
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 `rancher-selinux` 的 GitHub 仓库在[这里](https://github.com/rancher/rancher-selinux)。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
@@ -4,7 +4,7 @@ title: 关于 rancher-selinux
 
 要让 Rancher 使用 SELinux，你必须手动为 SELinux 节点启用一些功能。为了解决这个问题，Rancher 提供了一个 SELinux RPM。
 
-`rancher-selinux` RPM 仅包含 [rancher-logging 应用程序](https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging)的策略。
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 `rancher-selinux` 的 GitHub 仓库在[这里](https://github.com/rancher/rancher-selinux)。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
@@ -4,7 +4,7 @@ title: 关于 rancher-selinux
 
 要让 Rancher 使用 SELinux，你必须手动为 SELinux 节点启用一些功能。为了解决这个问题，Rancher 提供了一个 SELinux RPM。
 
-`rancher-selinux` RPM 仅包含 [rancher-logging 应用程序](https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging)的策略。
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 `rancher-selinux` 的 GitHub 仓库在[这里](https://github.com/rancher/rancher-selinux)。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.8/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.8/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
@@ -4,7 +4,7 @@ title: 关于 rancher-selinux
 
 要让 Rancher 使用 SELinux，你必须手动为 SELinux 节点启用一些功能。为了解决这个问题，Rancher 提供了一个 SELinux RPM。
 
-`rancher-selinux` RPM 仅包含 [rancher-logging 应用程序](https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging)的策略。
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 `rancher-selinux` 的 GitHub 仓库在[这里](https://github.com/rancher/rancher-selinux)。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.9/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.9/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
@@ -4,7 +4,7 @@ title: 关于 rancher-selinux
 
 要让 Rancher 使用 SELinux，你必须手动为 SELinux 节点启用一些功能。为了解决这个问题，Rancher 提供了一个 SELinux RPM。
 
-`rancher-selinux` RPM 仅包含 [rancher-logging 应用程序](https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging)的策略。
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 `rancher-selinux` 的 GitHub 仓库在[这里](https://github.com/rancher/rancher-selinux)。
 

--- a/versioned_docs/version-2.10/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
+++ b/versioned_docs/version-2.10/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
@@ -6,9 +6,9 @@ title: About rancher-selinux
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux"/>
 </head>
 
-To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides a SELinux RPM. 
+To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides an SELinux RPM.
 
-The `rancher-selinux` RPM only contains policies for the [rancher-logging application.](https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging)
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 The `rancher-selinux` GitHub repository is [here.](https://github.com/rancher/rancher-selinux)
 

--- a/versioned_docs/version-2.11/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
+++ b/versioned_docs/version-2.11/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
@@ -6,9 +6,9 @@ title: About rancher-selinux
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux"/>
 </head>
 
-To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides a SELinux RPM. 
+To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides an SELinux RPM.
 
-The `rancher-selinux` RPM only contains policies for the [rancher-logging application.](https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging)
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 The `rancher-selinux` GitHub repository is [here.](https://github.com/rancher/rancher-selinux)
 

--- a/versioned_docs/version-2.6/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
+++ b/versioned_docs/version-2.6/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
@@ -6,9 +6,9 @@ title: About rancher-selinux
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux"/>
 </head>
 
-To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides a SELinux RPM. 
+To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides an SELinux RPM.
 
-The `rancher-selinux` RPM only contains policies for the [rancher-logging application.](https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging)
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 The `rancher-selinux` GitHub repository is [here.](https://github.com/rancher/rancher-selinux)
 

--- a/versioned_docs/version-2.7/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
+++ b/versioned_docs/version-2.7/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
@@ -6,9 +6,9 @@ title: About rancher-selinux
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux"/>
 </head>
 
-To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides a SELinux RPM. 
+To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides an SELinux RPM.
 
-The `rancher-selinux` RPM only contains policies for the [rancher-logging application.](https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging)
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 The `rancher-selinux` GitHub repository is [here.](https://github.com/rancher/rancher-selinux)
 

--- a/versioned_docs/version-2.8/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
+++ b/versioned_docs/version-2.8/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
@@ -6,9 +6,9 @@ title: About rancher-selinux
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux"/>
 </head>
 
-To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides a SELinux RPM. 
+To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides an SELinux RPM.
 
-The `rancher-selinux` RPM only contains policies for the [rancher-logging application.](https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging)
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 The `rancher-selinux` GitHub repository is [here.](https://github.com/rancher/rancher-selinux)
 

--- a/versioned_docs/version-2.9/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
+++ b/versioned_docs/version-2.9/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux.md
@@ -6,9 +6,9 @@ title: About rancher-selinux
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux"/>
 </head>
 
-To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides a SELinux RPM. 
+To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides an SELinux RPM.
 
-The `rancher-selinux` RPM only contains policies for the [rancher-logging application.](https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging)
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 The `rancher-selinux` GitHub repository is [here.](https://github.com/rancher/rancher-selinux)
 


### PR DESCRIPTION
Updating outdated information with [GH definition of `rancher-selinux`](https://github.com/rancher/rancher-selinux#:~:text=rancher%2Dselinux%20contains%20a%20set%20of%20SELinux%20policies%20designed%20to%20grant%20the%20necessary%20privileges%20to%20various%20Rancher%20components%20running%20on%20Linux%20systems%20with%20SELinux%20enabled.) referenced on Slack thread.

Product PR ref: https://github.com/rancher/rancher-product-docs/pull/305