### PR TITLE
Remove RKE1 references: use-new-nodes-in-an-infra-provider/<providers>

### DIFF
--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-digitalocean-cluster.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-digitalocean-cluster.md
@@ -6,53 +6,11 @@ title: Creating a DigitalOcean Cluster
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-digitalocean-cluster"/>
 </head>
 
-In this section, you'll learn how to use Rancher to install an [RKE](https://rancher.com/docs/rke/latest/en/) Kubernetes cluster in DigitalOcean.
+In this section, you'll learn how to deploy an [RKE2](https://docs.rke2.io/)/[K3s](https://docs.k3s.io/) Kubernetes cluster in DigitalOcean.
 
-First, you will set up your DigitalOcean cloud credentials in Rancher. Then you will use your cloud credentials to create a node template, which Rancher will use to provision new nodes in DigitalOcean.
+First, you will set up your DigitalOcean cloud credentials in Rancher.
 
-Then you will create a DigitalOcean cluster in Rancher, and when configuring the new cluster, you will define node pools for it. Each node pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install RKE Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the node pool.
-
-<Tabs>
-<TabItem value="RKE">
-
-1. [Create your cloud credentials](#1-create-your-cloud-credentials)
-2. [Create a node template with your cloud credentials](#2-create-a-node-template-with-your-cloud-credentials)
-3. [Create a cluster with node pools using the node template](#3-create-a-cluster-with-node-pools-using-the-node-template)
-
-### 1. Create your cloud credentials
-
-1. Click **☰ > Cluster Management**.
-1. Click **Cloud Credentials**.
-1. Click **Create**.
-1. Click **DigitalOcean**.
-1. Enter your Digital Ocean credentials.
-1. Click **Create**.
-
-**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster. You can reuse these credentials for other node templates, or in other clusters.
-
-### 2. Create a node template with your cloud credentials
-
-Creating a [node template](use-new-nodes-in-an-infra-provider.md#node-templates) for DigitalOcean will allow Rancher to provision new nodes in DigitalOcean. Node templates can be reused for other clusters.
-
-1. Click **☰ > Cluster Management**.
-1. Click **RKE1 Configuration > Node Templates**.
-1. Click **Add Template**.
-1. Click **DigitalOcean**.
-1. Fill out a node template for DigitalOcean. For help filling out the form, refer to [DigitalOcean Node Template Configuration.](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/digitalocean.md)
-
-### 3. Create a cluster with node pools using the node template
-
-1. Click **☰ > Cluster Management**.
-1. On the **Clusters** page, click **Create**.
-1. Click **DigitalOcean**.
-1. Enter a **Cluster Name**.
-1. Add one or more node pools to your cluster. Add one or more node pools to your cluster. Each node pool uses a node template to provision new nodes. For more information about node pools, including best practices for assigning Kubernetes roles to them, see [this section.](use-new-nodes-in-an-infra-provider.md)
-1. **In the Cluster Configuration** section, choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options**. For help configuring the cluster, refer to the [RKE cluster configuration reference.](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md)
-1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
-1. Click **Create**.
-
-</TabItem>
-<TabItem value="RKE2">
+Then you will create a DigitalOcean cluster in Rancher, and when configuring the new cluster, you will define machine pools for it. Each machine pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the machine pool.
 
 ### 1. Create your cloud credentials
 
@@ -77,12 +35,9 @@ Use Rancher to create a Kubernetes cluster in DigitalOcean.
 1. Enter a **Cluster Name**.
 1. Create a machine pool for each Kubernetes role. Refer to the [best practices](use-new-nodes-in-an-infra-provider.md#node-roles) for recommendations on role assignments and counts.
     1. For each machine pool, define the machine configuration. Refer to the [DigitalOcean machine configuration reference](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/digitalocean.md) for information on configuration options.
-1. Use the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. For help configuring the cluster, refer to the [RKE2 cluster configuration reference.](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md)
+1. Use the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. For help configuring the cluster, refer to the [RKE2](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md) and [K3s](../../../../reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md) cluster configuration reference.
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
 1. Click **Create**.
-
-</TabItem>
-</Tabs>
 
 **Result:**
 

--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-google-compute-engine-cluster.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-google-compute-engine-cluster.md
@@ -7,7 +7,7 @@ title: Creating a Google Compute Engine cluster
 </head>
 
 
-In this section, you'll learn how to use Rancher to provision an [RKE2](https://docs.rke2.io/) Kubernetes cluster on the Google Cloud Platform (GCP) using Google Compute Engine (GCE) through Rancher.
+In this section, you'll learn how to use Rancher to provision an [RKE2](https://docs.rke2.io/)/[K3s](https://docs.k3s.io/) Kubernetes cluster on the Google Cloud Platform (GCP) using Google Compute Engine (GCE) through Rancher.
 
 
 First, you will enable the GCE node driver in the Rancher UI. Then, you follow the steps to create a GCP service account with the necessary permissions, and generate a JSON key file. This key file will be used to create a cloud credential in Rancher. 
@@ -64,7 +64,7 @@ The GCE node driver is not enabled by default in Rancher. You must enable it bef
 1. Enter a **Cluster Name**.
 1. Create a machine pool for each Kubernetes role. Refer to the [best practices](use-new-nodes-in-an-infra-provider.md#node-roles) for recommendations on role assignments and counts.
   1. For each machine pool, define the machine configuration. Refer to the [Google GCE machine configuration reference](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/google-gce.md) for information on configuration options.
-1. Use the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. For help configuring the cluster, refer to the [RKE2 cluster configuration reference.](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md)
+1. Use the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. For help configuring the cluster, refer to the [RKE2](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md) and [K3s](../../../../reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md) cluster configuration reference.
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
 1. Click **Create**.
 

--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.md
@@ -7,11 +7,11 @@ description: Learn the prerequisites and steps required in order for you to crea
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster"/>
 </head>
 
-In this section, you'll learn how to use Rancher to install an [RKE](https://rancher.com/docs/rke/latest/en/) Kubernetes cluster in Amazon EC2.
+In this section, you'll learn how to deploy an [RKE2](https://docs.rke2.io/)/[K3s](https://docs.k3s.io/) Kubernetes cluster in Amazon EC2.
 
-First, you will set up your EC2 cloud credentials in Rancher. Then you will use your cloud credentials to create a node template, which Rancher will use to provision new nodes in EC2.
+First, you will set up your EC2 cloud credentials in Rancher.
 
-Then you will create an EC2 cluster in Rancher, and when configuring the new cluster, you will define node pools for it. Each node pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install RKE Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the node pool.
+Then you will create an EC2 cluster in Rancher, and when configuring the new cluster, you will define machine pools for it. Each machine pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the machine pool.
 
 ### Prerequisites
 
@@ -26,64 +26,6 @@ Then you will create an EC2 cluster in Rancher, and when configuring the new clu
 
 The steps to create a cluster differ based on your Rancher version.
 
-<Tabs>
-<TabItem value="RKE">
-
-1. [Create your cloud credentials](#1-create-your-cloud-credentials)
-2. [Create a node template with your cloud credentials and information from EC2](#2-create-a-node-template-with-your-cloud-credentials-and-information-from-ec2)
-3. [Create a cluster with node pools using the node template](#3-create-a-cluster-with-node-pools-using-the-node-template)
-
-### 1. Create your cloud credentials
-
-1. Click **☰ > Cluster Management**.
-1. Click **Cloud Credentials**.
-1. Click **Create**.
-1. Click **Amazon**.
-1. Enter a name for the cloud credential.
-1. In the **Default Region** field, select the AWS region where your cluster nodes will be located.
-1. Enter your AWS EC2 **Access Key** and **Secret Key**.
-1. Click **Create**.
-
-**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster. You can reuse these credentials for other node templates, or in other clusters.
-
-### 2. Create a node template with your cloud credentials and information from EC2
-
-Creating a [node template](use-new-nodes-in-an-infra-provider.md#node-templates) for EC2 will allow Rancher to provision new nodes in EC2. Node templates can be reused for other clusters.
-
-1. Click **☰ > Cluster Management**.
-1. Click **RKE1 Configuration > Node Templates**
-1. Click **Add Template**.
-1. Fill out a node template for EC2. For help filling out the form, refer to [EC2 Node Template Configuration.](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/amazon-ec2.md)
-1. Click **Create**.
-
-    :::note
-
-    If you want to use the [dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/) feature, there are additional [requirements](https://rancher.com/docs/rke//latest/en/config-options/dual-stack#requirements) that must be taken into consideration.
-
-    :::
-
-### 3. Create a cluster with node pools using the node template
-
-Add one or more node pools to your cluster. For more information about node pools, see [this section.](use-new-nodes-in-an-infra-provider.md)
-
-1. Click **☰ > Cluster Management**.
-1. On the **Clusters** page, click **Create**.
-1. Click **Amazon EC2**.
-1. Create a node pool for each Kubernetes role. For each node pool, choose a node template that you created. For more information about node pools, including best practices for assigning Kubernetes roles to them, see [this section.](use-new-nodes-in-an-infra-provider.md)
-1. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
-1. Use **Cluster Options** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. Refer to [Selecting Cloud Providers](../../kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/set-up-cloud-providers.md) to configure the Kubernetes Cloud Provider. For help configuring the cluster, refer to the [RKE cluster configuration reference.](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md)
-
-    :::note
-
-    If you want to use the [dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/) feature, there are additional [requirements](https://rancher.com/docs/rke//latest/en/config-options/dual-stack#requirements) that must be taken into consideration.
-
-    :::
-
-1. Click **Create**.
-
-</TabItem>
-<TabItem value="RKE2">
-
 ### 1. Create your cloud credentials
 
 If you already have a set of cloud credentials to use, skip this section.
@@ -97,7 +39,7 @@ If you already have a set of cloud credentials to use, skip this section.
 1. Enter your AWS EC2 **Access Key** and **Secret Key**.
 1. Click **Create**.
 
-**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster. You can reuse these credentials for other node templates, or in other clusters.
+**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster.
 
 ### 2. Create your cluster
 
@@ -109,12 +51,9 @@ If you already have a set of cloud credentials to use, skip this section.
 1. Enter a **Cluster Name**.
 1. Create a machine pool for each Kubernetes role. Refer to the [best practices](use-new-nodes-in-an-infra-provider.md#node-roles) for recommendations on role assignments and counts.
     1. For each machine pool, define the machine configuration. Refer to [the EC2 machine configuration reference](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/amazon-ec2.md) for information on configuration options.
-1. Use the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. For help configuring the cluster, refer to the [RKE2 cluster configuration reference.](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md)
+1. Use the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. For help configuring the cluster, refer to the [RKE2](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md) and [K3s](../../../../reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md) cluster configuration reference.
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
 1. Click **Create**.
-
-</TabItem>
-</Tabs>
 
 **Result:**
 

--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-azure-cluster.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-azure-cluster.md
@@ -6,15 +6,15 @@ title: Creating an Azure Cluster
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-azure-cluster"/>
 </head>
 
-In this section, you'll learn how to install an [RKE](https://rancher.com/docs/rke/latest/en/) Kubernetes cluster in Azure through Rancher.
+In this section, you'll learn how to deploy an [RKE2](https://docs.rke2.io/)/[K3s](https://docs.k3s.io/) Kubernetes cluster in Azure through Rancher.
 
-First, you will set up your Azure cloud credentials in Rancher. Then you will use your cloud credentials to create a node template, which Rancher will use to provision new nodes in Azure.
+First, you will set up your Azure cloud credentials in Rancher.
 
-Then you will create an Azure cluster in Rancher, and when configuring the new cluster, you will define node pools for it. Each node pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the node pool.
+Then you will create an Azure cluster in Rancher, and when configuring the new cluster, you will define machine pools for it. Each machine pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the machine pool.
 
 :::caution
 
-When the Rancher RKE cluster is running in Azure and has an Azure load balancer in front, the outbound flow will fail. The workaround for this problem is as follows:
+When the Rancher RKE2/K3s cluster is running in Azure and has an Azure load balancer in front, the outbound flow will fail. The workaround for this problem is as follows:
 
 - Terminate the SSL/TLS on the internal load balancer
 - Use the L7 load balancer
@@ -23,16 +23,16 @@ For more information, refer to the documentation on [Azure load balancer limitat
 
 :::
 
-For more information on configuring the Kubernetes cluster that Rancher will install on the Azure nodes, refer to the [RKE cluster configuration reference.](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md)
+For more information on configuring the Kubernetes cluster that Rancher will install on the Azure nodes, refer to the [RKE2](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md) and [K3s](../../../../reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md) cluster configuration references.
 
-For more information on configuring Azure node templates, refer to the [Azure node template configuration reference.](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/azure.md)
+For more information on configuring Azure machines, refer to the [Azure machine configuration reference](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/azure.md).
 
 - [Preparation in Azure](#preparation-in-azure)
 - [Creating an Azure Cluster](#creating-an-azure-cluster)
 
 ## Preparation in Azure
 
-Before creating a node template in Rancher using a cloud infrastructure such as Azure, we must configure Rancher to allow the manipulation of resources in an Azure subscription.
+Before a cluster can be deployed, we must configure our Azure subscription to allow the manipulation of its resources by a third party, such as Rancher.
 
 To do this, we will first create a new Azure **service principal (SP)** in Azure **Active Directory (AD)**, which, in Azure, is an application user who has permission to manage Azure resources.
 
@@ -45,53 +45,9 @@ az ad sp create-for-rbac \
   --scopes="/subscriptions/<subscription Id>"
 ```
 
-The creation of this service principal returns three pieces of identification information, *The application ID, also called the client ID*, and *The client secret*. This information will be used when you create a node template for Azure.
+The creation of this service principal returns the **application ID**, also called the **client ID**, and the **client secret**. This information is used when you create your cloud credentials.
 
 ## Creating an Azure Cluster
-
-<Tabs>
-<TabItem value="RKE">
-
-1. [Create your cloud credentials](#1-create-your-cloud-credentials)
-2. [Create a node template with your cloud credentials](#2-create-a-node-template-with-your-cloud-credentials)
-3. [Create a cluster with node pools using the node template](#3-create-a-cluster-with-node-pools-using-the-node-template)
-
-### 1. Create your cloud credentials
-
-1. Click **☰ > Cluster Management**.
-1. Click **Cloud Credentials**.
-1. Click **Create**.
-1. Click **Azure**.
-1. Enter your Azure credentials.
-1. Click **Create**.
-
-**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster. You can reuse these credentials for other node templates, or in other clusters.
-
-### 2. Create a node template with your cloud credentials
-
-Creating a [node template](use-new-nodes-in-an-infra-provider.md#node-templates) for Azure will allow Rancher to provision new nodes in Azure. Node templates can be reused for other clusters.
-
-1. Click **☰ > Cluster Management**.
-1. Click **RKE1 Configuration > Node Templates**.
-1. Click **Add Template**.
-1. Click **Azure**.
-1. Fill out a node template for Azure. For help filling out the form, refer to [Azure Node Template Configuration.](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/azure.md)
-
-### 3. Create a cluster with node pools using the node template
-
-Use Rancher to create a Kubernetes cluster in Azure.
-
-1. Click **☰ > Cluster Management**.
-1. On the **Clusters** page, click **Create**.
-1. Click **Azure**.
-1. Enter a **Cluster Name**.
-1. Add one or more node pools to your cluster. Each node pool uses a node template to provision new nodes. For more information about node pools, including best practices, see [this section.](use-new-nodes-in-an-infra-provider.md)
-1. In the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options**. For help configuring the cluster, refer to the [RKE cluster configuration reference.](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md)
-1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
-1. Click **Create**.
-
-</TabItem>
-<TabItem value="RKE2">
 
 ### 1. Create your cloud credentials
 
@@ -104,7 +60,7 @@ If you already have a set of cloud credentials to use, skip this section.
 1. Enter your Azure credentials.
 1. Click **Create**.
 
-**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster. You can reuse these credentials for other node templates, or in other clusters.
+**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster.
 
 ### 2. Create your cluster
 
@@ -118,12 +74,9 @@ Use Rancher to create a Kubernetes cluster in Azure.
 1. Enter a **Cluster Name**.
 1. Create a machine pool for each Kubernetes role. Refer to the [best practices](use-new-nodes-in-an-infra-provider.md#node-roles) for recommendations on role assignments and counts.
     1. For each machine pool, define the machine configuration. Refer to the [Azure machine configuration reference](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/azure.md) for information on configuration options.
-1. Use the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation.  For help configuring the cluster, refer to the [RKE2 cluster configuration reference.](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md)
+1. Use the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation.  For help configuring the cluster, refer to the [RKE2](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md) and [K3s](../../../../reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md) cluster configuration reference.
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
 1. Click **Create**.
-
-</TabItem>
-</Tabs>
 
 **Result:**
 

--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/nutanix.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/nutanix.md
@@ -18,4 +18,4 @@ A Nutanix cluster may consist of multiple groups of VMs with distinct properties
 
 ## Creating a Nutanix Cluster
 
-In [this section,](provision-kubernetes-clusters-in-aos.md) you'll learn how to use Rancher to install an [RKE](https://rancher.com/docs/rke/latest/en/) Kubernetes cluster in Nutanix AOS.
+In [this section,](provision-kubernetes-clusters-in-aos.md) you'll learn how to use Rancher to install an [RKE2](https://docs.rke2.io/)/[K3s](https://docs.k3s.io/) Kubernetes cluster in Nutanix AOS.

--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
@@ -6,9 +6,9 @@ title: Creating a VMware vSphere Virtual Machine Template
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template"/>
 </head>
 
-Creating virtual machines in a repeatable and reliable fashion can often be difficult. VMware vSphere offers the ability to build one VM that can then be converted to a template. The template can then be used to create identically configured VMs. Rancher leverages this capability within node pools to create identical RKE1 and RKE2 nodes.
+Creating virtual machines in a repeatable and reliable fashion can often be difficult. VMware vSphere offers the ability to build one VM that can then be converted to a template. The template can then be used to create identically configured VMs. Rancher leverages this capability to create identical RKE/K3s nodes.
 
-In order to leverage the template to create new VMs, Rancher has some [specific requirements](#requirements) that the VM must have pre-installed. After you configure the VM with these requirements, you will next need to [prepare the VM](#preparing-your-vm) before [creating the template](#creating-a-template). Finally, once preparation is complete, the VM can be [converted to a template](#converting-to-a-template) and [moved into a content library](#moving-to-a-content-library), ready for Rancher node pool usage.
+In order to leverage the template to create new VMs, Rancher has some [specific requirements](#requirements) that the VM must have pre-installed. After you configure the VM with these requirements, you will next need to [prepare the VM](#preparing-your-vm) before [creating the template](#creating-a-template). Finally, once preparation is complete, the VM can be [converted to a template](#converting-to-a-template) and [moved into a content library](#moving-to-a-content-library).
 
 
 ## Requirements
@@ -47,14 +47,6 @@ The list of packages that need to be installed on the template is as follows:
 
 * Windows Container Feature
 * [cloudbase-init](https://cloudbase.it/cloudbase-init/#download)
-* [Docker EE](https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=Windows-Server#install-docker) - RKE1 Only
-
-:::note About the configuration for Windows templates varies between RKE1 and RKE2:
-
-- RKE1 leverages Docker, so any RKE1 templates need to have Docker EE pre-installed as well
-- RKE2 does not require Docker EE, and thus it does not need to be installed
-
-:::
 
 ## Creating a Template
 

--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-credentials.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-credentials.md
@@ -34,7 +34,7 @@ The following steps create a role with the required privileges and then assign i
 
 4. Go to the **Users and Groups** tab.
 
-5. Create a new user. Fill out the form and then click **OK**. Make sure to note the username and password, because you will need it when configuring node templates in Rancher.
+5. Create a new user. Fill out the form and then click **OK**. Make sure to note the username and password, because you will need it when creating cloud credentials in Rancher.
 
     ![](/img/rancheruser.png)
 

--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere.md
@@ -17,7 +17,9 @@ Then you will create a vSphere cluster in Rancher, and when configuring the new 
 
 ## Preparation in VMware vSphere
 
-This section describes the requirements for setting up vSphere so that Rancher can provision VMs and clusters.### Create Credentials in VMware vSphere
+This section describes the requirements for setting up vSphere so that Rancher can provision VMs and clusters.
+
+### Create Credentials in VMware vSphere
 
 Before proceeding to create a cluster, you must ensure that you have a vSphere user with sufficient permissions.
 

--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere.md
@@ -6,29 +6,20 @@ title: Provisioning Kubernetes Clusters in VMware vSphere
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere"/>
 </head>
 
-In this section, you'll learn how to use Rancher to install an [RKE](https://rancher.com/docs/rke/latest/en/)  Kubernetes cluster in VMware vSphere.
+In this section, you'll learn how to deploy an [RKE2](https://docs.rke2.io/)/[K3s](https://docs.k3s.io/) Kubernetes cluster in VMware vSphere.
 
-First, you will set up your vSphere cloud credentials in Rancher. Then you will use your cloud credentials to create a node template, which Rancher will use to provision nodes in vSphere.
+First, you will set up your vSphere cloud credentials in Rancher.
 
-Then you will create a vSphere cluster in Rancher, and when configuring the new cluster, you will define node pools for it. Each node pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install RKE Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the node pool.
-
-For details on configuring the vSphere node template, refer to the [vSphere node template configuration reference.](../../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/vsphere.md)
-
-For details on configuring RKE Kubernetes clusters in Rancher, refer to the [cluster configuration reference.](../../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md#rke-cluster-config-file-reference)
-
+Then you will create a vSphere cluster in Rancher, and when configuring the new cluster, you will define machine pools for it. Each machine pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the machine pool.
 
 - [Preparation in vSphere](#preparation-in-vmware-vsphere)
 - [Creating a vSphere Cluster](#creating-a-vmware-vsphere-cluster)
 
 ## Preparation in VMware vSphere
 
-This section describes the requirements for setting up vSphere so that Rancher can provision VMs and clusters.
+This section describes the requirements for setting up vSphere so that Rancher can provision VMs and clusters.### Create Credentials in VMware vSphere
 
-The node templates are documented and tested with the vSphere Web Services API version 6.5.
-
-### Create Credentials in VMware vSphere
-
-Before proceeding to create a cluster, you must ensure that you have a vSphere user with sufficient permissions. When you set up a node template, the template will need to use these vSphere credentials.
+Before proceeding to create a cluster, you must ensure that you have a vSphere user with sufficient permissions.
 
 Refer to this [how-to guide](create-credentials.md) for instructions on how to create a user in vSphere with the required permissions. These steps result in a username and password that you will need to provide to Rancher, which allows Rancher to provision resources in vSphere.
 
@@ -58,10 +49,6 @@ User-data.iso files may have become orphaned upon node deletion due to a vSphere
 
 :::
 
-1. [Create your cloud credentials](#1-create-your-cloud-credentials)
-2. [Create a node template with your cloud credentials](#2-create-a-node-template-with-your-cloud-credentials)
-3. [Create a cluster with node pools using the node template](#3-create-a-cluster-with-node-pools-using-the-node-template)
-
 ### 1. Create your cloud credentials
 
 1. Click **☰ > Cluster Management**.
@@ -71,32 +58,21 @@ User-data.iso files may have become orphaned upon node deletion due to a vSphere
 1. Enter your vSphere credentials. For help, refer to **Account Access** in the [node template configuration reference.](../../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/vsphere.md)
 1. Click **Create**.
 
-**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster. You can reuse these credentials for other node templates, or in other clusters.
+**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster.
 
-### 2. Create a node template with your cloud credentials
-
-Creating a [node template](../use-new-nodes-in-an-infra-provider.md#node-templates) for vSphere will allow Rancher to provision new nodes in vSphere. Node templates can be reused for other clusters.
-
-1. Click **☰ > Cluster Management**.
-1. Click **RKE1 Configuration > Node Templates**.
-1. Click **Create**.
-1. Click **Add Template**.
-1. Click **vSphere**.
-1. Fill out a node template for vSphere. For help filling out the form, refer to the vSphere node template [configuration reference.](../../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/vsphere.md).
-1. Click **Create**.
-
-### 3. Create a cluster with node pools using the node template
+### 2. Create your cluster
 
 Use Rancher to create a Kubernetes cluster in vSphere.
 
 1. In the upper left corner, click **☰ > Cluster Management**.
 1. On the **Clusters** page, click **Create**.
 1. Click **VMware vSphere**.
-1. Enter a **Cluster Name** and use your vSphere cloud credentials. Click **Continue**.
+1. Enter a **Cluster Name** and use your vSphere cloud credentials.
+1. Create a machine pool for each Kubernetes role. Refer to the [best practices](../use-new-nodes-in-an-infra-provider.md#node-roles) for recommendations on role assignments and counts.
+    1. For each machine pool, define the machine configuration.
+1. Use **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. For help configuring the cluster, refer to the [RKE2](../../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md) and [K3s](../../../../../reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md) cluster configuration reference.
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
-1. Use **Cluster Options** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options**. For help configuring the cluster, refer to the [RKE cluster configuration reference.](../../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md)
 1. If you want to dynamically provision persistent storage or other infrastructure later, you will need to enable the vSphere cloud provider by modifying the cluster YAML file. For details, refer to [in-tree vSphere cloud provider docs](../../../../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-in-tree-vsphere.md) and [out-of-tree vSphere cloud provider docs](../../../../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-out-of-tree-vsphere.md).
-1. Add one or more node pools to your cluster. Each node pool uses a node template to provision new nodes. For more information about node pools, including best practices for assigning Kubernetes roles to the nodes, see [this section.](../use-new-nodes-in-an-infra-provider.md#node-pools)
 1. Review your options to confirm they're correct. Then click **Create**.
 
 **Result:**

--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/shutdown-vm.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/shutdown-vm.md
@@ -10,8 +10,6 @@ In Rancher v2.8.3 and later, you can configure the graceful shutdown of virtual 
 
 In RKE2/K3s, you can set up graceful shutdown when you create the cluster, or edit the cluster configuration to add it afterward. 
 
-In RKE, you can edit node templates to similar results.
-
 :::note 
 
 Since Rancher can't detect the platform of an imported cluster, you cannot enable graceful shutdown on VMware vSphere clusters you have imported.
@@ -20,29 +18,11 @@ Since Rancher can't detect the platform of an imported cluster, you cannot enabl
 
 ## Enable Graceful Shutdown During VMware vSphere Cluster Creation 
 
-<Tabs>
-<TabItem value="RKE2/K3s">
-
 In RKE2/K3s, you can configure new VMware vSphere clusters with graceful shutdown for VMs:
 
 1. Click **☰ > Cluster Management**.
 1. Click **Create** and select **VMware vSphere** to provision a new cluster.
 1. Under **Machine Pools > Scheduling**, in the **Graceful Shutdown Timeout** field, enter an integer value greater than 0. The value you enter is the amount of time in seconds Rancher waits before deleting VMs on the cluster. If the value is set to `0`, graceful shutdown is disabled.
-
-</TabItem>
-<TabItem value="RKE">
-
-In RKE, you can't directly configure a new cluster with graceful shutdown. However, you can configure node templates which automatically create node pools with graceful shutdown enabled. The node template can then be used to provision new VMware vSphere clusters that have a graceful shutdown delay. 
-
-1. Click **☰ > Cluster Management**.
-1. From the left navigation, select **RKE1 Configuration > Node Templates**.
-1. Click **Add Template** and select **vSphere** to create a node template.
-1. Under **2. Scheduling**, in the **Graceful Shutdown Timeout** field, enter an integer value greater than 0. The value you enter is the amount of time in seconds Rancher waits before deleting VMs on the cluster. If the value is set to `0`, graceful shutdown is disabled.
-
-When you [use the newly-created node template to create node pools](../use-new-nodes-in-an-infra-provider.md), the nodes will gracefully shutdown of VMs according to the **Graceful Shutdown Timeout** value you have set.
-
-</TabItem>
-</Tabs>
 
 ## Enable Graceful Shutdown in Existing RKE2/K3s Clusters
 
@@ -52,14 +32,3 @@ In RKE2/K3s, you can edit the configuration of an existing VMware vSphere cluste
 1. On the **Clusters** page, find the VMware vSphere hosted cluster you want to edit. Click **⋮** at the end of the row associated with the cluster. Select **Edit Config**.
 1. Under **Machine Pools > Scheduling**, in the **Graceful Shutdown Timeout** field, enter an integer value greater than 0. The value you enter is the amount of time in seconds Rancher waits before deleting VMs on the cluster. If the value is set to `0`, graceful shutdown is disabled.
 
-## Enable Graceful Shutdown in Existing RKE Clusters
-
-In RKE, you can't directly edit an existing cluster's configuration to add graceful shutdown to existing VMware vSphere clusters. However, you can edit the configuration of existing node templates. As noted in [Updating a Node Template](../../../../../reference-guides/user-settings/manage-node-templates.md#updating-a-node-template), all node pools using the node template automatically use the updated information when new nodes are added to the cluster.
-
-To edit an existing node template to enable graceful shutdown:
-
-1. Click **☰ > Cluster Management**.
-1. From the left navigation, select **RKE1 Configuration > Node Templates**.
-1. Find the VMware vSphere node template you want to edit. Click **⋮** at the end of the row associated with the template. Select **Edit**.
-1. Under **2. Scheduling**, in the **Graceful Shutdown Timeout** field, enter an integer value greater than 0. The value you enter is the amount of time in seconds Rancher waits before deleting VMs on the cluster. If the value is set to `0`, graceful shutdown is disabled.
-1. Click **Save**.

--- a/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
+++ b/docs/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
@@ -15,33 +15,9 @@ Rancher can provision nodes in vSphere and install Kubernetes on them. When crea
 
 A vSphere cluster may consist of multiple groups of VMs with distinct properties, such as the amount of memory or the number of vCPUs. This grouping allows for fine-grained control over the sizing of nodes for each Kubernetes role.
 
-## VMware vSphere Enhancements
-
-The vSphere node templates allow you to bring cloud operations on-premises with the following enhancements:
-
-### Self-healing Node Pools
-
-One of the biggest advantages of provisioning vSphere nodes with Rancher is that it allows you to take advantage of Rancher's self-healing node pools, also called the [node auto-replace feature,](../use-new-nodes-in-an-infra-provider.md#about-node-auto-replace) in your on-premises clusters. Self-healing node pools are designed to help you replace worker nodes for stateless applications. When Rancher provisions nodes from a node template, Rancher can automatically replace unreachable nodes.
-
-:::caution
-
-It is not recommended to enable node auto-replace on a node pool of master nodes or nodes with persistent volumes attached, because VMs are treated ephemerally. When a node in a node pool loses connectivity with the cluster, its persistent volumes are destroyed, resulting in data loss for stateful applications.
-
-:::
-
-### Dynamically Populated Options for Instances and Scheduling
-
-Node templates for vSphere have been updated so that when you create a node template with your vSphere credentials, the template is automatically populated with the same options for provisioning VMs that you have access to in the vSphere console.
-
-For the fields to be populated, your setup needs to fulfill the [prerequisites.](provision-kubernetes-clusters-in-vsphere.md#preparation-in-vmware-vsphere)
-
-### More Supported Operating Systems
-
-You can provision VMs with any operating system that supports `cloud-init`. Only YAML format is supported for the [cloud config.](https://cloudinit.readthedocs.io/en/latest/topics/examples.html)
-
 ## Creating a VMware vSphere Cluster
 
-In [this section,](provision-kubernetes-clusters-in-vsphere.md) you'll learn how to use Rancher to install an [RKE](https://rancher.com/docs/rke/latest/en/) Kubernetes cluster in vSphere.
+In [this section,](provision-kubernetes-clusters-in-vsphere.md) you'll learn how to use Rancher to install an [RKE2](https://docs.rke2.io/)/[K3s](https://docs.k3s.io/) Kubernetes cluster in vSphere.
 
 ## Provisioning Storage
 

--- a/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-digitalocean-cluster.md
+++ b/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-digitalocean-cluster.md
@@ -6,53 +6,11 @@ title: Creating a DigitalOcean Cluster
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-digitalocean-cluster"/>
 </head>
 
-In this section, you'll learn how to use Rancher to install an [RKE](https://rancher.com/docs/rke/latest/en/) Kubernetes cluster in DigitalOcean.
+In this section, you'll learn how to deploy an [RKE2](https://docs.rke2.io/)/[K3s](https://docs.k3s.io/) Kubernetes cluster in DigitalOcean.
 
-First, you will set up your DigitalOcean cloud credentials in Rancher. Then you will use your cloud credentials to create a node template, which Rancher will use to provision new nodes in DigitalOcean.
+First, you will set up your DigitalOcean cloud credentials in Rancher.
 
-Then you will create a DigitalOcean cluster in Rancher, and when configuring the new cluster, you will define node pools for it. Each node pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install RKE Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the node pool.
-
-<Tabs>
-<TabItem value="RKE">
-
-1. [Create your cloud credentials](#1-create-your-cloud-credentials)
-2. [Create a node template with your cloud credentials](#2-create-a-node-template-with-your-cloud-credentials)
-3. [Create a cluster with node pools using the node template](#3-create-a-cluster-with-node-pools-using-the-node-template)
-
-### 1. Create your cloud credentials
-
-1. Click **☰ > Cluster Management**.
-1. Click **Cloud Credentials**.
-1. Click **Create**.
-1. Click **DigitalOcean**.
-1. Enter your Digital Ocean credentials.
-1. Click **Create**.
-
-**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster. You can reuse these credentials for other node templates, or in other clusters.
-
-### 2. Create a node template with your cloud credentials
-
-Creating a [node template](use-new-nodes-in-an-infra-provider.md#node-templates) for DigitalOcean will allow Rancher to provision new nodes in DigitalOcean. Node templates can be reused for other clusters.
-
-1. Click **☰ > Cluster Management**.
-1. Click **RKE1 Configuration > Node Templates**.
-1. Click **Add Template**.
-1. Click **DigitalOcean**.
-1. Fill out a node template for DigitalOcean. For help filling out the form, refer to [DigitalOcean Node Template Configuration.](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/digitalocean.md)
-
-### 3. Create a cluster with node pools using the node template
-
-1. Click **☰ > Cluster Management**.
-1. On the **Clusters** page, click **Create**.
-1. Click **DigitalOcean**.
-1. Enter a **Cluster Name**.
-1. Add one or more node pools to your cluster. Add one or more node pools to your cluster. Each node pool uses a node template to provision new nodes. For more information about node pools, including best practices for assigning Kubernetes roles to them, see [this section.](use-new-nodes-in-an-infra-provider.md)
-1. **In the Cluster Configuration** section, choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options**. For help configuring the cluster, refer to the [RKE cluster configuration reference.](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md)
-1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
-1. Click **Create**.
-
-</TabItem>
-<TabItem value="RKE2">
+Then you will create a DigitalOcean cluster in Rancher, and when configuring the new cluster, you will define machine pools for it. Each machine pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the machine pool.
 
 ### 1. Create your cloud credentials
 
@@ -77,12 +35,9 @@ Use Rancher to create a Kubernetes cluster in DigitalOcean.
 1. Enter a **Cluster Name**.
 1. Create a machine pool for each Kubernetes role. Refer to the [best practices](use-new-nodes-in-an-infra-provider.md#node-roles) for recommendations on role assignments and counts.
     1. For each machine pool, define the machine configuration. Refer to the [DigitalOcean machine configuration reference](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/digitalocean.md) for information on configuration options.
-1. Use the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. For help configuring the cluster, refer to the [RKE2 cluster configuration reference.](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md)
+1. Use the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. For help configuring the cluster, refer to the [RKE2](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md) and [K3s](../../../../reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md) cluster configuration reference.
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
 1. Click **Create**.
-
-</TabItem>
-</Tabs>
 
 **Result:**
 

--- a/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-google-compute-engine-cluster.md
+++ b/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-google-compute-engine-cluster.md
@@ -7,7 +7,7 @@ title: Creating a Google Compute Engine cluster
 </head>
 
 
-In this section, you'll learn how to use Rancher to provision an [RKE2](https://docs.rke2.io/) Kubernetes cluster on the Google Cloud Platform (GCP) using Google Compute Engine (GCE) through Rancher.
+In this section, you'll learn how to use Rancher to provision an [RKE2](https://docs.rke2.io/)/[K3s](https://docs.k3s.io/) Kubernetes cluster on the Google Cloud Platform (GCP) using Google Compute Engine (GCE) through Rancher.
 
 
 First, you will enable the GCE node driver in the Rancher UI. Then, you follow the steps to create a GCP service account with the necessary permissions, and generate a JSON key file. This key file will be used to create a cloud credential in Rancher. 
@@ -64,7 +64,7 @@ The GCE node driver is not enabled by default in Rancher. You must enable it bef
 1. Enter a **Cluster Name**.
 1. Create a machine pool for each Kubernetes role. Refer to the [best practices](use-new-nodes-in-an-infra-provider.md#node-roles) for recommendations on role assignments and counts.
   1. For each machine pool, define the machine configuration. Refer to the [Google GCE machine configuration reference](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/google-gce.md) for information on configuration options.
-1. Use the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. For help configuring the cluster, refer to the [RKE2 cluster configuration reference.](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md)
+1. Use the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. For help configuring the cluster, refer to the [RKE2](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md) and [K3s](../../../../reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md) cluster configuration reference.
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
 1. Click **Create**.
 

--- a/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.md
+++ b/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.md
@@ -7,11 +7,11 @@ description: Learn the prerequisites and steps required in order for you to crea
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster"/>
 </head>
 
-In this section, you'll learn how to use Rancher to install an [RKE](https://rancher.com/docs/rke/latest/en/) Kubernetes cluster in Amazon EC2.
+In this section, you'll learn how to deploy an [RKE2](https://docs.rke2.io/)/[K3s](https://docs.k3s.io/) Kubernetes cluster in Amazon EC2.
 
-First, you will set up your EC2 cloud credentials in Rancher. Then you will use your cloud credentials to create a node template, which Rancher will use to provision new nodes in EC2.
+First, you will set up your EC2 cloud credentials in Rancher.
 
-Then you will create an EC2 cluster in Rancher, and when configuring the new cluster, you will define node pools for it. Each node pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install RKE Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the node pool.
+Then you will create an EC2 cluster in Rancher, and when configuring the new cluster, you will define machine pools for it. Each machine pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the machine pool.
 
 ### Prerequisites
 
@@ -26,64 +26,6 @@ Then you will create an EC2 cluster in Rancher, and when configuring the new clu
 
 The steps to create a cluster differ based on your Rancher version.
 
-<Tabs>
-<TabItem value="RKE">
-
-1. [Create your cloud credentials](#1-create-your-cloud-credentials)
-2. [Create a node template with your cloud credentials and information from EC2](#2-create-a-node-template-with-your-cloud-credentials-and-information-from-ec2)
-3. [Create a cluster with node pools using the node template](#3-create-a-cluster-with-node-pools-using-the-node-template)
-
-### 1. Create your cloud credentials
-
-1. Click **☰ > Cluster Management**.
-1. Click **Cloud Credentials**.
-1. Click **Create**.
-1. Click **Amazon**.
-1. Enter a name for the cloud credential.
-1. In the **Default Region** field, select the AWS region where your cluster nodes will be located.
-1. Enter your AWS EC2 **Access Key** and **Secret Key**.
-1. Click **Create**.
-
-**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster. You can reuse these credentials for other node templates, or in other clusters.
-
-### 2. Create a node template with your cloud credentials and information from EC2
-
-Creating a [node template](use-new-nodes-in-an-infra-provider.md#node-templates) for EC2 will allow Rancher to provision new nodes in EC2. Node templates can be reused for other clusters.
-
-1. Click **☰ > Cluster Management**.
-1. Click **RKE1 Configuration > Node Templates**
-1. Click **Add Template**.
-1. Fill out a node template for EC2. For help filling out the form, refer to [EC2 Node Template Configuration.](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/amazon-ec2.md)
-1. Click **Create**.
-
-    :::note
-
-    If you want to use the [dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/) feature, there are additional [requirements](https://rancher.com/docs/rke//latest/en/config-options/dual-stack#requirements) that must be taken into consideration.
-
-    :::
-
-### 3. Create a cluster with node pools using the node template
-
-Add one or more node pools to your cluster. For more information about node pools, see [this section.](use-new-nodes-in-an-infra-provider.md)
-
-1. Click **☰ > Cluster Management**.
-1. On the **Clusters** page, click **Create**.
-1. Click **Amazon EC2**.
-1. Create a node pool for each Kubernetes role. For each node pool, choose a node template that you created. For more information about node pools, including best practices for assigning Kubernetes roles to them, see [this section.](use-new-nodes-in-an-infra-provider.md)
-1. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
-1. Use **Cluster Options** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. Refer to [Selecting Cloud Providers](../../kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/set-up-cloud-providers.md) to configure the Kubernetes Cloud Provider. For help configuring the cluster, refer to the [RKE cluster configuration reference.](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md)
-
-    :::note
-
-    If you want to use the [dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/) feature, there are additional [requirements](https://rancher.com/docs/rke//latest/en/config-options/dual-stack#requirements) that must be taken into consideration.
-
-    :::
-
-1. Click **Create**.
-
-</TabItem>
-<TabItem value="RKE2">
-
 ### 1. Create your cloud credentials
 
 If you already have a set of cloud credentials to use, skip this section.
@@ -97,7 +39,7 @@ If you already have a set of cloud credentials to use, skip this section.
 1. Enter your AWS EC2 **Access Key** and **Secret Key**.
 1. Click **Create**.
 
-**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster. You can reuse these credentials for other node templates, or in other clusters.
+**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster.
 
 ### 2. Create your cluster
 
@@ -109,12 +51,9 @@ If you already have a set of cloud credentials to use, skip this section.
 1. Enter a **Cluster Name**.
 1. Create a machine pool for each Kubernetes role. Refer to the [best practices](use-new-nodes-in-an-infra-provider.md#node-roles) for recommendations on role assignments and counts.
     1. For each machine pool, define the machine configuration. Refer to [the EC2 machine configuration reference](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/amazon-ec2.md) for information on configuration options.
-1. Use the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. For help configuring the cluster, refer to the [RKE2 cluster configuration reference.](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md)
+1. Use the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. For help configuring the cluster, refer to the [RKE2](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md) and [K3s](../../../../reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md) cluster configuration reference.
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
 1. Click **Create**.
-
-</TabItem>
-</Tabs>
 
 **Result:**
 

--- a/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-azure-cluster.md
+++ b/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-azure-cluster.md
@@ -6,15 +6,15 @@ title: Creating an Azure Cluster
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-azure-cluster"/>
 </head>
 
-In this section, you'll learn how to install an [RKE](https://rancher.com/docs/rke/latest/en/) Kubernetes cluster in Azure through Rancher.
+In this section, you'll learn how to deploy an [RKE2](https://docs.rke2.io/)/[K3s](https://docs.k3s.io/) Kubernetes cluster in Azure through Rancher.
 
-First, you will set up your Azure cloud credentials in Rancher. Then you will use your cloud credentials to create a node template, which Rancher will use to provision new nodes in Azure.
+First, you will set up your Azure cloud credentials in Rancher.
 
-Then you will create an Azure cluster in Rancher, and when configuring the new cluster, you will define node pools for it. Each node pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the node pool.
+Then you will create an Azure cluster in Rancher, and when configuring the new cluster, you will define machine pools for it. Each machine pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the machine pool.
 
 :::caution
 
-When the Rancher RKE cluster is running in Azure and has an Azure load balancer in front, the outbound flow will fail. The workaround for this problem is as follows:
+When the Rancher RKE2/K3s cluster is running in Azure and has an Azure load balancer in front, the outbound flow will fail. The workaround for this problem is as follows:
 
 - Terminate the SSL/TLS on the internal load balancer
 - Use the L7 load balancer
@@ -23,16 +23,16 @@ For more information, refer to the documentation on [Azure load balancer limitat
 
 :::
 
-For more information on configuring the Kubernetes cluster that Rancher will install on the Azure nodes, refer to the [RKE cluster configuration reference.](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md)
+For more information on configuring the Kubernetes cluster that Rancher will install on the Azure nodes, refer to the [RKE2](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md) and [K3s](../../../../reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md) cluster configuration references.
 
-For more information on configuring Azure node templates, refer to the [Azure node template configuration reference.](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/azure.md)
+For more information on configuring Azure machines, refer to the [Azure machine configuration reference](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/azure.md).
 
 - [Preparation in Azure](#preparation-in-azure)
 - [Creating an Azure Cluster](#creating-an-azure-cluster)
 
 ## Preparation in Azure
 
-Before creating a node template in Rancher using a cloud infrastructure such as Azure, we must configure Rancher to allow the manipulation of resources in an Azure subscription.
+Before a cluster can be deployed, we must configure our Azure subscription to allow the manipulation of its resources by a third party, such as Rancher.
 
 To do this, we will first create a new Azure **service principal (SP)** in Azure **Active Directory (AD)**, which, in Azure, is an application user who has permission to manage Azure resources.
 
@@ -45,53 +45,9 @@ az ad sp create-for-rbac \
   --scopes="/subscriptions/<subscription Id>"
 ```
 
-The creation of this service principal returns three pieces of identification information, *The application ID, also called the client ID*, and *The client secret*. This information will be used when you create a node template for Azure.
+The creation of this service principal returns the **application ID**, also called the **client ID**, and the **client secret**. This information is used when you create your cloud credentials.
 
 ## Creating an Azure Cluster
-
-<Tabs>
-<TabItem value="RKE">
-
-1. [Create your cloud credentials](#1-create-your-cloud-credentials)
-2. [Create a node template with your cloud credentials](#2-create-a-node-template-with-your-cloud-credentials)
-3. [Create a cluster with node pools using the node template](#3-create-a-cluster-with-node-pools-using-the-node-template)
-
-### 1. Create your cloud credentials
-
-1. Click **☰ > Cluster Management**.
-1. Click **Cloud Credentials**.
-1. Click **Create**.
-1. Click **Azure**.
-1. Enter your Azure credentials.
-1. Click **Create**.
-
-**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster. You can reuse these credentials for other node templates, or in other clusters.
-
-### 2. Create a node template with your cloud credentials
-
-Creating a [node template](use-new-nodes-in-an-infra-provider.md#node-templates) for Azure will allow Rancher to provision new nodes in Azure. Node templates can be reused for other clusters.
-
-1. Click **☰ > Cluster Management**.
-1. Click **RKE1 Configuration > Node Templates**.
-1. Click **Add Template**.
-1. Click **Azure**.
-1. Fill out a node template for Azure. For help filling out the form, refer to [Azure Node Template Configuration.](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/azure.md)
-
-### 3. Create a cluster with node pools using the node template
-
-Use Rancher to create a Kubernetes cluster in Azure.
-
-1. Click **☰ > Cluster Management**.
-1. On the **Clusters** page, click **Create**.
-1. Click **Azure**.
-1. Enter a **Cluster Name**.
-1. Add one or more node pools to your cluster. Each node pool uses a node template to provision new nodes. For more information about node pools, including best practices, see [this section.](use-new-nodes-in-an-infra-provider.md)
-1. In the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options**. For help configuring the cluster, refer to the [RKE cluster configuration reference.](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md)
-1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
-1. Click **Create**.
-
-</TabItem>
-<TabItem value="RKE2">
 
 ### 1. Create your cloud credentials
 
@@ -104,7 +60,7 @@ If you already have a set of cloud credentials to use, skip this section.
 1. Enter your Azure credentials.
 1. Click **Create**.
 
-**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster. You can reuse these credentials for other node templates, or in other clusters.
+**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster.
 
 ### 2. Create your cluster
 
@@ -118,12 +74,9 @@ Use Rancher to create a Kubernetes cluster in Azure.
 1. Enter a **Cluster Name**.
 1. Create a machine pool for each Kubernetes role. Refer to the [best practices](use-new-nodes-in-an-infra-provider.md#node-roles) for recommendations on role assignments and counts.
     1. For each machine pool, define the machine configuration. Refer to the [Azure machine configuration reference](../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/machine-configuration/azure.md) for information on configuration options.
-1. Use the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation.  For help configuring the cluster, refer to the [RKE2 cluster configuration reference.](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md)
+1. Use the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation.  For help configuring the cluster, refer to the [RKE2](../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md) and [K3s](../../../../reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md) cluster configuration reference.
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
 1. Click **Create**.
-
-</TabItem>
-</Tabs>
 
 **Result:**
 

--- a/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/nutanix.md
+++ b/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/nutanix.md
@@ -18,4 +18,4 @@ A Nutanix cluster may consist of multiple groups of VMs with distinct properties
 
 ## Creating a Nutanix Cluster
 
-In [this section,](provision-kubernetes-clusters-in-aos.md) you'll learn how to use Rancher to install an [RKE](https://rancher.com/docs/rke/latest/en/) Kubernetes cluster in Nutanix AOS.
+In [this section,](provision-kubernetes-clusters-in-aos.md) you'll learn how to use Rancher to install an [RKE2](https://docs.rke2.io/)/[K3s](https://docs.k3s.io/) Kubernetes cluster in Nutanix AOS.

--- a/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
+++ b/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template.md
@@ -6,9 +6,9 @@ title: Creating a VMware vSphere Virtual Machine Template
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-a-vm-template"/>
 </head>
 
-Creating virtual machines in a repeatable and reliable fashion can often be difficult. VMware vSphere offers the ability to build one VM that can then be converted to a template. The template can then be used to create identically configured VMs. Rancher leverages this capability within node pools to create identical RKE1 and RKE2 nodes.
+Creating virtual machines in a repeatable and reliable fashion can often be difficult. VMware vSphere offers the ability to build one VM that can then be converted to a template. The template can then be used to create identically configured VMs. Rancher leverages this capability to create identical RKE/K3s nodes.
 
-In order to leverage the template to create new VMs, Rancher has some [specific requirements](#requirements) that the VM must have pre-installed. After you configure the VM with these requirements, you will next need to [prepare the VM](#preparing-your-vm) before [creating the template](#creating-a-template). Finally, once preparation is complete, the VM can be [converted to a template](#converting-to-a-template) and [moved into a content library](#moving-to-a-content-library), ready for Rancher node pool usage.
+In order to leverage the template to create new VMs, Rancher has some [specific requirements](#requirements) that the VM must have pre-installed. After you configure the VM with these requirements, you will next need to [prepare the VM](#preparing-your-vm) before [creating the template](#creating-a-template). Finally, once preparation is complete, the VM can be [converted to a template](#converting-to-a-template) and [moved into a content library](#moving-to-a-content-library).
 
 
 ## Requirements
@@ -47,14 +47,6 @@ The list of packages that need to be installed on the template is as follows:
 
 * Windows Container Feature
 * [cloudbase-init](https://cloudbase.it/cloudbase-init/#download)
-* [Docker EE](https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=Windows-Server#install-docker) - RKE1 Only
-
-:::note About the configuration for Windows templates varies between RKE1 and RKE2:
-
-- RKE1 leverages Docker, so any RKE1 templates need to have Docker EE pre-installed as well
-- RKE2 does not require Docker EE, and thus it does not need to be installed
-
-:::
 
 ## Creating a Template
 

--- a/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-credentials.md
+++ b/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/create-credentials.md
@@ -34,7 +34,7 @@ The following steps create a role with the required privileges and then assign i
 
 4. Go to the **Users and Groups** tab.
 
-5. Create a new user. Fill out the form and then click **OK**. Make sure to note the username and password, because you will need it when configuring node templates in Rancher.
+5. Create a new user. Fill out the form and then click **OK**. Make sure to note the username and password, because you will need it when creating cloud credentials in Rancher.
 
     ![](/img/rancheruser.png)
 

--- a/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere.md
+++ b/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere.md
@@ -6,29 +6,20 @@ title: Provisioning Kubernetes Clusters in VMware vSphere
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere"/>
 </head>
 
-In this section, you'll learn how to use Rancher to install an [RKE](https://rancher.com/docs/rke/latest/en/)  Kubernetes cluster in VMware vSphere.
+In this section, you'll learn how to deploy an [RKE2](https://docs.rke2.io/)/[K3s](https://docs.k3s.io/) Kubernetes cluster in VMware vSphere.
 
-First, you will set up your vSphere cloud credentials in Rancher. Then you will use your cloud credentials to create a node template, which Rancher will use to provision nodes in vSphere.
+First, you will set up your vSphere cloud credentials in Rancher.
 
-Then you will create a vSphere cluster in Rancher, and when configuring the new cluster, you will define node pools for it. Each node pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install RKE Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the node pool.
-
-For details on configuring the vSphere node template, refer to the [vSphere node template configuration reference.](../../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/vsphere.md)
-
-For details on configuring RKE Kubernetes clusters in Rancher, refer to the [cluster configuration reference.](../../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md#rke-cluster-config-file-reference)
-
+Then you will create a vSphere cluster in Rancher, and when configuring the new cluster, you will define machine pools for it. Each machine pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the machine pool.
 
 - [Preparation in vSphere](#preparation-in-vmware-vsphere)
 - [Creating a vSphere Cluster](#creating-a-vmware-vsphere-cluster)
 
 ## Preparation in VMware vSphere
 
-This section describes the requirements for setting up vSphere so that Rancher can provision VMs and clusters.
+This section describes the requirements for setting up vSphere so that Rancher can provision VMs and clusters.### Create Credentials in VMware vSphere
 
-The node templates are documented and tested with the vSphere Web Services API version 6.5.
-
-### Create Credentials in VMware vSphere
-
-Before proceeding to create a cluster, you must ensure that you have a vSphere user with sufficient permissions. When you set up a node template, the template will need to use these vSphere credentials.
+Before proceeding to create a cluster, you must ensure that you have a vSphere user with sufficient permissions.
 
 Refer to this [how-to guide](create-credentials.md) for instructions on how to create a user in vSphere with the required permissions. These steps result in a username and password that you will need to provide to Rancher, which allows Rancher to provision resources in vSphere.
 
@@ -58,45 +49,30 @@ User-data.iso files may have become orphaned upon node deletion due to a vSphere
 
 :::
 
-1. [Create your cloud credentials](#1-create-your-cloud-credentials)
-2. [Create a node template with your cloud credentials](#2-create-a-node-template-with-your-cloud-credentials)
-3. [Create a cluster with node pools using the node template](#3-create-a-cluster-with-node-pools-using-the-node-template)
-
 ### 1. Create your cloud credentials
 
 1. Click **☰ > Cluster Management**.
 1. Click **Cloud Credentials**.
 1. Click **Create**.
 1. Click **VMware vSphere**.
-1. Enter your vSphere credentials. For help, refer to **Account Access** in the [node template configuration reference.](../../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/vsphere.md)
+1. Enter your vSphere credentials.
 1. Click **Create**.
 
-**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster. You can reuse these credentials for other node templates, or in other clusters.
+**Result:** You have created the cloud credentials that will be used to provision nodes in your cluster.
 
-### 2. Create a node template with your cloud credentials
-
-Creating a [node template](../use-new-nodes-in-an-infra-provider.md#node-templates) for vSphere will allow Rancher to provision new nodes in vSphere. Node templates can be reused for other clusters.
-
-1. Click **☰ > Cluster Management**.
-1. Click **RKE1 Configuration > Node Templates**.
-1. Click **Create**.
-1. Click **Add Template**.
-1. Click **vSphere**.
-1. Fill out a node template for vSphere. For help filling out the form, refer to the vSphere node template [configuration reference.](../../../../../reference-guides/cluster-configuration/downstream-cluster-configuration/node-template-configuration/vsphere.md).
-1. Click **Create**.
-
-### 3. Create a cluster with node pools using the node template
+### 2. Create your cluster
 
 Use Rancher to create a Kubernetes cluster in vSphere.
 
 1. In the upper left corner, click **☰ > Cluster Management**.
 1. On the **Clusters** page, click **Create**.
 1. Click **VMware vSphere**.
-1. Enter a **Cluster Name** and use your vSphere cloud credentials. Click **Continue**.
+1. Enter a **Cluster Name** and use your vSphere cloud credentials.
+1. Create a machine pool for each Kubernetes role. Refer to the [best practices](../use-new-nodes-in-an-infra-provider.md#node-roles) for recommendations on role assignments and counts.
+    1. For each machine pool, define the machine configuration.
+1. Use **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. For help configuring the cluster, refer to the [RKE2](../../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.md) and [K3s](../../../../../reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration.md) cluster configuration reference.
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
-1. Use **Cluster Options** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options**. For help configuring the cluster, refer to the [RKE cluster configuration reference.](../../../../../reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.md)
 1. If you want to dynamically provision persistent storage or other infrastructure later, you will need to enable the vSphere cloud provider by modifying the cluster YAML file. For details, refer to [in-tree vSphere cloud provider docs](../../../../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-in-tree-vsphere.md) and [out-of-tree vSphere cloud provider docs](../../../../../how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/configure-out-of-tree-vsphere.md).
-1. Add one or more node pools to your cluster. Each node pool uses a node template to provision new nodes. For more information about node pools, including best practices for assigning Kubernetes roles to the nodes, see [this section.](../use-new-nodes-in-an-infra-provider.md#node-pools)
 1. Review your options to confirm they're correct. Then click **Create**.
 
 **Result:**

--- a/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere.md
+++ b/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere.md
@@ -17,7 +17,9 @@ Then you will create a vSphere cluster in Rancher, and when configuring the new 
 
 ## Preparation in VMware vSphere
 
-This section describes the requirements for setting up vSphere so that Rancher can provision VMs and clusters.### Create Credentials in VMware vSphere
+This section describes the requirements for setting up vSphere so that Rancher can provision VMs and clusters.
+
+### Create Credentials in VMware vSphere
 
 Before proceeding to create a cluster, you must ensure that you have a vSphere user with sufficient permissions.
 

--- a/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/shutdown-vm.md
+++ b/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/shutdown-vm.md
@@ -10,8 +10,6 @@ In Rancher v2.8.3 and later, you can configure the graceful shutdown of virtual 
 
 In RKE2/K3s, you can set up graceful shutdown when you create the cluster, or edit the cluster configuration to add it afterward. 
 
-In RKE, you can edit node templates to similar results.
-
 :::note 
 
 Since Rancher can't detect the platform of an imported cluster, you cannot enable graceful shutdown on VMware vSphere clusters you have imported.
@@ -20,29 +18,11 @@ Since Rancher can't detect the platform of an imported cluster, you cannot enabl
 
 ## Enable Graceful Shutdown During VMware vSphere Cluster Creation 
 
-<Tabs>
-<TabItem value="RKE2/K3s">
-
 In RKE2/K3s, you can configure new VMware vSphere clusters with graceful shutdown for VMs:
 
 1. Click **☰ > Cluster Management**.
 1. Click **Create** and select **VMware vSphere** to provision a new cluster.
 1. Under **Machine Pools > Scheduling**, in the **Graceful Shutdown Timeout** field, enter an integer value greater than 0. The value you enter is the amount of time in seconds Rancher waits before deleting VMs on the cluster. If the value is set to `0`, graceful shutdown is disabled.
-
-</TabItem>
-<TabItem value="RKE">
-
-In RKE, you can't directly configure a new cluster with graceful shutdown. However, you can configure node templates which automatically create node pools with graceful shutdown enabled. The node template can then be used to provision new VMware vSphere clusters that have a graceful shutdown delay. 
-
-1. Click **☰ > Cluster Management**.
-1. From the left navigation, select **RKE1 Configuration > Node Templates**.
-1. Click **Add Template** and select **vSphere** to create a node template.
-1. Under **2. Scheduling**, in the **Graceful Shutdown Timeout** field, enter an integer value greater than 0. The value you enter is the amount of time in seconds Rancher waits before deleting VMs on the cluster. If the value is set to `0`, graceful shutdown is disabled.
-
-When you [use the newly-created node template to create node pools](../use-new-nodes-in-an-infra-provider.md), the nodes will gracefully shutdown of VMs according to the **Graceful Shutdown Timeout** value you have set.
-
-</TabItem>
-</Tabs>
 
 ## Enable Graceful Shutdown in Existing RKE2/K3s Clusters
 
@@ -52,14 +32,3 @@ In RKE2/K3s, you can edit the configuration of an existing VMware vSphere cluste
 1. On the **Clusters** page, find the VMware vSphere hosted cluster you want to edit. Click **⋮** at the end of the row associated with the cluster. Select **Edit Config**.
 1. Under **Machine Pools > Scheduling**, in the **Graceful Shutdown Timeout** field, enter an integer value greater than 0. The value you enter is the amount of time in seconds Rancher waits before deleting VMs on the cluster. If the value is set to `0`, graceful shutdown is disabled.
 
-## Enable Graceful Shutdown in Existing RKE Clusters
-
-In RKE, you can't directly edit an existing cluster's configuration to add graceful shutdown to existing VMware vSphere clusters. However, you can edit the configuration of existing node templates. As noted in [Updating a Node Template](../../../../../reference-guides/user-settings/manage-node-templates.md#updating-a-node-template), all node pools using the node template automatically use the updated information when new nodes are added to the cluster.
-
-To edit an existing node template to enable graceful shutdown:
-
-1. Click **☰ > Cluster Management**.
-1. From the left navigation, select **RKE1 Configuration > Node Templates**.
-1. Find the VMware vSphere node template you want to edit. Click **⋮** at the end of the row associated with the template. Select **Edit**.
-1. Under **2. Scheduling**, in the **Graceful Shutdown Timeout** field, enter an integer value greater than 0. The value you enter is the amount of time in seconds Rancher waits before deleting VMs on the cluster. If the value is set to `0`, graceful shutdown is disabled.
-1. Click **Save**.

--- a/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
+++ b/versioned_docs/version-2.12/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere.md
@@ -15,33 +15,9 @@ Rancher can provision nodes in vSphere and install Kubernetes on them. When crea
 
 A vSphere cluster may consist of multiple groups of VMs with distinct properties, such as the amount of memory or the number of vCPUs. This grouping allows for fine-grained control over the sizing of nodes for each Kubernetes role.
 
-## VMware vSphere Enhancements
-
-The vSphere node templates allow you to bring cloud operations on-premises with the following enhancements:
-
-### Self-healing Node Pools
-
-One of the biggest advantages of provisioning vSphere nodes with Rancher is that it allows you to take advantage of Rancher's self-healing node pools, also called the [node auto-replace feature,](../use-new-nodes-in-an-infra-provider.md#about-node-auto-replace) in your on-premises clusters. Self-healing node pools are designed to help you replace worker nodes for stateless applications. When Rancher provisions nodes from a node template, Rancher can automatically replace unreachable nodes.
-
-:::caution
-
-It is not recommended to enable node auto-replace on a node pool of master nodes or nodes with persistent volumes attached, because VMs are treated ephemerally. When a node in a node pool loses connectivity with the cluster, its persistent volumes are destroyed, resulting in data loss for stateful applications.
-
-:::
-
-### Dynamically Populated Options for Instances and Scheduling
-
-Node templates for vSphere have been updated so that when you create a node template with your vSphere credentials, the template is automatically populated with the same options for provisioning VMs that you have access to in the vSphere console.
-
-For the fields to be populated, your setup needs to fulfill the [prerequisites.](provision-kubernetes-clusters-in-vsphere.md#preparation-in-vmware-vsphere)
-
-### More Supported Operating Systems
-
-You can provision VMs with any operating system that supports `cloud-init`. Only YAML format is supported for the [cloud config.](https://cloudinit.readthedocs.io/en/latest/topics/examples.html)
-
 ## Creating a VMware vSphere Cluster
 
-In [this section,](provision-kubernetes-clusters-in-vsphere.md) you'll learn how to use Rancher to install an [RKE](https://rancher.com/docs/rke/latest/en/) Kubernetes cluster in vSphere.
+In [this section,](provision-kubernetes-clusters-in-vsphere.md) you'll learn how to use Rancher to install an [RKE2](https://docs.rke2.io/)/[K3s](https://docs.k3s.io/) Kubernetes cluster in vSphere.
 
 ## Provisioning Storage
 


### PR DESCRIPTION
Relates to #1873 

Notes: 
- The index page (use-new-nodes-in-an-infra-provider.md) is not covered as the entire page requires an overhaul.
- nutanix/provision-kubernetes-clusters-in-aos.md is not covered it depends on a nutanix config reference page replacement existing, which we don't have a replacement for.