### PR TITLE
Remove superfluous words from Equinix Metal quickstart guide

### DIFF
--- a/docs/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/docs/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -65,7 +65,7 @@ Log in to Rancher to begin using the application. After you log in, you'll make 
 
     Replace `<SERVER_IP>` with your host IP address.
 
-2.  When prompted, create a password for the default `admin` account there cowpoke!
+2.  When prompted, create a password for the default `admin` account.
 
 3.  Set the **Rancher Server URL**. The URL can either be an IP address or a host name. However, each node added to your cluster must be able to connect to this URL.<br/><br/>If you use a hostname in the URL, this hostname must be resolvable by DNS on the nodes you want to add to you cluster.
 

--- a/versioned_docs/version-2.10/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/versioned_docs/version-2.10/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -65,7 +65,7 @@ Log in to Rancher to begin using the application. After you log in, you'll make 
 
     Replace `<SERVER_IP>` with your host IP address.
 
-2.  When prompted, create a password for the default `admin` account there cowpoke!
+2.  When prompted, create a password for the default `admin` account.
 
 3.  Set the **Rancher Server URL**. The URL can either be an IP address or a host name. However, each node added to your cluster must be able to connect to this URL.<br/><br/>If you use a hostname in the URL, this hostname must be resolvable by DNS on the nodes you want to add to you cluster.
 

--- a/versioned_docs/version-2.11/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/versioned_docs/version-2.11/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -65,7 +65,7 @@ Log in to Rancher to begin using the application. After you log in, you'll make 
 
     Replace `<SERVER_IP>` with your host IP address.
 
-2.  When prompted, create a password for the default `admin` account there cowpoke!
+2.  When prompted, create a password for the default `admin` account.
 
 3.  Set the **Rancher Server URL**. The URL can either be an IP address or a host name. However, each node added to your cluster must be able to connect to this URL.<br/><br/>If you use a hostname in the URL, this hostname must be resolvable by DNS on the nodes you want to add to you cluster.
 

--- a/versioned_docs/version-2.12/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/versioned_docs/version-2.12/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -65,7 +65,7 @@ Log in to Rancher to begin using the application. After you log in, you'll make 
 
     Replace `<SERVER_IP>` with your host IP address.
 
-2.  When prompted, create a password for the default `admin` account there cowpoke!
+2.  When prompted, create a password for the default `admin` account.
 
 3.  Set the **Rancher Server URL**. The URL can either be an IP address or a host name. However, each node added to your cluster must be able to connect to this URL.<br/><br/>If you use a hostname in the URL, this hostname must be resolvable by DNS on the nodes you want to add to you cluster.
 

--- a/versioned_docs/version-2.13/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/versioned_docs/version-2.13/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -65,7 +65,7 @@ Log in to Rancher to begin using the application. After you log in, you'll make 
 
     Replace `<SERVER_IP>` with your host IP address.
 
-2.  When prompted, create a password for the default `admin` account there cowpoke!
+2.  When prompted, create a password for the default `admin` account.
 
 3.  Set the **Rancher Server URL**. The URL can either be an IP address or a host name. However, each node added to your cluster must be able to connect to this URL.<br/><br/>If you use a hostname in the URL, this hostname must be resolvable by DNS on the nodes you want to add to you cluster.
 

--- a/versioned_docs/version-2.14/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
+++ b/versioned_docs/version-2.14/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.md
@@ -65,7 +65,7 @@ Log in to Rancher to begin using the application. After you log in, you'll make 
 
     Replace `<SERVER_IP>` with your host IP address.
 
-2.  When prompted, create a password for the default `admin` account there cowpoke!
+2.  When prompted, create a password for the default `admin` account.
 
 3.  Set the **Rancher Server URL**. The URL can either be an IP address or a host name. However, each node added to your cluster must be able to connect to this URL.<br/><br/>If you use a hostname in the URL, this hostname must be resolvable by DNS on the nodes you want to add to you cluster.
 


### PR DESCRIPTION
Those words seem out of place among the rest of instructions.
