### PR TITLE
[docs] etcd tuning fix typo etcd-args

### DIFF
--- a/docs/how-to-guides/advanced-user-guides/tune-etcd-for-large-installs.md
+++ b/docs/how-to-guides/advanced-user-guides/tune-etcd-for-large-installs.md
@@ -15,7 +15,7 @@ The etcd data set is automatically cleaned up on a five-minute interval by Kuber
 ```yaml
 # RKE2/K3s config.yaml
 ---
-etcd-args:
+etcd-arg:
   - "quota-backend-bytes=5368709120"
 ```
 
@@ -30,7 +30,7 @@ To implement this solution in an RKE2/K3s cluster, the `/var/lib/etcd/data` and 
 ```yaml
 # RKE2/K3s config.yaml
 ---
-etcd-args:
+etcd-arg:
   - "data-dir=/var/lib/etcd/data"
   - "wal-dir=/var/lib/etcd/wal"
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/advanced-user-guides/tune-etcd-for-large-installs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/how-to-guides/advanced-user-guides/tune-etcd-for-large-installs.md
@@ -11,7 +11,7 @@ Kubernetes 每隔五分钟会自动清理 etcd 数据集。在某些情况下（
 ```yaml
 # RKE2/K3s config.yaml
 ---
-etcd-args:
+etcd-arg:
   - "quota-backend-bytes=5368709120"
 ```
 
@@ -26,7 +26,7 @@ etcd-args:
 ```yaml
 # RKE2/K3s config.yaml
 ---
-etcd-args:
+etcd-arg:
   - "data-dir=/var/lib/etcd/data"
   - "wal-dir=/var/lib/etcd/wal"
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.12/how-to-guides/advanced-user-guides/tune-etcd-for-large-installs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.12/how-to-guides/advanced-user-guides/tune-etcd-for-large-installs.md
@@ -11,7 +11,7 @@ Kubernetes 每隔五分钟会自动清理 etcd 数据集。在某些情况下（
 ```yaml
 # RKE2/K3s config.yaml
 ---
-etcd-args:
+etcd-arg:
   - "quota-backend-bytes=5368709120"
 ```
 
@@ -26,7 +26,7 @@ etcd-args:
 ```yaml
 # RKE2/K3s config.yaml
 ---
-etcd-args:
+etcd-arg:
   - "data-dir=/var/lib/etcd/data"
   - "wal-dir=/var/lib/etcd/wal"
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.13/how-to-guides/advanced-user-guides/tune-etcd-for-large-installs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.13/how-to-guides/advanced-user-guides/tune-etcd-for-large-installs.md
@@ -11,7 +11,7 @@ Kubernetes 每隔五分钟会自动清理 etcd 数据集。在某些情况下（
 ```yaml
 # RKE2/K3s config.yaml
 ---
-etcd-args:
+etcd-arg:
   - "quota-backend-bytes=5368709120"
 ```
 

--- a/versioned_docs/version-2.12/how-to-guides/advanced-user-guides/tune-etcd-for-large-installs.md
+++ b/versioned_docs/version-2.12/how-to-guides/advanced-user-guides/tune-etcd-for-large-installs.md
@@ -15,7 +15,7 @@ The etcd data set is automatically cleaned up on a five-minute interval by Kuber
 ```yaml
 # RKE2/K3s config.yaml
 ---
-etcd-args:
+etcd-arg:
   - "quota-backend-bytes=5368709120"
 ```
 
@@ -30,7 +30,7 @@ To implement this solution in an RKE2/K3s cluster, the `/var/lib/etcd/data` and 
 ```yaml
 # RKE2/K3s config.yaml
 ---
-etcd-args:
+etcd-arg:
   - "data-dir=/var/lib/etcd/data"
   - "wal-dir=/var/lib/etcd/wal"
 ```

--- a/versioned_docs/version-2.13/how-to-guides/advanced-user-guides/tune-etcd-for-large-installs.md
+++ b/versioned_docs/version-2.13/how-to-guides/advanced-user-guides/tune-etcd-for-large-installs.md
@@ -15,7 +15,7 @@ The etcd data set is automatically cleaned up on a five-minute interval by Kuber
 ```yaml
 # RKE2/K3s config.yaml
 ---
-etcd-args:
+etcd-arg:
   - "quota-backend-bytes=5368709120"
 ```
 
@@ -30,7 +30,7 @@ To implement this solution in an RKE2/K3s cluster, the `/var/lib/etcd/data` and 
 ```yaml
 # RKE2/K3s config.yaml
 ---
-etcd-args:
+etcd-arg:
   - "data-dir=/var/lib/etcd/data"
   - "wal-dir=/var/lib/etcd/wal"
 ```


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

Fixes #2118

## Description

Fixes my typo of the `etcd-args`, when the actual value is `etcd-arg:`

## Comments

This is a typo on my part. Apologies.