### PR TITLE
Creating Apps: Added doc for `keywords`

### DIFF
--- a/docs/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
+++ b/docs/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
@@ -77,13 +77,13 @@ Rancher supports additional annotations that you can add to the `Chart.yaml` fil
 | catalog.cattle.io/display-name    | A display name that should be displayed in the App Marketplace instead of the chart name | Display Name of Chart |
 | catalog.cattle.io/namespace       | A fixed namespace where the chart should be deployed in. If set, this can't be changed by the user | fixed-namespace |
 | catalog.cattle.io/release-name    | A fixed release name for the Helm installation. If set, this can't be changed by the user | fixed-release-name |
-| catalog.cattle.io/requests-cpu    | Total amount of CPU that should be unreserverd in the cluster. If less CPU is available, a warning will be shown | 2000m |
-| catalog.cattle.io/requests-memory | Total amount of memory that should be unreserverd in the cluster. If less memory is available, a warning will be shown | 2Gi |
+| catalog.cattle.io/requests-cpu    | Total amount of CPU that should be unreserved in the cluster. If less CPU is available, a warning will be shown | 2000m |
+| catalog.cattle.io/requests-memory | Total amount of memory that should be unreserved in the cluster. If less memory is available, a warning will be shown | 2Gi |
 | catalog.cattle.io/os              | Restricts the OS where this chart can be installed. Possible values: `linux`, `windows`. Default: no restriction | linux |
 
 ### Keywords
 
-With the `keywords` option in the `Chart.yaml` file it is possible to provide a list of categories for sorting your appication in the Rancher UI, like `infrastructure`, `monitoring` and more.
+With the `keywords` option in the `Chart.yaml` file it is possible to provide a list of categories for sorting your application in the Rancher UI, like `infrastructure`, `monitoring` and more.
 
 ### questions.yml
 

--- a/versioned_docs/version-2.10/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
+++ b/versioned_docs/version-2.10/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
@@ -66,7 +66,8 @@ Before you create your own custom catalog, you should have a basic understanding
     ![values.yaml](/img/helm-app-2.6.png)
 
 
-### Chart.yaml annotations
+### Chart.yaml
+#### Annotations
 
 Rancher supports additional annotations that you can add to the `Chart.yaml` file. These annotations allow you to define application dependencies or configure additional UI defaults:
 
@@ -76,9 +77,13 @@ Rancher supports additional annotations that you can add to the `Chart.yaml` fil
 | catalog.cattle.io/display-name    | A display name that should be displayed in the App Marketplace instead of the chart name | Display Name of Chart |
 | catalog.cattle.io/namespace       | A fixed namespace where the chart should be deployed in. If set, this can't be changed by the user | fixed-namespace |
 | catalog.cattle.io/release-name    | A fixed release name for the Helm installation. If set, this can't be changed by the user | fixed-release-name |
-| catalog.cattle.io/requests-cpu    | Total amount of CPU that should be unreserverd in the cluster. If less CPU is available, a warning will be shown | 2000m |
-| catalog.cattle.io/requests-memory | Total amount of memory that should be unreserverd in the cluster. If less memory is available, a warning will be shown | 2Gi |
+| catalog.cattle.io/requests-cpu    | Total amount of CPU that should be unreserved in the cluster. If less CPU is available, a warning will be shown | 2000m |
+| catalog.cattle.io/requests-memory | Total amount of memory that should be unreserved in the cluster. If less memory is available, a warning will be shown | 2Gi |
 | catalog.cattle.io/os              | Restricts the OS where this chart can be installed. Possible values: `linux`, `windows`. Default: no restriction | linux |
+
+### Keywords
+
+With the `keywords` option in the `Chart.yaml` file it is possible to provide a list of categories for sorting your application in the Rancher UI, like `infrastructure`, `monitoring` and more.
 
 ### questions.yml
 

--- a/versioned_docs/version-2.11/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
+++ b/versioned_docs/version-2.11/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
@@ -66,7 +66,8 @@ Before you create your own custom catalog, you should have a basic understanding
     ![values.yaml](/img/helm-app-2.6.png)
 
 
