### PR TITLE
Update doc for PNI in GKE

### DIFF
--- a/docs/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
+++ b/docs/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
@@ -67,11 +67,11 @@ Choose whether to enable or disable inter-project communication.
 
 #### Imported Clusters
 
-For imported clusters, Project Network Isolation (PNI) requires Kubernetes Network Policy to be enabled on the cluster beforehand.  
+For imported clusters, Project Network Isolation (PNI) requires Kubernetes Network Policy to be enabled on the cluster beforehand.
 For clusters created by Rancher, Rancher enables Kubernetes Network Policy automatically.
 
-1. In GKE, enable Network Policy at the cluster level. (Refer to the official GKE guide)[https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy]
-2. After enabling Network Policy, import the cluster into Rancher and enable PNI for project-level isolation.
+1. In GKE, enable Network Policy at the cluster level. Refer to the [official GKE guide](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy) for instructions.
+1. After enabling Network Policy, import the cluster into Rancher and enable PNI for project-level isolation.
 
 ### Node Ipv4 CIDR Block
 

--- a/versioned_docs/version-2.13/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
+++ b/versioned_docs/version-2.13/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration.md
@@ -63,7 +63,15 @@ Enable network policy enforcement on the cluster. A network policy defines the l
 
 _Mutable: yes_
 
-choose whether to enable or disable inter-project communication. Note that enabling Project Network Isolation will automatically enable Network Policy and Network Policy Config, but not vice versa.
+Choose whether to enable or disable inter-project communication.
+
+#### Imported Clusters
+
+For imported clusters, Project Network Isolation (PNI) requires Kubernetes Network Policy to be enabled on the cluster beforehand.
+For clusters created by Rancher, Rancher enables Kubernetes Network Policy automatically.
+
+1. In GKE, enable Network Policy at the cluster level. Refer to the [official GKE guide](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy) for instructions.
+1. After enabling Network Policy, import the cluster into Rancher and enable PNI for project-level isolation.
 
 ### Node Ipv4 CIDR Block
 


### PR DESCRIPTION
Fixes #<add_issue_number_if_any>

## Description

- Added a note under **Project Network Isolation** in the GKE cluster configuration page.  
- Clarifies that for **imported GKE clusters**, Network Policy (Calico) must be enabled on both master and worker nodes before enabling PNI.  

## Comments

- This update improves clarity for users importing GKE clusters with PNI.  
