### PR TITLE
Documents node draining behvaiour during Rancher upgrades

### DIFF
--- a/docs/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
+++ b/docs/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
@@ -96,14 +96,8 @@ To enable draining each node during a cluster upgrade,
 
 :::note
 
-There is a [known issue](https://github.com/rancher/rancher/issues/25478) in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
-
-:::
-
-:::note
-
-During an upgrade, nodes may be drained even when no user-visible YAML changes are present. This can occur if non-dynamic configuration files are updated or if a new `system-agent-installer` image is introduced.
-In such cases, Rancher generates a new upgrade plan, resulting in a new plan hash. When `Upgrade Strategy` is set to `Drain nodes`, this plan change can trigger node draining.
+- There is a [known issue](https://github.com/rancher/rancher/issues/25478) in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+- During an upgrade, nodes may be drained even when no user-visible YAML changes are present. This can occur if non-dynamic configuration files are updated or if a new `system-agent-installer` image is introduced. In such cases, Rancher generates a new upgrade plan, resulting in a new plan hash. When `Upgrade Strategy` is set to `Drain nodes`, this plan change can trigger node draining.
 
 :::
 

--- a/versioned_docs/version-2.10/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
+++ b/versioned_docs/version-2.10/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
@@ -96,7 +96,8 @@ To enable draining each node during a cluster upgrade,
 
 :::note
 
-There is a [known issue](https://github.com/rancher/rancher/issues/25478) in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+- There is a [known issue](https://github.com/rancher/rancher/issues/25478) in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+- During an upgrade, nodes may be drained even when no user-visible YAML changes are present. This can occur if non-dynamic configuration files are updated or if a new `system-agent-installer` image is introduced. In such cases, Rancher generates a new upgrade plan, resulting in a new plan hash. When `Upgrade Strategy` is set to `Drain nodes`, this plan change can trigger node draining.
 
 :::
 

--- a/versioned_docs/version-2.11/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
+++ b/versioned_docs/version-2.11/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
@@ -96,7 +96,8 @@ To enable draining each node during a cluster upgrade,
 
 :::note
 
-There is a [known issue](https://github.com/rancher/rancher/issues/25478) in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+- There is a [known issue](https://github.com/rancher/rancher/issues/25478) in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+- During an upgrade, nodes may be drained even when no user-visible YAML changes are present. This can occur if non-dynamic configuration files are updated or if a new `system-agent-installer` image is introduced. In such cases, Rancher generates a new upgrade plan, resulting in a new plan hash. When `Upgrade Strategy` is set to `Drain nodes`, this plan change can trigger node draining.
 
 :::
 

--- a/versioned_docs/version-2.12/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
+++ b/versioned_docs/version-2.12/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
@@ -96,14 +96,8 @@ To enable draining each node during a cluster upgrade,
 
 :::note
 
-There is a [known issue](https://github.com/rancher/rancher/issues/25478) in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
-
-:::
-
-:::note
-
-During an upgrade, nodes may be drained even when no user-visible YAML changes are present. This can occur if non-dynamic configuration files are updated or if a new `system-agent-installer` image is introduced.
-In such cases, Rancher generates a new upgrade plan, resulting in a new plan hash. When `Upgrade Strategy` is set to `Drain nodes`, this plan change can trigger node draining.
+- There is a [known issue](https://github.com/rancher/rancher/issues/25478) in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+- During an upgrade, nodes may be drained even when no user-visible YAML changes are present. This can occur if non-dynamic configuration files are updated or if a new `system-agent-installer` image is introduced. In such cases, Rancher generates a new upgrade plan, resulting in a new plan hash. When `Upgrade Strategy` is set to `Drain nodes`, this plan change can trigger node draining.
 
 :::
 

--- a/versioned_docs/version-2.13/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
+++ b/versioned_docs/version-2.13/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
@@ -96,14 +96,8 @@ To enable draining each node during a cluster upgrade,
 
 :::note
 
-There is a [known issue](https://github.com/rancher/rancher/issues/25478) in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
-
-:::
-
-:::note
-
-During an upgrade, nodes may be drained even when no user-visible YAML changes are present. This can occur if non-dynamic configuration files are updated or if a new `system-agent-installer` image is introduced.
-In such cases, Rancher generates a new upgrade plan, resulting in a new plan hash. When `Upgrade Strategy` is set to `Drain nodes`, this plan change can trigger node draining.
+- There is a [known issue](https://github.com/rancher/rancher/issues/25478) in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+- During an upgrade, nodes may be drained even when no user-visible YAML changes are present. This can occur if non-dynamic configuration files are updated or if a new `system-agent-installer` image is introduced. In such cases, Rancher generates a new upgrade plan, resulting in a new plan hash. When `Upgrade Strategy` is set to `Drain nodes`, this plan change can trigger node draining.
 
 :::
 

--- a/versioned_docs/version-2.9/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
+++ b/versioned_docs/version-2.9/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes.md
@@ -96,7 +96,8 @@ To enable draining each node during a cluster upgrade,
 
 :::note
 
-There is a [known issue](https://github.com/rancher/rancher/issues/25478) in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+- There is a [known issue](https://github.com/rancher/rancher/issues/25478) in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+- During an upgrade, nodes may be drained even when no user-visible YAML changes are present. This can occur if non-dynamic configuration files are updated or if a new `system-agent-installer` image is introduced. In such cases, Rancher generates a new upgrade plan, resulting in a new plan hash. When `Upgrade Strategy` is set to `Drain nodes`, this plan change can trigger node draining.
 
 :::
 


### PR DESCRIPTION
Fixes #2178 

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, remember to add a "MERGE ON RELEASE" label and set the proper milestone.

## Description

This commit adds a note highlighting the expectations for downstream cluster nodes, when `Upgrade Strategy` is set to `Drain Nodes` .