-### Chart.yaml annotations
+### Chart.yaml
+#### Annotations
 
 Rancher supports additional annotations that you can add to the `Chart.yaml` file. These annotations allow you to define application dependencies or configure additional UI defaults:
 
@@ -76,9 +77,13 @@ Rancher supports additional annotations that you can add to the `Chart.yaml` fil
 | catalog.cattle.io/display-name    | A display name that should be displayed in the App Marketplace instead of the chart name | Display Name of Chart |
 | catalog.cattle.io/namespace       | A fixed namespace where the chart should be deployed in. If set, this can't be changed by the user | fixed-namespace |
 | catalog.cattle.io/release-name    | A fixed release name for the Helm installation. If set, this can't be changed by the user | fixed-release-name |
-| catalog.cattle.io/requests-cpu    | Total amount of CPU that should be unreserverd in the cluster. If less CPU is available, a warning will be shown | 2000m |
-| catalog.cattle.io/requests-memory | Total amount of memory that should be unreserverd in the cluster. If less memory is available, a warning will be shown | 2Gi |
+| catalog.cattle.io/requests-cpu    | Total amount of CPU that should be unreserved in the cluster. If less CPU is available, a warning will be shown | 2000m |
+| catalog.cattle.io/requests-memory | Total amount of memory that should be unreserved in the cluster. If less memory is available, a warning will be shown | 2Gi |
 | catalog.cattle.io/os              | Restricts the OS where this chart can be installed. Possible values: `linux`, `windows`. Default: no restriction | linux |
+
+### Keywords
+
+With the `keywords` option in the `Chart.yaml` file it is possible to provide a list of categories for sorting your application in the Rancher UI, like `infrastructure`, `monitoring` and more.
 
 ### questions.yml
 

--- a/versioned_docs/version-2.12/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
+++ b/versioned_docs/version-2.12/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
@@ -66,7 +66,8 @@ Before you create your own custom catalog, you should have a basic understanding
     ![values.yaml](/img/helm-app-2.6.png)
 
 
-### Chart.yaml annotations
+### Chart.yaml
+#### Annotations
 
 Rancher supports additional annotations that you can add to the `Chart.yaml` file. These annotations allow you to define application dependencies or configure additional UI defaults:
 
@@ -76,9 +77,13 @@ Rancher supports additional annotations that you can add to the `Chart.yaml` fil
 | catalog.cattle.io/display-name    | A display name that should be displayed in the App Marketplace instead of the chart name | Display Name of Chart |
 | catalog.cattle.io/namespace       | A fixed namespace where the chart should be deployed in. If set, this can't be changed by the user | fixed-namespace |
 | catalog.cattle.io/release-name    | A fixed release name for the Helm installation. If set, this can't be changed by the user | fixed-release-name |
-| catalog.cattle.io/requests-cpu    | Total amount of CPU that should be unreserverd in the cluster. If less CPU is available, a warning will be shown | 2000m |
-| catalog.cattle.io/requests-memory | Total amount of memory that should be unreserverd in the cluster. If less memory is available, a warning will be shown | 2Gi |
+| catalog.cattle.io/requests-cpu    | Total amount of CPU that should be unreserved in the cluster. If less CPU is available, a warning will be shown | 2000m |
+| catalog.cattle.io/requests-memory | Total amount of memory that should be unreserved in the cluster. If less memory is available, a warning will be shown | 2Gi |
 | catalog.cattle.io/os              | Restricts the OS where this chart can be installed. Possible values: `linux`, `windows`. Default: no restriction | linux |
+
+### Keywords
+
+With the `keywords` option in the `Chart.yaml` file it is possible to provide a list of categories for sorting your application in the Rancher UI, like `infrastructure`, `monitoring` and more.
 
 ### questions.yml
 

--- a/versioned_docs/version-2.13/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
+++ b/versioned_docs/version-2.13/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
@@ -66,7 +66,8 @@ Before you create your own custom catalog, you should have a basic understanding
     ![values.yaml](/img/helm-app-2.6.png)
 
 
