### PR TITLE
Improve air-gapped migration documentation

### DIFF
--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -48,35 +48,35 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
      helm install rancher-backup rancher-charts/rancher-backup -n cattle-resources-system --version $CHART_VERSION
      ```
 
-   :::note
+     :::note
 
-   The above assumes an environment with outbound connectivity to Docker Hub.
+     The above assumes an environment with outbound connectivity to Docker Hub.
 
-   For an **air-gapped environment**, use the following Helm values to pull the `backup-restore-operator` and `kubectl` images from your private registry when you install the rancher-backup Helm chart.
+     For an **air-gapped environment**, use the following Helm values to pull the `backup-restore-operator` and `kubectl` images from your private registry when you install the rancher-backup Helm chart.
 
-   ```bash
-   --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
-   ```
+     ```bash
+     --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
+     ```
 
-   If the host running the Helm commands is **also air-gapped and cannot reach charts.rancher.io**, download the charts on a non-air-gapped host and then install them from local files on the air-gapped host.
+     If the host running the Helm commands is **also air-gapped and cannot reach charts.rancher.io**, download the charts on a non-air-gapped host and then install them from local files on the air-gapped host.
 
-   On a non-air-gapped host:
+     On a non-air-gapped host:
 
-   ```bash
-   helm repo add rancher-charts https://charts.rancher.io
-   helm repo update
-   helm fetch rancher-charts/rancher-backup-crd --version $CHART_VERSION
-   helm fetch rancher-charts/rancher-backup --version $CHART_VERSION
-   ```
+     ```bash
+     helm repo add rancher-charts https://charts.rancher.io
+     helm repo update
+     helm fetch rancher-charts/rancher-backup-crd --version $CHART_VERSION
+     helm fetch rancher-charts/rancher-backup --version $CHART_VERSION
+     ```
 
-   Copy the `rancher-backup-crd-<chart-version>.tgz` and `rancher-backup-<chart-version>.tgz` files to the air-gapped host, then use them to install the charts:
+     Copy the `rancher-backup-crd-<chart-version>.tgz` and `rancher-backup-<chart-version>.tgz` files to the air-gapped host, then use them to install the charts:
 
-   ```bash
-   helm install rancher-backup-crd ./rancher-backup-crd-<chart-version>.tgz -n cattle-resources-system --create-namespace
-   helm install rancher-backup ./rancher-backup-<chart-version>.tgz -n cattle-resources-system --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
-   ```
+     ```bash
+     helm install rancher-backup-crd ./rancher-backup-crd-<chart-version>.tgz -n cattle-resources-system --create-namespace
+     helm install rancher-backup ./rancher-backup-<chart-version>.tgz -n cattle-resources-system --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
+     ```
 
-   :::
+     :::
 
 ### 2. Restore from backup using a Restore custom resource
 

--- a/versioned_docs/version-2.10/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.10/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -48,35 +48,35 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
      helm install rancher-backup rancher-charts/rancher-backup -n cattle-resources-system --version $CHART_VERSION
      ```
 
-   :::note
+     :::note
 
-   The above assumes an environment with outbound connectivity to Docker Hub.
+     The above assumes an environment with outbound connectivity to Docker Hub.
 
-   For an **air-gapped environment**, use the following Helm values to pull the `backup-restore-operator` and `kubectl` images from your private registry when you install the rancher-backup Helm chart.
+     For an **air-gapped environment**, use the following Helm values to pull the `backup-restore-operator` and `kubectl` images from your private registry when you install the rancher-backup Helm chart.
 
-   ```bash
-   --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
-   ```
+     ```bash
+     --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
+     ```
 
-   If the host running the Helm commands is **also air-gapped and cannot reach charts.rancher.io**, download the charts on a non-air-gapped host and then install them from local files on the air-gapped host.
+     If the host running the Helm commands is **also air-gapped and cannot reach charts.rancher.io**, download the charts on a non-air-gapped host and then install them from local files on the air-gapped host.
 
-   On a non-air-gapped host:
+     On a non-air-gapped host:
 
-   ```bash
-   helm repo add rancher-charts https://charts.rancher.io
-   helm repo update
-   helm fetch rancher-charts/rancher-backup-crd --version $CHART_VERSION
-   helm fetch rancher-charts/rancher-backup --version $CHART_VERSION
-   ```
+     ```bash
+     helm repo add rancher-charts https://charts.rancher.io
+     helm repo update
+     helm fetch rancher-charts/rancher-backup-crd --version $CHART_VERSION
+     helm fetch rancher-charts/rancher-backup --version $CHART_VERSION
+     ```
 
