### PR TITLE
Clarify the expected format of `NO_PROXY`

### DIFF
--- a/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-kubernetes.md
+++ b/docs/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-kubernetes.md
@@ -10,7 +10,15 @@ Once the infrastructure is ready, you can continue with setting up a Kubernetes 
 
 The steps to set up RKE, RKE2, or K3s are shown below.
 
-For convenience, export the IP address and port of your proxy into an environment variable and set up the HTTP_PROXY variables for your current shell on every node:
+For convenience, export the IP address and port of your proxy into an environment variable and set up the `HTTP_PROXY` variables for your current shell on every node:
+
+:::caution
+
+The `NO_PROXY` environment variable is not standardized, and the accepted format of the value can differ between applications. When configuring the `NO_PROXY` variable for Rancher, the value must adhere to the format expected by Golang. 
+
+Specifically, the value should be a comma-delimited string which only contains IP addresses, CIDR notation, domain names, or special DNS labels (e.g. `*`). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config)
+
+:::
 
 ```
 export proxy_host="10.0.0.5:8888"

--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -57,6 +57,14 @@ GKE Autopilot clusters aren't supported. See [Compare GKE Autopilot and Standard
 9. If you are using self-signed certificates, you will receive the message `certificate signed by unknown authority`. To work around this validation, copy the command starting with `curl` displayed in Rancher to your clipboard. Then run the command on a node where kubeconfig is configured to point to the cluster you want to import.
 10. When you finish running the command(s) on your node, click **Done**.
 
+:::important
+
+The `NO_PROXY` environment variable is not standardized, and the accepted format of the value can differ between applications. When configuring the `NO_PROXY` variable in Rancher, the value must adhere to the format expected by Golang.
+
+Specifically, the value should be a comma-delimited string which only contains IP addresses, CIDR notation, domain names, or special DNS labels (e.g. `*`). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config)
+
+:::
+
 **Result:**
 
 - Your cluster is registered and assigned a state of **Pending**. Rancher is deploying resources to manage your cluster.

--- a/docs/integrations-in-rancher/fleet/use-fleet-behind-a-proxy.md
+++ b/docs/integrations-in-rancher/fleet/use-fleet-behind-a-proxy.md
@@ -22,6 +22,14 @@ For private nodes or private clusters, the environment variables need to be set 
 
 When adding Fleet agent environment variables for the proxy, replace <PROXY_IP> with your private proxy IP.
 
+:::caution
+
+The `NO_PROXY` environment variable is not standardized, and the accepted format of the value can differ between applications. When configuring the `NO_PROXY` variable in Rancher, the value must adhere to the format expected by Golang.
+
+Specifically, the value should be a comma-delimited string which only contains IP addresses, CIDR notation, domain names, or special DNS labels (e.g. `*`). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config)
+
+:::
+
 | Variable Name | Value |
 |------------------|--------|
 | `HTTP_PROXY` | http://<PROXY_IP>:8888 |

--- a/docs/reference-guides/single-node-rancher-in-docker/http-proxy-configuration.md
+++ b/docs/reference-guides/single-node-rancher-in-docker/http-proxy-configuration.md
@@ -10,11 +10,11 @@ If you operate Rancher behind a proxy and you want to access services through th
 
 Make sure `NO_PROXY` contains the network addresses, network address ranges and domains that should be excluded from using the proxy.
 
-| Environment variable | Purpose                                                                                                                 |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| HTTP_PROXY           | Proxy address to use when initiating HTTP connection(s)                                                                 |
-| HTTPS_PROXY          | Proxy address to use when initiating HTTPS connection(s)                                                                |
-| NO_PROXY             | Network address(es), network address range(s) and domains to exclude from using the proxy when initiating connection(s) |
+| Environment variable | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                              |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| HTTP_PROXY           | Proxy address to use when initiating HTTP connection(s)                                                                                                                                                                                                                                                                                                                                                                              |
+| HTTPS_PROXY          | Proxy address to use when initiating HTTPS connection(s)                                                                                                                                                                                                                                                                                                                                                                             |
+| NO_PROXY             | Network address(es), network address range(s) and domains to exclude from using the proxy when initiating connection(s). <br/><br/> The value must be a comma-delimited string which contains IP addresses, CIDR notation, domain names, or special DNS labels (*). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config) |
 
 :::note Important:
 

--- a/versioned_docs/version-2.10/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-kubernetes.md
+++ b/versioned_docs/version-2.10/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-kubernetes.md
@@ -12,6 +12,14 @@ The steps to set up RKE, RKE2, or K3s are shown below.
 
 For convenience, export the IP address and port of your proxy into an environment variable and set up the HTTP_PROXY variables for your current shell on every node:
 
+:::caution
+
+The `NO_PROXY` environment variable is not standardized, and the accepted format of the value can differ between applications. When configuring the `NO_PROXY` variable for Rancher, the value must adhere to the format expected by Golang.
+
+Specifically, the value should be a comma-delimited string which only contains IP addresses, CIDR notation, domain names, or special DNS labels (e.g. `*`). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config)
+
+:::
+
 ```
 export proxy_host="10.0.0.5:8888"
 export HTTP_PROXY=http://${proxy_host}