-### Chart.yaml annotations
+### Chart.yaml
+#### Annotations
 
 Rancher supports additional annotations that you can add to the `Chart.yaml` file. These annotations allow you to define application dependencies or configure additional UI defaults:
 
@@ -76,9 +77,13 @@ Rancher supports additional annotations that you can add to the `Chart.yaml` fil
 | catalog.cattle.io/display-name    | A display name that should be displayed in the App Marketplace instead of the chart name | Display Name of Chart |
 | catalog.cattle.io/namespace       | A fixed namespace where the chart should be deployed in. If set, this can't be changed by the user | fixed-namespace |
 | catalog.cattle.io/release-name    | A fixed release name for the Helm installation. If set, this can't be changed by the user | fixed-release-name |
-| catalog.cattle.io/requests-cpu    | Total amount of CPU that should be unreserverd in the cluster. If less CPU is available, a warning will be shown | 2000m |
-| catalog.cattle.io/requests-memory | Total amount of memory that should be unreserverd in the cluster. If less memory is available, a warning will be shown | 2Gi |
+| catalog.cattle.io/requests-cpu    | Total amount of CPU that should be unreserved in the cluster. If less CPU is available, a warning will be shown | 2000m |
+| catalog.cattle.io/requests-memory | Total amount of memory that should be unreserved in the cluster. If less memory is available, a warning will be shown | 2Gi |
 | catalog.cattle.io/os              | Restricts the OS where this chart can be installed. Possible values: `linux`, `windows`. Default: no restriction | linux |
+
+### Keywords
+
+With the `keywords` option in the `Chart.yaml` file it is possible to provide a list of categories for sorting your application in the Rancher UI, like `infrastructure`, `monitoring` and more.
 
 ### questions.yml
 

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/helm-charts-in-rancher/create-apps.md
@@ -66,7 +66,8 @@ Before you create your own custom catalog, you should have a basic understanding
     ![values.yaml](/img/helm-app-2.6.png)
 
 
-### Chart.yaml annotations
+### Chart.yaml
+#### Annotations
 
 Rancher supports additional annotations that you can add to the `Chart.yaml` file. These annotations allow you to define application dependencies or configure additional UI defaults:
 
@@ -76,9 +77,13 @@ Rancher supports additional annotations that you can add to the `Chart.yaml` fil
 | catalog.cattle.io/display-name    | A display name that should be displayed in the App Marketplace instead of the chart name | Display Name of Chart |
 | catalog.cattle.io/namespace       | A fixed namespace where the chart should be deployed in. If set, this can't be changed by the user | fixed-namespace |
 | catalog.cattle.io/release-name    | A fixed release name for the Helm installation. If set, this can't be changed by the user | fixed-release-name |
-| catalog.cattle.io/requests-cpu    | Total amount of CPU that should be unreserverd in the cluster. If less CPU is available, a warning will be shown | 2000m |
-| catalog.cattle.io/requests-memory | Total amount of memory that should be unreserverd in the cluster. If less memory is available, a warning will be shown | 2Gi |
+| catalog.cattle.io/requests-cpu    | Total amount of CPU that should be unreserved in the cluster. If less CPU is available, a warning will be shown | 2000m |
+| catalog.cattle.io/requests-memory | Total amount of memory that should be unreserved in the cluster. If less memory is available, a warning will be shown | 2Gi |
 | catalog.cattle.io/os              | Restricts the OS where this chart can be installed. Possible values: `linux`, `windows`. Default: no restriction | linux |
+
+### Keywords
+
+With the `keywords` option in the `Chart.yaml` file it is possible to provide a list of categories for sorting your application in the Rancher UI, like `infrastructure`, `monitoring` and more.
 
 ### questions.yml
 


### PR DESCRIPTION
## Description

In the `Creating Apps` documentation the image links pointed to an old path which was changed at some point.  
Additionally it wasn't documented how to sort an application within the Rancher UI into a Category.