### PR TITLE
Fix broken indentation in api workflows projects doc #2109

### DIFF
--- a/archived_docs/en/version-2.8/api/workflows/projects.md
+++ b/archived_docs/en/version-2.8/api/workflows/projects.md
@@ -37,8 +37,7 @@ apiVersion: management.cattle.io/v3
 kind: Project
 metadata:
   annotations: 
-  field.cattle.io/creatorId:
-    user-id
+    field.cattle.io/creatorId: user-id
   generateName: p-
   namespace: c-m-abcde
 spec:

--- a/archived_docs/zh/version-2.8/api/workflows/projects.md
+++ b/archived_docs/zh/version-2.8/api/workflows/projects.md
@@ -37,8 +37,7 @@ apiVersion: management.cattle.io/v3
 kind: Project
 metadata:
   annotations: 
-  field.cattle.io/creatorId:
-    user-id
+    field.cattle.io/creatorId: user-id
   generateName: p-
   namespace: c-m-abcde
 spec:

--- a/docs/api/workflows/projects.md
+++ b/docs/api/workflows/projects.md
@@ -37,8 +37,7 @@ apiVersion: management.cattle.io/v3
 kind: Project
 metadata:
   annotations: 
-  field.cattle.io/creatorId:
-    user-id
+    field.cattle.io/creatorId: user-id
   generateName: p-
   namespace: c-m-abcde
 spec:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/api/workflows/projects.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/api/workflows/projects.md
@@ -37,8 +37,7 @@ apiVersion: management.cattle.io/v3
 kind: Project
 metadata:
   annotations: 
-  field.cattle.io/creatorId:
-    user-id
+    field.cattle.io/creatorId: user-id
   generateName: p-
   namespace: c-m-abcde
 spec:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.10/api/workflows/projects.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.10/api/workflows/projects.md
@@ -37,8 +37,7 @@ apiVersion: management.cattle.io/v3
 kind: Project
 metadata:
   annotations: 
-  field.cattle.io/creatorId:
-    user-id
+    field.cattle.io/creatorId: user-id
   generateName: p-
   namespace: c-m-abcde
 spec:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.11/api/workflows/projects.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.11/api/workflows/projects.md
@@ -37,8 +37,7 @@ apiVersion: management.cattle.io/v3
 kind: Project
 metadata:
   annotations: 
-  field.cattle.io/creatorId:
-    user-id
+    field.cattle.io/creatorId: user-id
   generateName: p-
   namespace: c-m-abcde
 spec:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.12/api/workflows/projects.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.12/api/workflows/projects.md
@@ -37,8 +37,7 @@ apiVersion: management.cattle.io/v3
 kind: Project
 metadata:
   annotations: 
-  field.cattle.io/creatorId:
-    user-id
+    field.cattle.io/creatorId: user-id
   generateName: p-
   namespace: c-m-abcde
 spec:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.13/api/workflows/projects.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.13/api/workflows/projects.md
@@ -37,8 +37,7 @@ apiVersion: management.cattle.io/v3
 kind: Project
 metadata:
   annotations: 
-  field.cattle.io/creatorId:
-    user-id
+    field.cattle.io/creatorId: user-id
   generateName: p-
   namespace: c-m-abcde
 spec:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.9/api/workflows/projects.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.9/api/workflows/projects.md
@@ -37,8 +37,7 @@ apiVersion: management.cattle.io/v3
 kind: Project
 metadata:
   annotations: 
-  field.cattle.io/creatorId:
-    user-id
+    field.cattle.io/creatorId: user-id
   generateName: p-
   namespace: c-m-abcde
 spec:

--- a/versioned_docs/version-2.10/api/workflows/projects.md
+++ b/versioned_docs/version-2.10/api/workflows/projects.md
@@ -37,8 +37,7 @@ apiVersion: management.cattle.io/v3
 kind: Project
 metadata:
   annotations: 
-  field.cattle.io/creatorId:
-    user-id
+    field.cattle.io/creatorId: user-id
   generateName: p-
   namespace: c-m-abcde
 spec:

--- a/versioned_docs/version-2.11/api/workflows/projects.md
+++ b/versioned_docs/version-2.11/api/workflows/projects.md
@@ -37,8 +37,7 @@ apiVersion: management.cattle.io/v3
 kind: Project
 metadata:
   annotations: 
-  field.cattle.io/creatorId:
-    user-id
+    field.cattle.io/creatorId: user-id
   generateName: p-
   namespace: c-m-abcde
 spec:

--- a/versioned_docs/version-2.12/api/workflows/projects.md
+++ b/versioned_docs/version-2.12/api/workflows/projects.md
@@ -37,8 +37,7 @@ apiVersion: management.cattle.io/v3
 kind: Project
 metadata:
   annotations: 
-  field.cattle.io/creatorId:
-    user-id
+    field.cattle.io/creatorId: user-id
   generateName: p-
   namespace: c-m-abcde
 spec:

--- a/versioned_docs/version-2.13/api/workflows/projects.md
+++ b/versioned_docs/version-2.13/api/workflows/projects.md
@@ -37,8 +37,7 @@ apiVersion: management.cattle.io/v3
 kind: Project
 metadata:
   annotations: 
-  field.cattle.io/creatorId:
-    user-id
+    field.cattle.io/creatorId: user-id
   generateName: p-
   namespace: c-m-abcde
 spec:

--- a/versioned_docs/version-2.9/api/workflows/projects.md
+++ b/versioned_docs/version-2.9/api/workflows/projects.md
@@ -37,8 +37,7 @@ apiVersion: management.cattle.io/v3
 kind: Project
 metadata:
   annotations: 
-  field.cattle.io/creatorId:
-    user-id
+    field.cattle.io/creatorId: user-id
   generateName: p-
   namespace: c-m-abcde
 spec:


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #2109 and https://github.com/rancher/rancher/issues/52554

## Description

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->
PR fixes incorrect yaml indentation in project crd code snippet:
```bash
diff --git a/docs/api/workflows/projects.md b/docs/api/workflows/projects.md
index 7b7ced1e6..853dd7f16 100644
--- a/docs/api/workflows/projects.md
+++ b/docs/api/workflows/projects.md
@@ -37,8 +37,7 @@ apiVersion: management.cattle.io/v3
 kind: Project
 metadata:
   annotations:
-  field.cattle.io/creatorId:
-    user-id
+    field.cattle.io/creatorId: user-id
   generateName: p-
   namespace: c-m-abcde
 spec:
```
## Comments

<!--
Any additional notes a reviewer should know before we review.
-->
Tested locally and confirm code snippet is correct for all versions.

<img width="1714" height="721" alt="image" src="https://github.com/user-attachments/assets/d128e836-8d48-4e08-a5a7-3ffcd2db341f" />