--- a/versioned_docs/version-2.10/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.10/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -56,6 +56,15 @@ GKE Autopilot clusters aren't supported. See [Compare GKE Autopilot and Standard
 9. If you are using self-signed certificates, you will receive the message `certificate signed by unknown authority`. To work around this validation, copy the command starting with `curl` displayed in Rancher to your clipboard. Then run the command on a node where kubeconfig is configured to point to the cluster you want to import.
 10. When you finish running the command(s) on your node, click **Done**.
 
+:::important
+
+The `NO_PROXY` environment variable is not standardized, and the accepted format of the value can differ between applications. When configuring the `NO_PROXY` variable in Rancher, the value must adhere to the format expected by Golang.
+
+Specifically, the value should be a comma-delimited string which only contains IP addresses, CIDR notation, domain names, or special DNS labels (e.g. `*`). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config)
+
+:::
+
+
 **Result:**
 
 - Your cluster is registered and assigned a state of **Pending**. Rancher is deploying resources to manage your cluster.

--- a/versioned_docs/version-2.10/integrations-in-rancher/fleet/use-fleet-behind-a-proxy.md
+++ b/versioned_docs/version-2.10/integrations-in-rancher/fleet/use-fleet-behind-a-proxy.md
@@ -22,6 +22,14 @@ For private nodes or private clusters, the environment variables need to be set 
 
 When adding Fleet agent environment variables for the proxy, replace <PROXY_IP> with your private proxy IP.
 
+:::caution
+
+The `NO_PROXY` environment variable is not standardized, and the accepted format of the value can differ between applications. When configuring the `NO_PROXY` variable in Rancher, the value must adhere to the format expected by Golang.
+
+Specifically, the value should be a comma-delimited string which only contains IP addresses, CIDR notation, domain names, or special DNS labels (e.g. `*`). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config)
+
+:::
+
 | Variable Name | Value |
 |------------------|--------|
 | `HTTP_PROXY` | http://<PROXY_IP>:8888 |

--- a/versioned_docs/version-2.10/reference-guides/single-node-rancher-in-docker/http-proxy-configuration.md
+++ b/versioned_docs/version-2.10/reference-guides/single-node-rancher-in-docker/http-proxy-configuration.md
@@ -10,12 +10,11 @@ If you operate Rancher behind a proxy and you want to access services through th
 
 Make sure `NO_PROXY` contains the network addresses, network address ranges and domains that should be excluded from using the proxy.
 
-| Environment variable | Purpose                                                                                                                 |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| HTTP_PROXY           | Proxy address to use when initiating HTTP connection(s)                                                                 |
-| HTTPS_PROXY          | Proxy address to use when initiating HTTPS connection(s)                                                                |
-| NO_PROXY             | Network address(es), network address range(s) and domains to exclude from using the proxy when initiating connection(s) |
-
+| Environment variable | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                              |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| HTTP_PROXY           | Proxy address to use when initiating HTTP connection(s)                                                                                                                                                                                                                                                                                                                                                                              |
+| HTTPS_PROXY          | Proxy address to use when initiating HTTPS connection(s)                                                                                                                                                                                                                                                                                                                                                                             |
+| NO_PROXY             | Network address(es), network address range(s) and domains to exclude from using the proxy when initiating connection(s). <br/><br/> The value must be a comma-delimited string which contains IP addresses, CIDR notation, domain names, or special DNS labels (*). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config) |
 :::note Important:
 
 NO_PROXY must be in uppercase to use network range (CIDR) notation.

