### PR TITLE
[Rancher2] Docs: Clarify RKE1-only scope in nginx-proxy troubleshooting guide

### DIFF
--- a/docs/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
+++ b/docs/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
@@ -6,7 +6,7 @@ title: Troubleshooting nginx-proxy
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy"/>
 </head>
 
-:::note
+:::caution
 
 The `nginx-proxy` container is an RKE1-specific component. If you are using RKE2 or K3s, this container is not deployed, as load balancing to the API servers is handled internally by a client-side load balancer within the agent process itself.
 

--- a/docs/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
+++ b/docs/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
@@ -6,6 +6,14 @@ title: Troubleshooting nginx-proxy
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy"/>
 </head>
 
+:::note
+
+The `nginx-proxy` container is an RKE1-specific component. If you are using RKE2 or K3s, this container is not deployed, as load balancing to the API servers is handled internally by a client-side load balancer within the agent process itself.
+
+Additionally, please note that RKE1 has reached its [End of Life (EOL)](https://support.scc.suse.com/s/kb/RKE-EOL-what-when-why?language=en_US). Therefore, the information on this page is considered deprecated.
+
+:::
+
 The `nginx-proxy` container is deployed on every node that does not have the `controlplane` role. It provides access to all the nodes with the `controlplane` role by dynamically generating the NGINX configuration based on available nodes with the `controlplane` role.
 
 ## Check if the Container is Running

--- a/versioned_docs/version-2.12/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
+++ b/versioned_docs/version-2.12/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
@@ -6,7 +6,7 @@ title: Troubleshooting nginx-proxy
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy"/>
 </head>
 
-:::note
+:::caution
 
 The `nginx-proxy` container is an RKE1-specific component. If you are using RKE2 or K3s, this container is not deployed, as load balancing to the API servers is handled internally by a client-side load balancer within the agent process itself.
 

--- a/versioned_docs/version-2.12/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
+++ b/versioned_docs/version-2.12/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
@@ -6,6 +6,14 @@ title: Troubleshooting nginx-proxy
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy"/>
 </head>
 
+:::note
+
+The `nginx-proxy` container is an RKE1-specific component. If you are using RKE2 or K3s, this container is not deployed, as load balancing to the API servers is handled internally by a client-side load balancer within the agent process itself.
+
+Additionally, please note that RKE1 has reached its [End of Life (EOL)](https://support.scc.suse.com/s/kb/RKE-EOL-what-when-why?language=en_US). Therefore, the information on this page is considered deprecated.
+
+:::
+
 The `nginx-proxy` container is deployed on every node that does not have the `controlplane` role. It provides access to all the nodes with the `controlplane` role by dynamically generating the NGINX configuration based on available nodes with the `controlplane` role.
 
 ## Check if the Container is Running

--- a/versioned_docs/version-2.13/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
+++ b/versioned_docs/version-2.13/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
@@ -6,7 +6,7 @@ title: Troubleshooting nginx-proxy
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy"/>
 </head>
 
-:::note
+:::caution
 
 The `nginx-proxy` container is an RKE1-specific component. If you are using RKE2 or K3s, this container is not deployed, as load balancing to the API servers is handled internally by a client-side load balancer within the agent process itself.
 

--- a/versioned_docs/version-2.13/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
+++ b/versioned_docs/version-2.13/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
@@ -6,6 +6,14 @@ title: Troubleshooting nginx-proxy
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy"/>
 </head>
 
+:::note
+
+The `nginx-proxy` container is an RKE1-specific component. If you are using RKE2 or K3s, this container is not deployed, as load balancing to the API servers is handled internally by a client-side load balancer within the agent process itself.
+
+Additionally, please note that RKE1 has reached its [End of Life (EOL)](https://support.scc.suse.com/s/kb/RKE-EOL-what-when-why?language=en_US). Therefore, the information on this page is considered deprecated.
+
+:::
+
 The `nginx-proxy` container is deployed on every node that does not have the `controlplane` role. It provides access to all the nodes with the `controlplane` role by dynamically generating the NGINX configuration based on available nodes with the `controlplane` role.
 
 ## Check if the Container is Running

--- a/versioned_docs/version-2.14/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
+++ b/versioned_docs/version-2.14/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
@@ -6,7 +6,7 @@ title: Troubleshooting nginx-proxy
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy"/>
 </head>
 
-:::note
+:::caution
 
 The `nginx-proxy` container is an RKE1-specific component. If you are using RKE2 or K3s, this container is not deployed, as load balancing to the API servers is handled internally by a client-side load balancer within the agent process itself.
 

--- a/versioned_docs/version-2.14/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
+++ b/versioned_docs/version-2.14/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.md
@@ -6,6 +6,14 @@ title: Troubleshooting nginx-proxy
   <link rel="canonical" href="https://ranchermanager.docs.rancher.com/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy"/>
 </head>
 
+:::note
+
+The `nginx-proxy` container is an RKE1-specific component. If you are using RKE2 or K3s, this container is not deployed, as load balancing to the API servers is handled internally by a client-side load balancer within the agent process itself.
+
+Additionally, please note that RKE1 has reached its [End of Life (EOL)](https://support.scc.suse.com/s/kb/RKE-EOL-what-when-why?language=en_US). Therefore, the information on this page is considered deprecated.
+
+:::
+
 The `nginx-proxy` container is deployed on every node that does not have the `controlplane` role. It provides access to all the nodes with the `controlplane` role by dynamically generating the NGINX configuration based on available nodes with the `controlplane` role.
 
 ## Check if the Container is Running


### PR DESCRIPTION
**Description of the Change**
The `nginx-proxy` container is an RKE1-specific component that acts as a local reverse proxy on worker nodes. In RKE2 and K3s, load balancing to the API servers is handled internally by a client-side load balancer within the agent process.

Because RKE1 has reached its End of Life (EOL), the `nginx-proxy` troubleshooting guide is effectively deprecated. This PR adds a clarification note at the top of the page to warn users that this container does not exist in RKE2/K3s and that the page's contents are considered deprecated.

**Linked Issue**
Fixes #2275

**Detailed Changes**
- Adds a `:::note` block to `troubleshooting-nginx-proxy.md` explaining the architectural difference in RKE2/K3s.
- Includes a warning regarding the RKE1 End of Life (EOL) with a link to the official SUSE support knowledge base article.
- Backports the changes to versions 2.12, 2.13, and 2.14.