-   Copy the `rancher-backup-crd-<chart-version>.tgz` and `rancher-backup-<chart-version>.tgz` files to the air-gapped host, then use them to install the charts:
+     Copy the `rancher-backup-crd-<chart-version>.tgz` and `rancher-backup-<chart-version>.tgz` files to the air-gapped host, then use them to install the charts:
 
-   ```bash
-   helm install rancher-backup-crd ./rancher-backup-crd-<chart-version>.tgz -n cattle-resources-system --create-namespace
-   helm install rancher-backup ./rancher-backup-<chart-version>.tgz -n cattle-resources-system --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
-   ```
+     ```bash
+     helm install rancher-backup-crd ./rancher-backup-crd-<chart-version>.tgz -n cattle-resources-system --create-namespace
+     helm install rancher-backup ./rancher-backup-<chart-version>.tgz -n cattle-resources-system --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
+     ```
 
-   :::
+     :::
 
 ### 2. Restore from backup using a Restore custom resource
 

--- a/versioned_docs/version-2.11/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.11/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -48,35 +48,35 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
      helm install rancher-backup rancher-charts/rancher-backup -n cattle-resources-system --version $CHART_VERSION
      ```
 
-   :::note
+     :::note
 
-   The above assumes an environment with outbound connectivity to Docker Hub.
+     The above assumes an environment with outbound connectivity to Docker Hub.
 
-   For an **air-gapped environment**, use the following Helm values to pull the `backup-restore-operator` and `kubectl` images from your private registry when you install the rancher-backup Helm chart.
+     For an **air-gapped environment**, use the following Helm values to pull the `backup-restore-operator` and `kubectl` images from your private registry when you install the rancher-backup Helm chart.
 
-   ```bash
-   --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
-   ```
+     ```bash
+     --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
+     ```
 
-   If the host running the Helm commands is **also air-gapped and cannot reach charts.rancher.io**, download the charts on a non-air-gapped host and then install them from local files on the air-gapped host.
+     If the host running the Helm commands is **also air-gapped and cannot reach charts.rancher.io**, download the charts on a non-air-gapped host and then install them from local files on the air-gapped host.
 
-   On a non-air-gapped host:
+     On a non-air-gapped host:
 
-   ```bash
-   helm repo add rancher-charts https://charts.rancher.io
-   helm repo update
-   helm fetch rancher-charts/rancher-backup-crd --version $CHART_VERSION
-   helm fetch rancher-charts/rancher-backup --version $CHART_VERSION
-   ```
+     ```bash
+     helm repo add rancher-charts https://charts.rancher.io
+     helm repo update
+     helm fetch rancher-charts/rancher-backup-crd --version $CHART_VERSION
+     helm fetch rancher-charts/rancher-backup --version $CHART_VERSION
+     ```
 
-   Copy the `rancher-backup-crd-<chart-version>.tgz` and `rancher-backup-<chart-version>.tgz` files to the air-gapped host, then use them to install the charts:
+     Copy the `rancher-backup-crd-<chart-version>.tgz` and `rancher-backup-<chart-version>.tgz` files to the air-gapped host, then use them to install the charts:
 
-   ```bash
-   helm install rancher-backup-crd ./rancher-backup-crd-<chart-version>.tgz -n cattle-resources-system --create-namespace
-   helm install rancher-backup ./rancher-backup-<chart-version>.tgz -n cattle-resources-system --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
-   ```
+     ```bash
+     helm install rancher-backup-crd ./rancher-backup-crd-<chart-version>.tgz -n cattle-resources-system --create-namespace
+     helm install rancher-backup ./rancher-backup-<chart-version>.tgz -n cattle-resources-system --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
+     ```
 
-   :::
+     :::
 
 ### 2. Restore from backup using a Restore custom resource
 

--- a/versioned_docs/version-2.12/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.12/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -48,35 +48,35 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
      helm install rancher-backup rancher-charts/rancher-backup -n cattle-resources-system --version $CHART_VERSION
      ```
 
-   :::note
+     :::note
 
-   The above assumes an environment with outbound connectivity to Docker Hub.
+     The above assumes an environment with outbound connectivity to Docker Hub.
 
