### PR TITLE
Remove self-referencing link

### DIFF
--- a/docs/api/api-tokens.md
+++ b/docs/api/api-tokens.md
@@ -75,7 +75,7 @@ Time to live (TTL) duration in minutes, used to determine when a user auth sessi
 ### auth-user-session-idle-ttl-minutes
 
 Time to live (TTL) without user activity for login sessions tokens, in minutes.
-By default, [`auth-user-session-idle-ttl-minutes`](#auth-user-session-idle-ttl-minutes) is set to the same value as [`auth-user-session-ttl-minutes`](#auth-user-session-ttl-minutes) (for backward compatibility). It must never exceed the value of `auth-user-session-ttl-minutes`.
+By default, `auth-user-session-idle-ttl-minutes` is set to the same value as [`auth-user-session-ttl-minutes`](#auth-user-session-ttl-minutes) (for backward compatibility). It must never exceed the value of `auth-user-session-ttl-minutes`.
 
 ### kubeconfig-default-token-ttl-minutes
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/api/api-tokens.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/api/api-tokens.md
@@ -75,7 +75,7 @@ title: API 令牌
 ### auth-user-session-idle-ttl-minutes
 
 Time to live (TTL) without user activity for login sessions tokens, in minutes.
-By default, [`auth-user-session-idle-ttl-minutes`](#auth-user-session-idle-ttl-minutes) is set to the same value as [`auth-user-session-ttl-minutes`](#auth-user-session-ttl-minutes) (for backward compatibility). It must never exceed the value of `auth-user-session-ttl-minutes`.
+By default, `auth-user-session-idle-ttl-minutes` is set to the same value as [`auth-user-session-ttl-minutes`](#auth-user-session-ttl-minutes) (for backward compatibility). It must never exceed the value of `auth-user-session-ttl-minutes`.
 
 ### kubeconfig-default-token-TTL-minutes
 存活时间（TTL）（单位：分钟），用于确定 kubeconfig 令牌的到期时间。令牌过期后，API 将拒绝令牌。此设置的值不能大于 [`auth-token-max-ttl-minutes`](#auth-token-max-ttl-minutes) 的值。此设置适用于在请求的 kubeconfig 文件中生成的令牌，不包括[由 Rancher CLI 生成的](#在生成的-kubeconfig-中禁用令牌)令牌。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.13/api/api-tokens.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.13/api/api-tokens.md
@@ -75,7 +75,7 @@ title: API 令牌
 ### auth-user-session-idle-ttl-minutes
 
 Time to live (TTL) without user activity for login sessions tokens, in minutes.
-By default, [`auth-user-session-idle-ttl-minutes`](#auth-user-session-idle-ttl-minutes) is set to the same value as [`auth-user-session-ttl-minutes`](#auth-user-session-ttl-minutes) (for backward compatibility). It must never exceed the value of `auth-user-session-ttl-minutes`.
+By default, `auth-user-session-idle-ttl-minutes` is set to the same value as [`auth-user-session-ttl-minutes`](#auth-user-session-ttl-minutes) (for backward compatibility). It must never exceed the value of `auth-user-session-ttl-minutes`.
 
 ### kubeconfig-default-token-TTL-minutes
 存活时间（TTL）（单位：分钟），用于确定 kubeconfig 令牌的到期时间。令牌过期后，API 将拒绝令牌。此设置的值不能大于 [`auth-token-max-ttl-minutes`](#auth-token-max-ttl-minutes) 的值。此设置适用于在请求的 kubeconfig 文件中生成的令牌，不包括[由 Rancher CLI 生成的](#在生成的-kubeconfig-中禁用令牌)令牌。

--- a/versioned_docs/version-2.13/api/api-tokens.md
+++ b/versioned_docs/version-2.13/api/api-tokens.md
@@ -75,7 +75,7 @@ Time to live (TTL) duration in minutes, used to determine when a user auth sessi
 ### auth-user-session-idle-ttl-minutes
 
 Time to live (TTL) without user activity for login sessions tokens, in minutes.
-By default, [`auth-user-session-idle-ttl-minutes`](#auth-user-session-idle-ttl-minutes) is set to the same value as [`auth-user-session-ttl-minutes`](#auth-user-session-ttl-minutes) (for backward compatibility). It must never exceed the value of `auth-user-session-ttl-minutes`.
+By default, `auth-user-session-idle-ttl-minutes` is set to the same value as [`auth-user-session-ttl-minutes`](#auth-user-session-ttl-minutes) (for backward compatibility). It must never exceed the value of `auth-user-session-ttl-minutes`.
 
 ### kubeconfig-default-token-ttl-minutes
 


### PR DESCRIPTION
The cross reference in the text links to the section the text is contained in. i.e., it's a self-referencing link.