### PR TITLE
Updating Tokens/Kubeconfigs pages

### DIFF
--- a/docs/api/workflows/kubeconfigs.md
+++ b/docs/api/workflows/kubeconfigs.md
@@ -8,11 +8,12 @@ title: Kubeconfigs
 
 ## Kubeconfig Resource
 
-Kubeconfig is a Rancher resource `kubeconfigs.ext.cattle.io` that allows generating  `v1.Config` kubeconfig files for interacting with Rancher and clusters managed by Rancher.
+Kubeconfig is a Rancher resource `kubeconfigs.ext.cattle.io` that allows generating `v1.Config` kubeconfig files for interacting with Rancher and clusters managed by Rancher.
 
 ```sh
 kubectl api-resources --api-group=ext.cattle.io
 ```
+
 To get a description of the fields and structure of the Kubeconfig resource, run:
 
 ```sh

--- a/docs/api/workflows/tokens.md
+++ b/docs/api/workflows/tokens.md
@@ -6,6 +6,20 @@ title: Tokens
     <link rel="canonical" href="https://ranchermanager.docs.rancher.com/api/workflows/tokens"/>
 </head>
 
+## Token Resource
+
+Rancher has an imperative API resource `tokens.ext.cattle.io` that allows for generating tokens for authenticating with Rancher.
+
+```sh
+kubectl api-resources --api-group=ext.cattle.io
+```
+
+To get a description of the fields and structure of the Token resource, run:
+
+```sh
+kubectl explain tokens.ext.cattle.io
+```
+
 ## Feature Flag
 
 The Tokens Public API is available for Rancher v2.12.0 and later, and is enabled by default. You can disable the Tokens Public API by setting the `ext-tokens` feature flag to `false` as shown in the example `kubectl` command below:
@@ -15,6 +29,10 @@ kubectl patch feature ext-tokens -p '{"spec":{"value":false}}'
 ```
 
 ## Creating a Token
+
+:::caution
+The Token value is only returned once in the `status.value` field.
+:::
 
 Only a **valid and active** Rancher user can create a Token. Otherwise, you will get an error displayed (`Error from server (Forbidden)...`) when attempting to create a Token.
 

--- a/versioned_docs/version-2.12/api/workflows/kubeconfigs.md
+++ b/versioned_docs/version-2.12/api/workflows/kubeconfigs.md
@@ -8,11 +8,12 @@ title: Kubeconfigs
 
 ## Kubeconfig Resource
 
-Kubeconfig is a Rancher resource `kubeconfigs.ext.cattle.io` that allows generating  `v1.Config` kubeconfig files for interacting with Rancher and clusters managed by Rancher.
+Kubeconfig is a Rancher resource `kubeconfigs.ext.cattle.io` that allows generating `v1.Config` kubeconfig files for interacting with Rancher and clusters managed by Rancher.
 
 ```sh
 kubectl api-resources --api-group=ext.cattle.io
 ```
+
 To get a description of the fields and structure of the Kubeconfig resource, run:
 
 ```sh

--- a/versioned_docs/version-2.12/api/workflows/tokens.md
+++ b/versioned_docs/version-2.12/api/workflows/tokens.md
@@ -6,6 +6,20 @@ title: Tokens
     <link rel="canonical" href="https://ranchermanager.docs.rancher.com/api/workflows/tokens"/>
 </head>
 
+## Token Resource
+
+Rancher has an imperative API resource `tokens.ext.cattle.io` that allows for generating tokens for authenticating with Rancher.
+
+```sh
+kubectl api-resources --api-group=ext.cattle.io
+```
+
+To get a description of the fields and structure of the Token resource, run:
+
+```sh
+kubectl explain tokens.ext.cattle.io
+```
+
 ## Feature Flag
 
 The Tokens Public API is available for Rancher v2.12.0 and later, and is enabled by default. You can disable the Tokens Public API by setting the `ext-tokens` feature flag to `false` as shown in the example `kubectl` command below:
@@ -15,6 +29,10 @@ kubectl patch feature ext-tokens -p '{"spec":{"value":false}}'
 ```
 
 ## Creating a Token
+
+:::caution
+The Token value is only returned once in the `status.value` field.
+:::
 
 Only a **valid and active** Rancher user can create a Token. Otherwise, you will get an error displayed (`Error from server (Forbidden)...`) when attempting to create a Token.
 


### PR DESCRIPTION
Standardizing Tokens page with Kubeconfigs page and adding a caution for Token return values. Also cleaned up some spacing on Kubeconfigs page. Will need to update Project page intro as well but will do in a subsequent PR.
