### PR TITLE
Amend documentation for fleet scheduling customization feature

### DIFF
--- a/docs/how-to-guides/advanced-user-guides/enable-cluster-agent-scheduling-customization.md
+++ b/docs/how-to-guides/advanced-user-guides/enable-cluster-agent-scheduling-customization.md
@@ -6,7 +6,7 @@ title: Enabling Cluster Agent Scheduling Customization
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/enable-cluster-agent-scheduling-customization"/>
 </head>
 
-The `cattle-cluster-agent` allows enabling automatic deployment of a Priority Class and Pod Disruption Budget.
+Both, the `cattle-cluster-agent` and `fleet-agent` allow enabling automatic deployment of a Priority Class and Pod Disruption Budget.
 
 When this feature is enabled, all newly provisioned Node Driver, Custom, and Imported RKE2 and K3s clusters will automatically deploy a Priority Class and Pod Disruption Budget during the provisioning process. Existing clusters can be gradually updated with this new behavior using the [Rancher UI or by setting a specific annotation](#updating-existing-clusters) on cluster objects.
 
@@ -24,7 +24,9 @@ Enabling or disabling this feature only impacts new clusters. Existing downstrea
 
 ## Configuring the Global Settings
 
-You can customize the default Priority Class (PC) and Pod Disruption Budget (PDB) by updating the `cluster-agent-default-priority-class` and `cluster-agent-default-pod-disruption-budget` global settings in the Rancher UI. Note that both the Priority Class and Pod Disruption Budget have configuration restrictions:
+You can customize the default PriorityClass (PC) and PodDisruptionBudget (PDB) by updating the `cluster-agent-default-priority-class` and `cluster-agent-default-pod-disruption-budget` global settings in the Rancher UI for the `cattle-cluster-agent`. For the `fleet-agent`, update the `fleet-agent-default-priority-class` and `fleet-agent-default-pod-disruption-budget` global settings.
+
+Note that both the Priority Class and Pod Disruption Budget have configuration restrictions:
 
 + The `Value` set for the default PC cannot be less than negative 1 billion, or greater than 1 billion.
 + The `PreemptionPolicy` set for the PC must be equal to `PreemptLowerPriority` or `Never`.
@@ -64,10 +66,13 @@ In order to prevent unexpected changes in scheduler behavior, Rancher does not u
 
 ## Downstream Objects
 
-When this feature is enabled for a given cluster, two downstream resources will be automatically created by Rancher:
+When this feature is enabled for a given cluster, four downstream resources will be automatically created by Rancher:
 
-+ A Pod Disruption Budget will be automatically created in the `cattle-system` namespace, named `cattle-cluster-agent-pod-disruption-budget`.
-+ A Priority Class will be automatically created, named `cattle-cluster-agent-priority-class`.
++ Two Pod Disruption Budgets will be automatically created in 
+  - the `cattle-system` namespace, named `cattle-cluster-agent-pod-disruption-budget` and
+  - the `cattle-fleet-system` namespace, named `fleet-agent-pod-disruption-budget`.
+  
++ Two Priority Classes will be automatically created, named `cattle-cluster-agent-priority-class` and `fleet-agent-priority-class`.
 
 These objects are maintained by Rancher and must not be modified or deleted. The Rancher server will automatically update these objects to match the configuration set on the Cluster object and remove them when they are no longer needed.
 


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Relates to rancher/rancher#52535 and rancher/rancher#52437

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, remember to add a "MERGE ON RELEASE" label and set the proper milestone.

## Description

This PR adds documentation for an extended feature in 2.14 and backported to 2.13, fleet agent scheduling customization. Both implementations are currently work-in-progress.

<!--
- What is the goal of this pull request? 
- What did you change? 
- Are there any other pull requests, tickets, or issues associated with this pull request?
-->

## Comments

:warning: Merging documentation might need to wait for the implementation in the UI!

## TODO 

- [x] Remove 2.13 from the documentation -- https://github.com/rancher/rancher/pull/53368
<!--
Any additional notes a reviewer should know before we review.
-->
