### PR TITLE
Clarify instructions for restarting cattle-cluster-agent pods after R…

### DIFF
--- a/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/docs/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -234,7 +234,7 @@ docker stop <original-rancher-container>
 
 :::note
 
-If you wish to keep the original Rancher environment running, you can also restart the cattle-cluster-agent pods on each cluster connected to your Rancher environment.
+If clusters do not automatically reconnect to the new environment after you have redirected traffic, for example if there is a delay in scaling down the original Rancher instance, you can also restart the cattle-cluster-agent pods on each cluster connected to your Rancher environment.
 
 ```bash
 kubectl rollout restart deployment cattle-cluster-agent -n cattle-system

--- a/versioned_docs/version-2.10/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.10/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -234,7 +234,7 @@ docker stop <original-rancher-container>
 
 :::note
 
-If you wish to keep the original Rancher environment running, you can also restart the cattle-cluster-agent pods on each cluster connected to your Rancher environment.
+If clusters do not automatically reconnect to the new environment after you have redirected traffic, for example if there is a delay in scaling down the original Rancher instance, you can also restart the cattle-cluster-agent pods on each cluster connected to your Rancher environment.
 
 ```bash
 kubectl rollout restart deployment cattle-cluster-agent -n cattle-system

--- a/versioned_docs/version-2.11/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.11/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -234,7 +234,7 @@ docker stop <original-rancher-container>
 
 :::note
 
-If you wish to keep the original Rancher environment running, you can also restart the cattle-cluster-agent pods on each cluster connected to your Rancher environment.
+If clusters do not automatically reconnect to the new environment after you have redirected traffic, for example if there is a delay in scaling down the original Rancher instance, you can also restart the cattle-cluster-agent pods on each cluster connected to your Rancher environment.
 
 ```bash
 kubectl rollout restart deployment cattle-cluster-agent -n cattle-system

--- a/versioned_docs/version-2.12/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.12/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -234,7 +234,7 @@ docker stop <original-rancher-container>
 
 :::note
 
-If you wish to keep the original Rancher environment running, you can also restart the cattle-cluster-agent pods on each cluster connected to your Rancher environment.
+If clusters do not automatically reconnect to the new environment after you have redirected traffic, for example if there is a delay in scaling down the original Rancher instance, you can also restart the cattle-cluster-agent pods on each cluster connected to your Rancher environment.
 
 ```bash
 kubectl rollout restart deployment cattle-cluster-agent -n cattle-system

--- a/versioned_docs/version-2.13/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.13/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -234,7 +234,7 @@ docker stop <original-rancher-container>
 
 :::note
 
-If you wish to keep the original Rancher environment running, you can also restart the cattle-cluster-agent pods on each cluster connected to your Rancher environment.
+If clusters do not automatically reconnect to the new environment after you have redirected traffic, for example if there is a delay in scaling down the original Rancher instance, you can also restart the cattle-cluster-agent pods on each cluster connected to your Rancher environment.
 
 ```bash
 kubectl rollout restart deployment cattle-cluster-agent -n cattle-system

--- a/versioned_docs/version-2.14/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
+++ b/versioned_docs/version-2.14/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster.md
@@ -234,7 +234,7 @@ docker stop <original-rancher-container>
 
 :::note
 
-If you wish to keep the original Rancher environment running, you can also restart the cattle-cluster-agent pods on each cluster connected to your Rancher environment.
+If clusters do not automatically reconnect to the new environment after you have redirected traffic, for example if there is a delay in scaling down the original Rancher instance, you can also restart the cattle-cluster-agent pods on each cluster connected to your Rancher environment.
 
 ```bash
 kubectl rollout restart deployment cattle-cluster-agent -n cattle-system


### PR DESCRIPTION
…ancher migration

<!--
Check the Rancher docs issues to see if there is an existing issue for this pull request. If there is, enter the issue number below.
-->

## Reminders

- See the [README](../README.md) for more details on how to work with the Rancher docs.

- Verify if changes pertain to other versions of Rancher. If they do, finalize the edits on one version of the page, then apply the edits to the other versions.

- If the pull request is dependent on an upcoming release, remember to add a "MERGE ON RELEASE" label and set the proper milestone.

## Description

I have updated the language in the Note at the end of the Rancher migration documentation. The primary aim is to remove the phrase `If you wish to keep the original Rancher environment running`, to remove the suggestion that scaling down the original Rancher environment is optional. I still wanted to leave the command documented, in case it is required as a workaround to force reconnection of the cattle-cluster-agents.

## Comments

<!--
Any additional notes a reviewer should know before we review.
-->