-   For an **air-gapped environment**, use the following Helm values to pull the `backup-restore-operator` and `kubectl` images from your private registry when you install the rancher-backup Helm chart.
+     For an **air-gapped environment**, use the following Helm values to pull the `backup-restore-operator` and `kubectl` images from your private registry when you install the rancher-backup Helm chart.
 
-   ```bash
-   --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
-   ```
+     ```bash
+     --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
+     ```
 
-   If the host running the Helm commands is **also air-gapped and cannot reach charts.rancher.io**, download the charts on a non-air-gapped host and then install them from local files on the air-gapped host.
+     If the host running the Helm commands is **also air-gapped and cannot reach charts.rancher.io**, download the charts on a non-air-gapped host and then install them from local files on the air-gapped host.
 
-   On a non-air-gapped host:
+     On a non-air-gapped host:
 
-   ```bash
-   helm repo add rancher-charts https://charts.rancher.io
-   helm repo update
-   helm fetch rancher-charts/rancher-backup-crd --version $CHART_VERSION
-   helm fetch rancher-charts/rancher-backup --version $CHART_VERSION
-   ```
+     ```bash
+     helm repo add rancher-charts https://charts.rancher.io
+     helm repo update
+     helm fetch rancher-charts/rancher-backup-crd --version $CHART_VERSION
+     helm fetch rancher-charts/rancher-backup --version $CHART_VERSION
+     ```
 
-   Copy the `rancher-backup-crd-<chart-version>.tgz` and `rancher-backup-<chart-version>.tgz` files to the air-gapped host, then use them to install the charts:
+     Copy the `rancher-backup-crd-<chart-version>.tgz` and `rancher-backup-<chart-version>.tgz` files to the air-gapped host, then use them to install the charts:
 
-   ```bash
-   helm install rancher-backup-crd ./rancher-backup-crd-<chart-version>.tgz -n cattle-resources-system --create-namespace
-   helm install rancher-backup ./rancher-backup-<chart-version>.tgz -n cattle-resources-system --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
-   ```
+     ```bash
+     helm install rancher-backup-crd ./rancher-backup-crd-<chart-version>.tgz -n cattle-resources-system --create-namespace
+     helm install rancher-backup ./rancher-backup-<chart-version>.tgz -n cattle-resources-system --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
+     ```
 
-   :::
+     :::
 
 ### 2. Restore from backup using a Restore custom resource
 

--- a/versioned_docs/version-2.13/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.13/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -48,35 +48,35 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
      helm install rancher-backup rancher-charts/rancher-backup -n cattle-resources-system --version $CHART_VERSION
      ```
 
-   :::note
+     :::note
 
-   The above assumes an environment with outbound connectivity to Docker Hub.
+     The above assumes an environment with outbound connectivity to Docker Hub.
 
-   For an **air-gapped environment**, use the following Helm values to pull the `backup-restore-operator` and `kubectl` images from your private registry when you install the rancher-backup Helm chart.
+     For an **air-gapped environment**, use the following Helm values to pull the `backup-restore-operator` and `kubectl` images from your private registry when you install the rancher-backup Helm chart.
 
-   ```bash
-   --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
-   ```
+     ```bash
+     --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
+     ```
 
-   If the host running the Helm commands is **also air-gapped and cannot reach charts.rancher.io**, download the charts on a non-air-gapped host and then install them from local files on the air-gapped host.
+     If the host running the Helm commands is **also air-gapped and cannot reach charts.rancher.io**, download the charts on a non-air-gapped host and then install them from local files on the air-gapped host.
 
-   On a non-air-gapped host:
+     On a non-air-gapped host:
 
-   ```bash
-   helm repo add rancher-charts https://charts.rancher.io
-   helm repo update
-   helm fetch rancher-charts/rancher-backup-crd --version $CHART_VERSION
-   helm fetch rancher-charts/rancher-backup --version $CHART_VERSION
-   ```
+     ```bash
+     helm repo add rancher-charts https://charts.rancher.io
+     helm repo update
+     helm fetch rancher-charts/rancher-backup-crd --version $CHART_VERSION
+     helm fetch rancher-charts/rancher-backup --version $CHART_VERSION
+     ```
 
-   Copy the `rancher-backup-crd-<chart-version>.tgz` and `rancher-backup-<chart-version>.tgz` files to the air-gapped host, then use them to install the charts:
+     Copy the `rancher-backup-crd-<chart-version>.tgz` and `rancher-backup-<chart-version>.tgz` files to the air-gapped host, then use them to install the charts:
 
-   ```bash
-   helm install rancher-backup-crd ./rancher-backup-crd-<chart-version>.tgz -n cattle-resources-system --create-namespace
-   helm install rancher-backup ./rancher-backup-<chart-version>.tgz -n cattle-resources-system --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
-   ```
+     ```bash
+     helm install rancher-backup-crd ./rancher-backup-crd-<chart-version>.tgz -n cattle-resources-system --create-namespace
+     helm install rancher-backup ./rancher-backup-<chart-version>.tgz -n cattle-resources-system --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
+     ```
 
-   :::
+     :::
 
 ### 2. Restore from backup using a Restore custom resource
 

--- a/versioned_docs/version-2.9/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.9/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -48,35 +48,35 @@ Install the [`rancher-backup chart`](https://github.com/rancher/backup-restore-o
      helm install rancher-backup rancher-charts/rancher-backup -n cattle-resources-system --version $CHART_VERSION
      ```
 