--- a/versioned_docs/version-2.11/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-kubernetes.md
+++ b/versioned_docs/version-2.11/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-kubernetes.md
@@ -12,6 +12,14 @@ The steps to set up RKE, RKE2, or K3s are shown below.
 
 For convenience, export the IP address and port of your proxy into an environment variable and set up the HTTP_PROXY variables for your current shell on every node:
 
+:::caution
+
+The `NO_PROXY` environment variable is not standardized, and the accepted format of the value can differ between applications. When configuring the `NO_PROXY` variable for Rancher, the value must adhere to the format expected by Golang.
+
+Specifically, the value should be a comma-delimited string which only contains IP addresses, CIDR notation, domain names, or special DNS labels (e.g. `*`). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config)
+
+:::
+
 ```
 export proxy_host="10.0.0.5:8888"
 export HTTP_PROXY=http://${proxy_host}

--- a/versioned_docs/version-2.11/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.11/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -57,6 +57,14 @@ GKE Autopilot clusters aren't supported. See [Compare GKE Autopilot and Standard
 9. If you are using self-signed certificates, you will receive the message `certificate signed by unknown authority`. To work around this validation, copy the command starting with `curl` displayed in Rancher to your clipboard. Then run the command on a node where kubeconfig is configured to point to the cluster you want to import.
 10. When you finish running the command(s) on your node, click **Done**.
 
+:::important
+
+The `NO_PROXY` environment variable is not standardized, and the accepted format of the value can differ between applications. When configuring the `NO_PROXY` variable in Rancher, the value must adhere to the format expected by Golang.
+
+Specifically, the value should be a comma-delimited string which only contains IP addresses, CIDR notation, domain names, or special DNS labels (e.g. `*`). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config)
+
+:::
+
 **Result:**
 
 - Your cluster is registered and assigned a state of **Pending**. Rancher is deploying resources to manage your cluster.

--- a/versioned_docs/version-2.11/integrations-in-rancher/fleet/use-fleet-behind-a-proxy.md
+++ b/versioned_docs/version-2.11/integrations-in-rancher/fleet/use-fleet-behind-a-proxy.md
@@ -22,6 +22,14 @@ For private nodes or private clusters, the environment variables need to be set 
 
 When adding Fleet agent environment variables for the proxy, replace <PROXY_IP> with your private proxy IP.
 
+:::caution
+
+The `NO_PROXY` environment variable is not standardized, and the accepted format of the value can differ between applications. When configuring the `NO_PROXY` variable in Rancher, the value must adhere to the format expected by Golang.
+
+Specifically, the value should be a comma-delimited string which only contains IP addresses, CIDR notation, domain names, or special DNS labels (e.g. `*`). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config)
+
+:::
+
 | Variable Name | Value |
 |------------------|--------|
 | `HTTP_PROXY` | http://<PROXY_IP>:8888 |

--- a/versioned_docs/version-2.11/reference-guides/single-node-rancher-in-docker/http-proxy-configuration.md
+++ b/versioned_docs/version-2.11/reference-guides/single-node-rancher-in-docker/http-proxy-configuration.md
@@ -10,12 +10,11 @@ If you operate Rancher behind a proxy and you want to access services through th
 
 Make sure `NO_PROXY` contains the network addresses, network address ranges and domains that should be excluded from using the proxy.
 
-| Environment variable | Purpose                                                                                                                 |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| HTTP_PROXY           | Proxy address to use when initiating HTTP connection(s)                                                                 |
-| HTTPS_PROXY          | Proxy address to use when initiating HTTPS connection(s)                                                                |
-| NO_PROXY             | Network address(es), network address range(s) and domains to exclude from using the proxy when initiating connection(s) |
-
+| Environment variable | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                              |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| HTTP_PROXY           | Proxy address to use when initiating HTTP connection(s)                                                                                                                                                                                                                                                                                                                                                                              |
+| HTTPS_PROXY          | Proxy address to use when initiating HTTPS connection(s)                                                                                                                                                                                                                                                                                                                                                                             |
+| NO_PROXY             | Network address(es), network address range(s) and domains to exclude from using the proxy when initiating connection(s). <br/><br/> The value must be a comma-delimited string which contains IP addresses, CIDR notation, domain names, or special DNS labels (*). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config) |
 :::note Important:
 
 NO_PROXY must be in uppercase to use network range (CIDR) notation.

--- a/versioned_docs/version-2.12/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-kubernetes.md
+++ b/versioned_docs/version-2.12/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-kubernetes.md
@@ -10,7 +10,15 @@ Once the infrastructure is ready, you can continue with setting up a Kubernetes 
 
 The steps to set up RKE, RKE2, or K3s are shown below.
 
-For convenience, export the IP address and port of your proxy into an environment variable and set up the HTTP_PROXY variables for your current shell on every node:
+For convenience, export the IP address and port of your proxy into an environment variable and set up the `HTTP_PROXY` variables for your current shell on every node:
+
+:::caution
+
+The `NO_PROXY` environment variable is not standardized, and the accepted format of the value can differ between applications. When configuring the `NO_PROXY` variable for Rancher, the value must adhere to the format expected by Golang. 
+
+Specifically, the value should be a comma-delimited string which only contains IP addresses, CIDR notation, domain names, or special DNS labels (e.g. `*`). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config)
+
+:::
 
 ```
 export proxy_host="10.0.0.5:8888"

