### PR TITLE
Be more precise in PSA configuration templates

### DIFF
--- a/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md
+++ b/docs/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md
@@ -17,7 +17,7 @@ The policies shipped by default in Rancher aim to provide a trade-off between se
 
 ## Assign a Pod Security Admissions (PSA) Configuration Template
 
-You can assign a PSA template at the same time that you create a downstream cluster. You can also add a template by configuring an existing cluster.
+You can assign a PSA template at the same time that you create a downstream cluster. You can also add a template by configuring an existing downstream cluster.
 
 ### Assign a Template During Cluster Creation
 <Tabs>

--- a/versioned_docs/version-2.10/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md
+++ b/versioned_docs/version-2.10/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md
@@ -17,7 +17,7 @@ The policies shipped by default in Rancher aim to provide a trade-off between se
 
 ## Assign a Pod Security Admissions (PSA) Configuration Template
 
-You can assign a PSA template at the same time that you create a downstream cluster. You can also add a template by configuring an existing cluster.
+You can assign a PSA template at the same time that you create a downstream cluster. You can also add a template by configuring an existing downstream cluster.
 
 ### Assign a Template During Cluster Creation
 <Tabs>

--- a/versioned_docs/version-2.11/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md
+++ b/versioned_docs/version-2.11/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md
@@ -17,7 +17,7 @@ The policies shipped by default in Rancher aim to provide a trade-off between se
 
 ## Assign a Pod Security Admissions (PSA) Configuration Template
 
-You can assign a PSA template at the same time that you create a downstream cluster. You can also add a template by configuring an existing cluster.
+You can assign a PSA template at the same time that you create a downstream cluster. You can also add a template by configuring an existing downstream cluster.
 
 ### Assign a Template During Cluster Creation
 <Tabs>

--- a/versioned_docs/version-2.12/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md
+++ b/versioned_docs/version-2.12/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md
@@ -17,7 +17,7 @@ The policies shipped by default in Rancher aim to provide a trade-off between se
 
 ## Assign a Pod Security Admissions (PSA) Configuration Template
 
-You can assign a PSA template at the same time that you create a downstream cluster. You can also add a template by configuring an existing cluster.
+You can assign a PSA template at the same time that you create a downstream cluster. You can also add a template by configuring an existing downstream cluster.
 
 ### Assign a Template During Cluster Creation
 <Tabs>

--- a/versioned_docs/version-2.13/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md
+++ b/versioned_docs/version-2.13/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md
@@ -17,7 +17,7 @@ The policies shipped by default in Rancher aim to provide a trade-off between se
 
 ## Assign a Pod Security Admissions (PSA) Configuration Template
 
-You can assign a PSA template at the same time that you create a downstream cluster. You can also add a template by configuring an existing cluster.
+You can assign a PSA template at the same time that you create a downstream cluster. You can also add a template by configuring an existing downstream cluster.
 
 ### Assign a Template During Cluster Creation
 <Tabs>

--- a/versioned_docs/version-2.14/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md
+++ b/versioned_docs/version-2.14/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.md
@@ -17,7 +17,7 @@ The policies shipped by default in Rancher aim to provide a trade-off between se
 
 ## Assign a Pod Security Admissions (PSA) Configuration Template
 
-You can assign a PSA template at the same time that you create a downstream cluster. You can also add a template by configuring an existing cluster.
+You can assign a PSA template at the same time that you create a downstream cluster. You can also add a template by configuring an existing downstream cluster.
 
 ### Assign a Template During Cluster Creation
 <Tabs>


### PR DESCRIPTION
The original wording was imprecise ("You can assign a PSA template at the same time that you create a downstream cluster. You can also add a template by configuring an existing cluster."), as it was unclear whether the existing cluster has to be a downstream cluster or can be the local cluster.

Fixes #2259