-   :::note
+     :::note
 
-   The above assumes an environment with outbound connectivity to Docker Hub.
+     The above assumes an environment with outbound connectivity to Docker Hub.
 
-   For an **air-gapped environment**, use the following Helm values to pull the `backup-restore-operator` and `kubectl` images from your private registry when you install the rancher-backup Helm chart.
+     For an **air-gapped environment**, use the following Helm values to pull the `backup-restore-operator` and `kubectl` images from your private registry when you install the rancher-backup Helm chart.
 
-   ```bash
-   --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
-   ```
+     ```bash
+     --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
+     ```
 
-   If the host running the Helm commands is **also air-gapped and cannot reach charts.rancher.io**, download the charts on a non-air-gapped host and then install them from local files on the air-gapped host.
+     If the host running the Helm commands is **also air-gapped and cannot reach charts.rancher.io**, download the charts on a non-air-gapped host and then install them from local files on the air-gapped host.
 
-   On a non-air-gapped host:
+     On a non-air-gapped host:
 
-   ```bash
-   helm repo add rancher-charts https://charts.rancher.io
-   helm repo update
-   helm fetch rancher-charts/rancher-backup-crd --version $CHART_VERSION
-   helm fetch rancher-charts/rancher-backup --version $CHART_VERSION
-   ```
+     ```bash
+     helm repo add rancher-charts https://charts.rancher.io
+     helm repo update
+     helm fetch rancher-charts/rancher-backup-crd --version $CHART_VERSION
+     helm fetch rancher-charts/rancher-backup --version $CHART_VERSION
+     ```
 
-   Copy the `rancher-backup-crd-<chart-version>.tgz` and `rancher-backup-<chart-version>.tgz` files to the air-gapped host, then use them to install the charts:
+     Copy the `rancher-backup-crd-<chart-version>.tgz` and `rancher-backup-<chart-version>.tgz` files to the air-gapped host, then use them to install the charts:
 
-   ```bash
-   helm install rancher-backup-crd ./rancher-backup-crd-<chart-version>.tgz -n cattle-resources-system --create-namespace
-   helm install rancher-backup ./rancher-backup-<chart-version>.tgz -n cattle-resources-system --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
-   ```
+     ```bash
+     helm install rancher-backup-crd ./rancher-backup-crd-<chart-version>.tgz -n cattle-resources-system --create-namespace
+     helm install rancher-backup ./rancher-backup-<chart-version>.tgz -n cattle-resources-system --set image.repository=<registry>/rancher/backup-restore-operator --set global.kubectl.repository=<registry>/rancher/kubectl
+     ```
 
-   :::
+     :::
 
 ### 2. Restore from backup using a Restore custom resource
 


### PR DESCRIPTION
<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

## Description

The purpose of this PR is to improve the Rancher migration documentation (using the rancher-backup operator), to cover use-cases where the environment is fully air-gapped, and the user runs helm commands from a host without internet access. In this instance the user needs to first fetch the charts from a non-air-gapped host, and then copy them to the host with access to the cluster, from which they run the helm commands.

## Comments

I have copied my proposed changes into all versioned documentation from v2.9 through to v2.13. Once the format of the proposed changes here is finalised and merged, I can go ahead and open a similar PR for the rancher-product-docs also.