--- a/versioned_docs/version-2.12/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.12/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -57,6 +57,14 @@ GKE Autopilot clusters aren't supported. See [Compare GKE Autopilot and Standard
 9. If you are using self-signed certificates, you will receive the message `certificate signed by unknown authority`. To work around this validation, copy the command starting with `curl` displayed in Rancher to your clipboard. Then run the command on a node where kubeconfig is configured to point to the cluster you want to import.
 10. When you finish running the command(s) on your node, click **Done**.
 
+:::important
+
+The `NO_PROXY` environment variable is not standardized, and the accepted format of the value can differ between applications. When configuring the `NO_PROXY` variable in Rancher, the value must adhere to the format expected by Golang.
+
+Specifically, the value should be a comma-delimited string which only contains IP addresses, CIDR notation, domain names, or special DNS labels (e.g. `*`). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config)
+
+:::
+
 **Result:**
 
 - Your cluster is registered and assigned a state of **Pending**. Rancher is deploying resources to manage your cluster.

--- a/versioned_docs/version-2.12/integrations-in-rancher/fleet/use-fleet-behind-a-proxy.md
+++ b/versioned_docs/version-2.12/integrations-in-rancher/fleet/use-fleet-behind-a-proxy.md
@@ -22,6 +22,14 @@ For private nodes or private clusters, the environment variables need to be set 
 
 When adding Fleet agent environment variables for the proxy, replace <PROXY_IP> with your private proxy IP.
 
+:::caution
+
+The `NO_PROXY` environment variable is not standardized, and the accepted format of the value can differ between applications. When configuring the `NO_PROXY` variable in Rancher, the value must adhere to the format expected by Golang.
+
+Specifically, the value should be a comma-delimited string which only contains IP addresses, CIDR notation, domain names, or special DNS labels (e.g. `*`). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config)
+
+:::
+
 | Variable Name | Value |
 |------------------|--------|
 | `HTTP_PROXY` | http://<PROXY_IP>:8888 |

--- a/versioned_docs/version-2.12/reference-guides/single-node-rancher-in-docker/http-proxy-configuration.md
+++ b/versioned_docs/version-2.12/reference-guides/single-node-rancher-in-docker/http-proxy-configuration.md
@@ -10,11 +10,11 @@ If you operate Rancher behind a proxy and you want to access services through th
 
 Make sure `NO_PROXY` contains the network addresses, network address ranges and domains that should be excluded from using the proxy.
 
