### PR TITLE
Update migrate-rancher-to-new-cluster.md

### DIFF
--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -197,3 +197,32 @@ helm install rancher rancher-latest/rancher -n cattle-system -f rancher-values.y
 After migration completes, update your DNS records and any load balancers, so that traffic is routed correctly to the migrated cluster. Remember that you must use the same hostname that was set as the server URL in the original cluster.
 
 Full instructions on how to redirect traffic to the migrated cluster differ based on your specific environment. Refer to your hosting provider's documentation for more details.
+
+### 6. Scale down the original Rancher instance
+
+After redirecting traffic to the new Rancher environment, **scale the original Rancher instance to 0 replicas** so it no longer contacts with your managed clusters.  
+
+Leaving the old server up can cause agents to keep contacting the original `server-url`, which often leaves clusters stuck in **Updating** in the new environment.
+
+```bash
+kubectl scale deployment rancher -n cattle-system --replicas=0
+```
+
+If you originally ran Rancher in Docker:
+
+```bash
+docker stop <original-rancher-container>
+```
+
+:::note
+
+If you wish to keep the original Rancher environment running, you can also restart the cattle-cluster-agent pods on each cluster connected to your Rancher environment.
+
+```bash
+kubectl rollout restart deployment cattle-cluster-agent -n cattle-system
+```
+
+This triggers a rolling restart of the agent so it re-establishes the connection to the new Rancher environment.
+
+:::
+


### PR DESCRIPTION
I was migrating my Rancher 2.10.1 instance to a new cluster running RKE2 (the original local cluster was running RKE1), I followed the steps as described in:
https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster

I found out that after I made the change on my DNS server - all the clusters that were connected to my original Rancher server - **were stuck on updating in the new Rancher server**.

I figured out that the cattle-cluster-agents were still communicating with the old Rancher server, and had to fail their connection with it (or had to be restarted) - in order to make them communicate with the new Rancher server.

After I scaled down the the original Rancher server, the clusters became in **Running** state in the new Rancher server.
This is a very important step that wasn't mentioned in the migration guide.

I assume that more Rancher users can experience this problem when migrating their cluster, and I think this addition to the Rancher migration guide will make their migrating operation easier (and possible).

<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #[issue_number]

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, remember to add a "MERGE ON RELEASE" label and set the proper milestone.

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->
