### PR TITLE
Add restore warning for Fleet users

### DIFF
--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/restore-rancher.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/restore-rancher.md
@@ -18,6 +18,12 @@ While restoring Rancher on the same setup, the operator will scale down the Ranc
 
 :::
 
+:::note Warning for Fleet users
+You must consider how to handle Kubernetes API server availability and paused GitRepos when restoring a Rancher setup
+that is running Fleet workloads. See the [Fleet
+documentation](http://fleet.rancher.io/gitrepo-add#backing-up-and-restoring) for more details.
+:::
+
 :::tip
 
 * Follow those steps to [migrate Rancher](migrate-rancher-to-new-cluster.md).

--- a/versioned_docs/version-2.10/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/restore-rancher.md
+++ b/versioned_docs/version-2.10/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/restore-rancher.md
@@ -18,6 +18,12 @@ While restoring Rancher on the same setup, the operator will scale down the Ranc
 
 :::
 
+:::note Warning for Fleet users
+You must consider how to handle Kubernetes API server availability and paused GitRepos when restoring a Rancher setup
+that is running Fleet workloads. See the [Fleet
+documentation](http://fleet.rancher.io/gitrepo-add#backing-up-and-restoring) for more details.
+:::
+
 :::tip
 
 * Follow those steps to [migrate Rancher](migrate-rancher-to-new-cluster.md).

--- a/versioned_docs/version-2.11/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/restore-rancher.md
+++ b/versioned_docs/version-2.11/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/restore-rancher.md
@@ -18,6 +18,12 @@ While restoring Rancher on the same setup, the operator will scale down the Ranc
 
 :::
 
+:::note Warning for Fleet users
+You must consider how to handle Kubernetes API server availability and paused GitRepos when restoring a Rancher setup
+that is running Fleet workloads. See the [Fleet
+documentation](http://fleet.rancher.io/gitrepo-add#backing-up-and-restoring) for more details.
+:::
+
 :::tip
 
 * Follow those steps to [migrate Rancher](migrate-rancher-to-new-cluster.md).

--- a/versioned_docs/version-2.12/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/restore-rancher.md
+++ b/versioned_docs/version-2.12/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/restore-rancher.md
@@ -18,6 +18,12 @@ While restoring Rancher on the same setup, the operator will scale down the Ranc
 
 :::
 
+:::note Warning for Fleet users
+You must consider how to handle Kubernetes API server availability and paused GitRepos when restoring a Rancher setup
+that is running Fleet workloads. See the [Fleet
+documentation](http://fleet.rancher.io/gitrepo-add#backing-up-and-restoring) for more details.
+:::
+
 :::tip
 
 * Follow those steps to [migrate Rancher](migrate-rancher-to-new-cluster.md).

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/restore-rancher.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/restore-rancher.md
@@ -18,6 +18,12 @@ While restoring Rancher on the same setup, the operator will scale down the Ranc
 
 :::
 
+:::note Warning for Fleet users
+You must consider how to handle Kubernetes API server availability and paused GitRepos when restoring a Rancher setup
+that is running Fleet workloads. See the [Fleet
+documentation](http://fleet.rancher.io/gitrepo-add#backing-up-and-restoring) for more details.
+:::
+
 :::tip
 
 * Follow those steps to [migrate Rancher](migrate-rancher-to-new-cluster.md).


### PR DESCRIPTION
Restoring setups with Fleet workloads requires a few more steps, now referenced with a link to Fleet documentation.

Depends on https://github.com/rancher/fleet-docs/pull/295 ; keeping this in draft state until that PR is merged.

Refers to https://github.com/rancher/fleet-docs/issues/249.