-| Environment variable | Purpose                                                                                                                 |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| HTTP_PROXY           | Proxy address to use when initiating HTTP connection(s)                                                                 |
-| HTTPS_PROXY          | Proxy address to use when initiating HTTPS connection(s)                                                                |
-| NO_PROXY             | Network address(es), network address range(s) and domains to exclude from using the proxy when initiating connection(s) |
+| Environment variable | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                              |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| HTTP_PROXY           | Proxy address to use when initiating HTTP connection(s)                                                                                                                                                                                                                                                                                                                                                                              |
+| HTTPS_PROXY          | Proxy address to use when initiating HTTPS connection(s)                                                                                                                                                                                                                                                                                                                                                                             |
+| NO_PROXY             | Network address(es), network address range(s) and domains to exclude from using the proxy when initiating connection(s). <br/><br/> The value must be a comma-delimited string which contains IP addresses, CIDR notation, domain names, or special DNS labels (*). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config) |
 
 :::note Important:
 

--- a/versioned_docs/version-2.9/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-kubernetes.md
+++ b/versioned_docs/version-2.9/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-kubernetes.md
@@ -12,6 +12,14 @@ The steps to set up RKE, RKE2, or K3s are shown below.
 
 For convenience, export the IP address and port of your proxy into an environment variable and set up the HTTP_PROXY variables for your current shell on every node:
 
+:::caution
+
+The `NO_PROXY` environment variable is not standardized, and the accepted format of the value can differ between applications. When configuring the `NO_PROXY` variable for Rancher, the value must adhere to the format expected by Golang.
+
+Specifically, the value should be a comma-delimited string which only contains IP addresses, CIDR notation, domain names, or special DNS labels (e.g. `*`). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config)
+
+:::
+
 ```
 export proxy_host="10.0.0.5:8888"
 export HTTP_PROXY=http://${proxy_host}

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.md
@@ -56,6 +56,14 @@ GKE Autopilot clusters aren't supported. See [Compare GKE Autopilot and Standard
 9. If you are using self-signed certificates, you will receive the message `certificate signed by unknown authority`. To work around this validation, copy the command starting with `curl` displayed in Rancher to your clipboard. Then run the command on a node where kubeconfig is configured to point to the cluster you want to import.
 10. When you finish running the command(s) on your node, click **Done**.
 
+:::important
+
+The `NO_PROXY` environment variable is not standardized, and the accepted format of the value can differ between applications. When configuring the `NO_PROXY` variable in Rancher, the value must adhere to the format expected by Golang.
+
+Specifically, the value should be a comma-delimited string which only contains IP addresses, CIDR notation, domain names, or special DNS labels (e.g. `*`). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config)
+
+:::
+
 **Result:**
 
 - Your cluster is registered and assigned a state of **Pending**. Rancher is deploying resources to manage your cluster.

--- a/versioned_docs/version-2.9/integrations-in-rancher/fleet/use-fleet-behind-a-proxy.md
+++ b/versioned_docs/version-2.9/integrations-in-rancher/fleet/use-fleet-behind-a-proxy.md
@@ -22,6 +22,14 @@ For private nodes or private clusters, the environment variables need to be set 
 
 When adding Fleet agent environment variables for the proxy, replace <PROXY_IP> with your private proxy IP.
 
+:::caution
+
+The `NO_PROXY` environment variable is not standardized, and the accepted format of the value can differ between applications. When configuring the `NO_PROXY` variable in Rancher, the value must adhere to the format expected by Golang.
+
+Specifically, the value should be a comma-delimited string which only contains IP addresses, CIDR notation, domain names, or special DNS labels (e.g. `*`). For a full description of the expected value format, refer to the [**upstream Golang documentation**](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config)
+
+:::
+
 | Variable Name | Value |
 |------------------|--------|
 | `HTTP_PROXY` | http://<PROXY_IP>:8888 |


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/50041

## Description

The current documentation doesn't state the expected format of the `NO_PROXY` environment variable. While there are several examples which follow the same format, `NO_PROXY` is not a standardized environment variable and users may be under the impression that various value formats will work, which is not the case. 

For instance, other [SUSE documentation](https://www.suse.com/support/kb/doc/?id=000019675) states that white space can be used as a delimiter. However doing this in Rancher will result in subtle issues that are difficult to debug.

This PR adds a clear explanation of the format of `NO_PROXY` which is accepted by Rancher (and actively tested) to several sections of the documentation that already mention `NO_PROXY`. The explanation includes a link to the official Golang docs which has a full description of the accepted format.

## Comments

Let me know if I should remove the link to the upstream Go documentation in favor of an additional page in the docs repo or some other approach. I'm not 100% clear on this repo's policy on linking to external resources / documentation. 